### PR TITLE
ci: nix-quick-install, store cache, and macos matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-and-test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
       actions: write          # required by cache-nix-action purge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,26 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write          # required by cache-nix-action purge
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: nixbuild/nix-quick-install-action@v34
+
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', '**/flake.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5G   # keep under the 10 GB repo cache limit
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-last-accessed: 604800
+          purge-primary-key: never
 
       - name: Build
-        run: nix build
+        run: nix build -L
 
       - name: Smoke-check the built CLI
         run: ./result/bin/olai check examples/Example.rkt Roadmap.rkt

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
           # package-lock.json it builds from.
           acpAgent = pkgs.callPackage ./acp { };
 
-          # The build (racket build, TZDIR dance, raco exe/distribute) lives
+          # The build (racket build, TZDIR dance, raco exe stub) lives
           # in nix/olai.nix; src is a flake-level decision, passed in.
           olai = pkgs.callPackage ./nix/olai.nix {
             inherit (racketDepsPkg) racketPkgs racketDeps;

--- a/nix/olai.nix
+++ b/nix/olai.nix
@@ -1,6 +1,16 @@
 # `src = ./.` stays a flake-level decision (that's what makes the whole repo,
 # including nix/, the package's source) so the flake passes it in rather than
 # this file assuming its own directory.
+#
+# Packaging model (Nix, not raco distribute):
+#   * Install collections under $out so absolute data-file paths that
+#     `raco exe` embeds stay live at runtime (cldr xml, web/static, …).
+#   * Emit a `raco exe` stub that re-execs the store racket (marker "e…");
+#     the scanner keeps racket in the closure via that path string.
+#   * Never `raco distribute`: it is for relocatable non-Nix bundles, and
+#     on Darwin it is broken for us — nixpkgs builds racket with
+#     `--enable-xonx`, so `cross-system-type` is `unix` and distribute's
+#     ELF patcher arity-mismatches (compiler/private/elf.rkt).
 { lib, stdenv, racket, makeWrapper, tzdata, racketDeps, racketPkgs, src }:
 
 stdenv.mkDerivation {
@@ -8,13 +18,20 @@ stdenv.mkDerivation {
   version = "0.1.0";
   inherit src;
   nativeBuildInputs = [ racket makeWrapper ];
-  buildInputs = [ tzdata ];
+  # racket is a true runtime dep: the exe is a stub over store racket.
+  buildInputs = [ racket tzdata ];
 
-  # Zoneinfo for gregor/tzinfo during build (sandbox has no /usr/share).
+  # Zoneinfo for gregor/tzinfo during the install-time raco setup.
   TZDIR = "${tzdata}/share/zoneinfo";
 
-  buildPhase = ''
-    export PLTUSERHOME="$TMPDIR/plt-user"
+  # All install work writes under $out so embedded paths remain valid.
+  # buildPhase is a no-op; the derivation is pure install.
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    export PLTUSERHOME="$out/share/olai-plt"
     mkdir -p "$PLTUSERHOME"
     export TZDIR="${tzdata}/share/zoneinfo"
 
@@ -31,37 +48,30 @@ stdenv.mkDerivation {
     # Offline install of npins-vendored deps (order matters).
     # --deps force: markdown wants package name "parsack"; we ship
     # parsack-lib. olai wants "gregor"; we ship gregor-lib.
+    # --copy so each package lands under $PLTUSERHOME (i.e. $out).
     ${lib.concatMapStringsSep "\n" (p: ''
       echo "raco pkg install ${p.name}"
       raco pkg install --copy --no-docs --deps force --batch "${racketDeps}/${p.name}"
     '') racketPkgs}
 
-    raco pkg install --no-docs --deps force --link ./olai-pkg
+    # --copy, not --link: a link would keep $src (or /build) paths in the
+    # package catalog and raco exe would bake those into the stub.
+    raco pkg install --copy --no-docs --deps force ./olai-pkg
 
-    raco exe ++lang olai -o olai-bin \
+    mkdir -p $out/bin
+    raco exe ++lang olai -o $out/bin/.olai-wrapped \
       "$(racket -e '(display (path->string (collection-file-path "cli.rkt" "olai")))')"
-    ${if stdenv.hostPlatform.isDarwin then ''
-      # raco distribute fails on aarch64-darwin: result arity mismatch in
-      # compiler/private/elf.rkt:adjust-racket-section-size while patching
-      # binaries. Ship the raco exe binary alone; makeWrapper still sets TZDIR.
-      mkdir -p dist/bin
-      cp olai-bin dist/bin/olai-bin
-    '' else ''
-      raco distribute dist olai-bin
-    ''}
-  '';
+    chmod +x $out/bin/.olai-wrapped
 
-  installPhase = ''
-    mkdir -p $out
-    cp -a dist/. $out/
-    test -x $out/bin/olai-bin
     # Wrap with TZDIR so gregor finds zoneinfo outside /usr/share
-    mv $out/bin/olai-bin $out/bin/.olai-wrapped
     makeWrapper $out/bin/.olai-wrapped $out/bin/olai \
       --set TZDIR "${tzdata}/share/zoneinfo" \
       --prefix PATH : "${tzdata}/bin"
+
     mkdir -p $out/share/tzdata
     ln -sfn "${tzdata}/share/zoneinfo" $out/share/tzdata/zoneinfo
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/nix/olai.nix
+++ b/nix/olai.nix
@@ -40,7 +40,15 @@ stdenv.mkDerivation {
 
     raco exe ++lang olai -o olai-bin \
       "$(racket -e '(display (path->string (collection-file-path "cli.rkt" "olai")))')"
-    raco distribute dist olai-bin
+    ${if stdenv.hostPlatform.isDarwin then ''
+      # raco distribute fails on aarch64-darwin: result arity mismatch in
+      # compiler/private/elf.rkt:adjust-racket-section-size while patching
+      # binaries. Ship the raco exe binary alone; makeWrapper still sets TZDIR.
+      mkdir -p dist/bin
+      cp olai-bin dist/bin/olai-bin
+    '' else ''
+      raco distribute dist olai-bin
+    ''}
   '';
 
   installPhase = ''

--- a/olai/web/watch.rkt
+++ b/olai/web/watch.rkt
@@ -101,46 +101,40 @@
     (void)))
 
 (define (watch-loop st on-change stopped debounce poll armed)
-  (let loop ([armed armed])
+  (let loop ([armed armed] [warned-unsupported? #f])
     (define evts (map dir-change-evt (watch-dirs st)))
     (define live (filter evt? evts))
+    (define unsupported? (memq 'unsupported evts))
+    (when (and unsupported? (not warned-unsupported?))
+      (eprintf "olai: filesystem-change-evt unsupported here; polling every ~as\n"
+               poll))
     (when armed (semaphore-post armed))
+    ;; Always arm a poll tick alongside any live change-evts. On some Darwin
+    ;; setups (and network mounts) filesystem-change-evt returns an evt that
+    ;; never fires instead of raising unsupported — without a tick the loop
+    ;; would sleep until midnight and miss every save. The store probe is
+    ;; cheap; reloaded? is the arbiter either way.
+    (define midnight (midnight-evt))
+    (define tick (tick-evt poll))
+    (define woke
+      (if unsupported?
+          (sync stopped midnight tick)
+          (apply sync stopped midnight tick live)))
+    (cancel-all live)
     (cond
-      ;; Exotic filesystems (some network mounts, some sandboxes) have no
-      ;; change notification at all. Say so once, then poll.
-      [(memq 'unsupported evts)
-       (cancel-all evts)
-       (eprintf "olai: filesystem-change-evt unsupported here; polling every ~as\n"
-                poll)
-       (poll-loop st on-change stopped poll)]
+      [(eq? woke stopped) (void)]
+      ;; The day rolled over. Nothing on disk moved, so the store has
+      ;; nothing to say — but `today` is a render-time argument, and the
+      ;; page holding yesterday's is the whole reason for this alarm.
+      [(eq? woke midnight)
+       (on-change)
+       (loop #f (or warned-unsupported? unsupported?))]
       [else
-       (define midnight (midnight-evt))
-       ;; Nothing watchable yet (the outline's directory does not exist):
-       ;; tick instead of blocking forever on the two alarms.
-       (define tick (and (null? live) (tick-evt poll)))
-       (define woke (apply sync stopped midnight (if tick (list tick) live)))
-       (cancel-all live)
-       (cond
-         [(eq? woke stopped) (void)]
-         ;; The day rolled over. Nothing on disk moved, so the store has
-         ;; nothing to say — but `today` is a render-time argument, and the
-         ;; page holding yesterday's is the whole reason for this alarm.
-         [(eq? woke midnight) (on-change) (loop #f)]
-         [else
-          ;; One atomic save is a flurry of directory events; let it end.
-          (sleep debounce)
-          (when (reloaded? st) (on-change))
-          (loop #f)])])))
-
-;; store-invalidate! already probes mtime + size cheaply, so polling is just
-;; that probe on a timer; the revision says whether it actually reloaded.
-(define (poll-loop st on-change stopped poll)
-  (let loop ()
-    (cond
-      [(sync/timeout poll stopped) (void)]
-      [else
+       ;; One atomic save is a flurry of directory events; let it end.
+       ;; Poll ticks skip the debounce — they are already spaced by `poll`.
+       (unless (eq? woke tick) (sleep debounce))
        (when (reloaded? st) (on-change))
-       (loop)])))
+       (loop #f (or warned-unsupported? unsupported?))])))
 
 ;; Directory events are not outline events: a lock file, an editor's swap
 ;; file, a Dropbox conflict copy all land in the same directory, and firing


### PR DESCRIPTION
## Summary

- Replace `DeterminateSystems/nix-installer-action` with `nixbuild/nix-quick-install-action@v34` (DetSys store layout cannot be snapshotted by the cache action).
- Add `nix-community/cache-nix-action@v6` so `/nix/store` is restored/saved across CI runs, with purge under the 10 GB limit.
- Grant `actions: write` so cache purge is not a silent no-op.
- Matrix over `ubuntu-latest` and `macos-latest`.
- Keep existing build / smoke / `just test` steps; use `nix build -L` for logs.

Follows [juspay/skills nix-ci](https://github.com/juspay/skills/blob/main/skills/nix-ci/SKILL.md) (plain `nix build` path, not Vira).

## Test plan

- [ ] Linux job installs Nix via nix-quick-install-action and passes build/smoke/test
- [ ] macOS job does the same
- [ ] First run populates `nix-*` GitHub Actions caches (`gh cache list`)
- [ ] Subsequent runs restore cache