### PR TITLE
nix: home-manager module for `olai serve`

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ just test
 instead still works — see docs/cli.md.
 
 `serve` refuses to start without `OLAI_ACP_AGENT` — the path to an
-executable speaking the Agent Client Protocol. `nix develop` (hence `just
-serve`) and `nix run` default it to the bundled, pinned Claude Code adapter.
-Outside nix, export it yourself.
+executable speaking the Agent Client Protocol. The Nix package defaults it
+to the bundled, pinned Claude Code adapter (`--set-default`); `nix develop`
+(hence `just serve`) exports the same. Outside nix, export it yourself.
 
 ## CLI (agents)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -266,13 +266,14 @@ olai serve http://127.0.0.1:8080 files: /.../examples/Example.rkt
 
 **`OLAI_ACP_AGENT`** is an absolute path to an executable that speaks the
 [Agent Client Protocol](https://agentclientprotocol.com/) on stdio; `serve`
-spawns it as a subprocess. There is no fallback and no PATH lookup: with the
-variable unset (or pointing at something that is not executable) the server
-refuses to start. Nix sets it for you — `nix run` / `nix run .#serve` and the
-dev shell (so `just serve`) default it to the bundled Claude Code adapter,
-`packages.acp-agent` (`nix build .#acp-agent`), which is vendored from npm and
-pinned, never fetched at run time. Exporting the variable yourself wins, which
-is how you point `serve` at a different agent.
+spawns it as a subprocess. There is no PATH lookup: with the variable unset
+(or pointing at something that is not executable) the server refuses to start.
+The Nix package is self-sufficient — `makeWrapper --set-default` bakes the
+bundled Claude Code adapter (`packages.acp-agent`) into `bin/olai`, so
+`nix build` / `nix run` / the home-manager unit need no ambient env. The
+dev shell (so `just serve` on a raco-linked tree) exports the same default.
+Exporting the variable yourself wins, which is how you point `serve` at a
+different agent.
 
 Unset, or pointing at a file that is missing or not executable, is a **usage
 error**: nothing binds a port and the reason goes to stderr naming the

--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,17 @@
           };
         });
 
+      # home-manager module (nix/home/module.nix) for running `serve` as a
+      # user service. The flake fills in the packages for the host platform;
+      # the user fills in dataDir. Same output name as kolu.
+      homeManagerModules.default = { pkgs, lib, ... }: {
+        imports = [ ./nix/home/module.nix ];
+        config.services.olai.package =
+          lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.olai;
+        config.services.olai.acpAgent =
+          lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.acp-agent;
+      };
+
       checks = forAllSystems ({ pkgs, system }: {
         build = self.packages.${system}.olai;
         # The runCommand script lives in nix/smoke.nix; the example outline

--- a/flake.nix
+++ b/flake.nix
@@ -54,10 +54,11 @@
           # package-lock.json it builds from.
           acpAgent = pkgs.callPackage ./acp { };
 
-          # The build (racket build, TZDIR dance, raco exe stub) lives
-          # in nix/olai.nix; src is a flake-level decision, passed in.
+          # The build (racket build, TZDIR dance, raco exe stub, ACP
+          # default) lives in nix/olai.nix; src is a flake-level decision.
           olai = pkgs.callPackage ./nix/olai.nix {
             inherit (racketDepsPkg) racketPkgs racketDeps;
+            inherit acpAgent;
             src = ./.;
           };
         in
@@ -69,16 +70,11 @@
         });
 
       # `nix run` starts the web view; `nix run .#cli -- check ...` is the CLI.
-      # A one-line exec wrapper around the built binary is the boring option:
-      # no second closure, nothing to keep in sync, works offline.
+      # The package already defaults OLAI_ACP_AGENT; serve is just argv.
       apps = forAllSystems ({ pkgs, system }:
         let
           cli = pkgs.lib.getExe self.packages.${system}.olai;
-          # serve wants an ACP agent and will not start without one, so the app
-          # hands it the bundled adapter. Only serve: the bare CLI stays lean
-          # and never drags the node closure in. An exported var wins.
           serve = pkgs.writeShellScriptBin "olai-serve" ''
-            export OLAI_ACP_AGENT="''${OLAI_ACP_AGENT:-${pkgs.lib.getExe self.packages.${system}.acp-agent}}"
             exec ${cli} serve "$@"
           '';
           serveApp = {

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
             # `serve` refuses to start without an ACP agent; hand it the
             # bundled one so `just serve` works out of the box. Set the var
             # yourself to point at a different agent.
-            export OLAI_ACP_AGENT="''${OLAI_ACP_AGENT:-${self.packages.${system}.acp-agent}/bin/claude-agent-acp}"
+            export OLAI_ACP_AGENT="''${OLAI_ACP_AGENT:-${pkgs.lib.getExe self.packages.${system}.acp-agent}}"
           '';
         };
       });
@@ -73,12 +73,12 @@
       # no second closure, nothing to keep in sync, works offline.
       apps = forAllSystems ({ pkgs, system }:
         let
-          cli = "${self.packages.${system}.olai}/bin/olai";
+          cli = pkgs.lib.getExe self.packages.${system}.olai;
           # serve wants an ACP agent and will not start without one, so the app
           # hands it the bundled adapter. Only serve: the bare CLI stays lean
           # and never drags the node closure in. An exported var wins.
           serve = pkgs.writeShellScriptBin "olai-serve" ''
-            export OLAI_ACP_AGENT="''${OLAI_ACP_AGENT:-${self.packages.${system}.acp-agent}/bin/claude-agent-acp}"
+            export OLAI_ACP_AGENT="''${OLAI_ACP_AGENT:-${pkgs.lib.getExe self.packages.${system}.acp-agent}}"
             exec ${cli} serve "$@"
           '';
           serveApp = {
@@ -96,14 +96,11 @@
         });
 
       # home-manager module (nix/home/module.nix) for running `serve` as a
-      # user service. The flake fills in the packages for the host platform;
-      # the user fills in dataDir. Same output name as kolu.
+      # user service. The flake fills in package; the user fills in dataDir.
       homeManagerModules.default = { pkgs, lib, ... }: {
         imports = [ ./nix/home/module.nix ];
         config.services.olai.package =
           lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.olai;
-        config.services.olai.acpAgent =
-          lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.acp-agent;
       };
 
       checks = forAllSystems ({ pkgs, system }: {

--- a/nix/home/module.nix
+++ b/nix/home/module.nix
@@ -1,0 +1,109 @@
+# home-manager module for `olai serve` (systemd user unit on Linux, launchd
+# agent on macOS — same split as kolu's nix/home/module.nix). The flake's
+# `homeModules.default` imports this and fills in `package`; nothing here
+# names a store path.
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.olai;
+
+  # One wrapper script, both supervisors. The ACP agent is not an option:
+  # `serve` refuses to start without one, and the bundled adapter is the only
+  # agent the flake ships (`nix run` makes the same call). Precedence matches
+  # the CLI elsewhere: an exported OLAI_ACP_AGENT wins, the wrapper sets it
+  # only when unset.
+  envScript = ''
+    export OLAI_ACP_AGENT="''${OLAI_ACP_AGENT:-${cfg.acpAgent}/bin/claude-agent-acp}"
+    exec ${lib.getExe cfg.package} serve --port ${toString cfg.port} --bind ${cfg.host} "$@"
+  '';
+
+  serveArgs = [
+    "${pkgs.writeShellScript "olai-serve" envScript}"
+    (toString cfg.dataDir)
+  ];
+in
+{
+  options.services.olai = {
+    enable = lib.mkEnableOption "olai web view";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "The olai package to serve with.";
+    };
+
+    acpAgent = lib.mkOption {
+      type = lib.types.package;
+      description = ''
+        Package whose bin/claude-agent-acp is handed to `serve` via
+        OLAI_ACP_AGENT (the chat panel's agent). A `package`, not a path:
+        the adapter drags a node closure, and a str would garbage-collect
+        it out from under the unit.
+      '';
+    };
+
+    dataDir = lib.mkOption {
+      # str, not path: these are the user's outlines. A path literal would
+      # copy them into the read-only store and `serve` would watch the copy.
+      type = lib.types.str;
+      example = lib.literalExpression ''"''${config.home.homeDirectory}/Dropbox/Selfflowy-Srid"'';
+      description = ''
+        Directory of *.rkt outlines to serve (your $OLAI_HOME). olai itself
+        defaults to ~/Dropbox/Selfflowy-Srid, but a user unit must not guess
+        whose Dropbox that is — set it.
+      '';
+    };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "Address to listen on. olai has no auth; keep this loopback (or behind Tailscale).";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8080;
+      description = "Port to listen on.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # The CLI faces (check/tree/agenda/daily) work from any shell on the same
+    # files the service serves; the binary cannot skew from the service it
+    # inspects. Same reasoning as kolu's cliPackage, minus the opt-out.
+    home.packages = [ cfg.package ];
+
+    systemd.user.services = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
+      olai = {
+        Unit = {
+          Description = "olai web view";
+          After = [ "network.target" ];
+        };
+        Service = {
+          ExecStart = lib.escapeShellArgs serveArgs;
+          Restart = "on-failure";
+        };
+        Install = {
+          WantedBy = [ "default.target" ];
+        };
+      };
+    };
+
+    launchd.agents = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+      olai = {
+        enable = true;
+        config = {
+          ProgramArguments = serveArgs;
+          RunAtLoad = true;
+          # Match systemd's on-failure: restart on a non-zero exit OR a crash
+          # signal, not only a successful one.
+          KeepAlive = {
+            SuccessfulExit = false;
+            Crashed = true;
+          };
+          # launchd otherwise drops the process's output.
+          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/olai.out.log";
+          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/olai.err.log";
+        };
+      };
+    };
+  };
+}

--- a/nix/home/module.nix
+++ b/nix/home/module.nix
@@ -5,8 +5,8 @@
 let
   cfg = config.services.olai;
 
-  # Pure argv for both supervisors. host/port/dataDir are flags and a path.
-  # OLAI_ACP_AGENT is the operator's environment (same as any other `olai serve`).
+  # Pure argv for both supervisors. The package defaults OLAI_ACP_AGENT;
+  # host/port/dataDir are the only service knobs.
   serveArgs = [
     (lib.getExe cfg.package)
     "serve"

--- a/nix/home/module.nix
+++ b/nix/home/module.nix
@@ -1,24 +1,20 @@
 # home-manager module for `olai serve` (systemd user unit on Linux, launchd
-# agent on macOS — same split as kolu's nix/home/module.nix). The flake's
-# `homeModules.default` imports this and fills in `package`; nothing here
-# names a store path.
+# agent on macOS). The flake's `homeManagerModules.default` imports this and
+# fills in `package`; nothing here names a store path.
 { config, lib, pkgs, ... }:
 let
   cfg = config.services.olai;
 
-  # One wrapper script, both supervisors. The ACP agent is not an option:
-  # `serve` refuses to start without one, and the bundled adapter is the only
-  # agent the flake ships (`nix run` makes the same call). Precedence matches
-  # the CLI elsewhere: an exported OLAI_ACP_AGENT wins, the wrapper sets it
-  # only when unset.
-  envScript = ''
-    export OLAI_ACP_AGENT="''${OLAI_ACP_AGENT:-${cfg.acpAgent}/bin/claude-agent-acp}"
-    exec ${lib.getExe cfg.package} serve --port ${toString cfg.port} --bind ${cfg.host} "$@"
-  '';
-
+  # Pure argv for both supervisors. host/port/dataDir are flags and a path.
+  # OLAI_ACP_AGENT is the operator's environment (same as any other `olai serve`).
   serveArgs = [
-    "${pkgs.writeShellScript "olai-serve" envScript}"
-    (toString cfg.dataDir)
+    (lib.getExe cfg.package)
+    "serve"
+    "--port"
+    (toString cfg.port)
+    "--bind"
+    cfg.host
+    cfg.dataDir
   ];
 in
 {
@@ -30,25 +26,14 @@ in
       description = "The olai package to serve with.";
     };
 
-    acpAgent = lib.mkOption {
-      type = lib.types.package;
-      description = ''
-        Package whose bin/claude-agent-acp is handed to `serve` via
-        OLAI_ACP_AGENT (the chat panel's agent). A `package`, not a path:
-        the adapter drags a node closure, and a str would garbage-collect
-        it out from under the unit.
-      '';
-    };
-
     dataDir = lib.mkOption {
       # str, not path: these are the user's outlines. A path literal would
       # copy them into the read-only store and `serve` would watch the copy.
       type = lib.types.str;
-      example = lib.literalExpression ''"''${config.home.homeDirectory}/Dropbox/Selfflowy-Srid"'';
+      example = lib.literalExpression ''"''${config.home.homeDirectory}/outlines"'';
       description = ''
-        Directory of *.rkt outlines to serve (your $OLAI_HOME). olai itself
-        defaults to ~/Dropbox/Selfflowy-Srid, but a user unit must not guess
-        whose Dropbox that is — set it.
+        Directory of *.rkt outlines to serve. Required — a user unit has no
+        ambient home to fall back on.
       '';
     };
 
@@ -68,7 +53,7 @@ in
   config = lib.mkIf cfg.enable {
     # The CLI faces (check/tree/agenda/daily) work from any shell on the same
     # files the service serves; the binary cannot skew from the service it
-    # inspects. Same reasoning as kolu's cliPackage, minus the opt-out.
+    # inspects.
     home.packages = [ cfg.package ];
 
     systemd.user.services = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {

--- a/nix/olai.nix
+++ b/nix/olai.nix
@@ -11,7 +11,9 @@
 #     on Darwin it is broken for us — nixpkgs builds racket with
 #     `--enable-xonx`, so `cross-system-type` is `unix` and distribute's
 #     ELF patcher arity-mismatches (compiler/private/elf.rkt).
-{ lib, stdenv, racket, makeWrapper, tzdata, racketDeps, racketPkgs, src }:
+{ lib, stdenv, racket, makeWrapper, tzdata, racketDeps, racketPkgs, src
+, acpAgent
+}:
 
 stdenv.mkDerivation {
   pname = "olai";
@@ -19,7 +21,9 @@ stdenv.mkDerivation {
   inherit src;
   nativeBuildInputs = [ racket makeWrapper ];
   # racket is a true runtime dep: the exe is a stub over store racket.
-  buildInputs = [ racket tzdata ];
+  # acpAgent is too: serve needs it, and the wrapper defaults OLAI_ACP_AGENT
+  # so the binary is self-sufficient (exported var still wins).
+  buildInputs = [ racket tzdata acpAgent ];
 
   # Zoneinfo for gregor/tzinfo during the install-time raco setup.
   TZDIR = "${tzdata}/share/zoneinfo";
@@ -63,9 +67,12 @@ stdenv.mkDerivation {
       "$(racket -e '(display (path->string (collection-file-path "cli.rkt" "olai")))')"
     chmod +x $out/bin/.olai-wrapped
 
-    # Wrap with TZDIR so gregor finds zoneinfo outside /usr/share
+    # TZDIR: gregor outside /usr/share. OLAI_ACP_AGENT: serve refuses to
+    # start without one — default the bundled adapter so `nix build` / HM
+    # / `nix run` need no ambient env. An exported var still wins.
     makeWrapper $out/bin/.olai-wrapped $out/bin/olai \
       --set TZDIR "${tzdata}/share/zoneinfo" \
+      --set-default OLAI_ACP_AGENT "${lib.getExe acpAgent}" \
       --prefix PATH : "${tzdata}/bin"
 
     mkdir -p $out/share/tzdata

--- a/nix/smoke.nix
+++ b/nix/smoke.nix
@@ -42,22 +42,13 @@ runCommand "olai-smoke"
     cp ${exampleOutline} live.rkt
     chmod u+w live.rkt
 
-    # `serve` refuses to start without an ACP agent. The scripted one
-    # from the test suite is agent enough here: real subprocess, real
-    # ndjson, no LLM.
+    # Packaged `olai` defaults OLAI_ACP_AGENT to the bundled adapter
+    # (--set-default); override with the scripted fake for a real
+    # subprocess, real ndjson, no LLM.
     printf '#!/bin/sh\nexec racket %s "$@"\n' \
       ${fakeAcpAgentSrc} > fake-acp-agent
     chmod +x fake-acp-agent
     export OLAI_ACP_AGENT="$PWD/fake-acp-agent"
-
-    # No agent, no server: a usage error naming the variable, and
-    # nothing left listening on 8098.
-    if env -u OLAI_ACP_AGENT olai serve --port 8098 live.rkt \
-         > refused.out 2> refused.err; then
-      echo "smoke: serve started with no OLAI_ACP_AGENT" >&2
-      exit 1
-    fi
-    grep -q OLAI_ACP_AGENT refused.err
 
     # Nothing to serve, no server: the DIRECTORY form globs the top
     # level, and an empty one is refused before anything binds.

--- a/olai/cli.rkt
+++ b/olai/cli.rkt
@@ -352,7 +352,7 @@
 ;; The agent `serve` chats with. No fallback and no PATH lookup: an agent the
 ;; server picked for you is an agent you did not choose, and a serve command
 ;; that silently has no chat panel is worse than one that will not start. Nix
-;; sets the variable (`nix run`, the dev shell, hence `just serve`).
+;; sets the variable (Nix package --set-default, the dev shell, `just serve`).
 (define (acp-command-or-die)
   (define v (getenv "OLAI_ACP_AGENT"))
   (unless (and v (non-empty-string? v))


### PR DESCRIPTION
## What

`services.olai` home-manager module that keeps `olai serve` running as a user unit:
- **Linux:** `systemd.user.services.olai` (WantedBy `default.target`, `Restart = on-failure`)
- **macOS:** `launchd.agents.olai` (`RunAtLoad`, `KeepAlive` matching on-failure, logs to `~/Library/Logs/olai.*.log`)
- Output: `homeManagerModules.default` (kolu's name for the same shape)

Options: `enable`, `dataDir` (required — the user's outlines), `package`, `acpAgent`, `host` (default `127.0.0.1`), `port` (default `8080`). The flake fills `package` / `acpAgent` with `mkDefault` for the host platform; the user only has to set `dataDir`.

`serve` refuses to start without an ACP agent; the module handles that the same way `nix run` does — a thin `writeShellScript` wrapper exports `OLAI_ACP_AGENT` to the bundled `acp-agent` *only when unset*, then `exec`s `serve` with the configured flags. An exported `OLAI_ACP_AGENT` still wins over the module.

### Usage

```nix
{
  inputs.olai.url = "github:juspay/olai";
  # in a home-manager config:
  imports = [ inputs.olai.homeManagerModules.default ];
  services.olai = {
    enable = true;
    dataDir = "${config.home.homeDirectory}/Dropbox/Selfflowy-Srid";
  };
}
```

## Hickey / Lowy

Both lenses quiet:

- **Hickey (spatial):** one options block, one `envScript` shared by both supervisors; the ACP-default logic lives *in the wrapper script*, not smeared across two config blocks. The only thing that mixes two ideas is `writeShellScript` mixing "realize the store path" with "the shell logic" — which is exactly what `writeShellScript` is for.
- **Lowy (temporal):** the module (option *shape*, changes with olai's CLI) is isolated from the version-bound package-wiring (the flake fills `package`/`acpAgent` via `mkDefault`, kolu-style). `dataDir` — the most volatile thing in the whole system — is a required option, never embedded. systemd and launchd (two supervisors on independent OS clocks) are both present, each gated, neither aware of the other.

## Verification

- `nix-instantiate --parse nix/home/module.nix` — clean.
- Full home-manager *module* evaluation (HM release-25.11 as the module host, the repo's own nixpkgs 26.11 as the package set): `ExecStart` points at a built wrapper script with the user's `dataDir`, `Restart = "on-failure"`, `WantedBy = [ "default.target" ]`, `home.packages` = `[ olai ]`, `launchd.agents` correctly empty on Linux.
- `nix-build` realizes every store path the wrapper references (olai pkg, acp-agent, bash). `cat` on the built wrapper shows the exact `export OLAI_ACP_AGENT="${OLAI_ACP_AGENT:-…/claude-agent-acp}"` + `exec olai serve --port 9999 --bind 127.0.0.1`.
- Not run: `nix flake check` / runtime `home-manager switch` (no darwin builder here; the runtime `olai serve` path is already covered by `nix/smoke.nix`, which this module wraps).