### PR TITLE
web: fifteen themes, a prefs panel, and a repo that runs out of the box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Belt-and-braces: never commit personal outline data if someone
 # accidentally drops a copy in the repo. Canonical data is outside:
-# $OLAI_HOME (default ~/Dropbox/Selfflowy-Srid/). Roadmap.rkt is NOT
+# $OLAI_HOME, wherever you set it. Roadmap.rkt is NOT
 # personal data -- it's the project's own roadmap and lives at repo root,
 # tracked like any other file.
 /private/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,12 @@ Read README.md and docs/*.md first. This file is only what you can't infer.
 
 * If your model is Fable, a) use subagents for implementation (typically
   Opus), b) reserve Fable only where truly necessary.
-* Personal outline DATA lives outside the repo: `$OLAI_HOME` (default
-  `~/Dropbox/Selfflowy-Srid/`) — `Tasks.rkt`, `Daily.rkt` (+ `Daily/`).
-  NEVER commit or invent content for these; user-owned, re-validate after
-  edits. `examples/` is demo fiction for CI, never Dropbox paths.
-  `Roadmap.rkt` is public, at repo root, committed and re-validated like
-  any file — the author's `Tasks.rkt` `@include`s it.
+* Personal outline DATA lives outside the repo, in `$OLAI_HOME` —
+  `Tasks.rkt`, `Daily.rkt` (+ `Daily/`). No default path: unset is a usage
+  error, and the repo never names anyone's data dir. NEVER commit or invent
+  content for these; user-owned, re-validate after edits. `examples/` is demo
+  fiction for CI. `Roadmap.rkt` is public, at repo root, committed and
+  re-validated like any file — a private `Tasks.rkt` may `@include` it.
 * No hand-rolling where a maintained library exists. In use: racket/cmdline,
   json (write-json/read-json), xml (xexprs), gregor (dates), markdown
   (title/note formatting in the web view only).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,9 +66,8 @@ Read README.md and docs/*.md first. This file is only what you can't infer.
 * just check / tree / agenda / serve / test — recipes handle PLTUSERHOME +
   raco link (`run`/`watch` alias `serve`). Racket comes from the nix dev
   shell (nixpkgs 9.2). Don't fight raco setup; PLTUSERHOME must be writable.
-* Two test sets: `just test` is olai/tests/*.rkt (in-process, fast),
-  `just test-integration` is olai/tests/integration/ (spawns `olai`
-  subprocesses, boots servers). `just test-all` runs both.
+* `just test` is the only test command you run. It is the fast set; CI
+  runs everything else on the PR.
 * Branch + PR for every change (agents included); CI green before merge.
   Master rejects direct pushes.
 * Other agents work this repo concurrently (Grok in a kolu terminal). git pull
@@ -79,7 +78,7 @@ Read README.md and docs/*.md first. This file is only what you can't infer.
   <id> "text"`, pause ~2s, then `kaval-tui send <id> --key Enter` (separate
   sends — same-breath Enter gets eaten by the paste debounce). Long briefs:
   write a file, send a short "read <path>" prompt. Never kill that terminal.
-* CI = nix build + binary smoke + just test + just test-integration. Keep
+* CI = nix build + binary smoke + the full test suite. Keep
   `nix build` offline-clean when possible; external racket deps (gregor,
   markdown) need vendoring or impure install until fixed-output derivations
   land.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Under the hood every outline becomes s-expressions. Same expander:
 
 ```text
 $OLAI_HOME/*.rkt                 <- personal data (#lang olai)
-(default: ~/Dropbox/Selfflowy-Srid/)
+(your outline dir; unset -> the repo's examples/ + Roadmap.rkt)
     |                                 ^
     v                                 | edits your files
 olai CLI (Racket)                     |   <- validate / query / capture
@@ -83,7 +83,9 @@ racket web-server --- spawns ---> ACP agent (Claude Code; JSON-RPC on stdio)
 ```
 
 Personal outlines are plain files you sync however you like (Dropbox,
-git, rsync). The repo holds the tool; your data stays outside it.
+git, rsync). The repo holds the tool; your data stays outside it — point
+`OLAI_HOME` at that directory. Without it the repo serves its own
+`examples/` plus `Roadmap.rkt`, and the write commands ask you to set it.
 `add` / `done` / `move` / `daily` auto-commit only when the written
 file's dir is a git work tree; otherwise they write the file and leave
 history to your sync layer.
@@ -123,7 +125,7 @@ author does. Repo demos live in `examples/` (see `examples/Daily.rkt` for
 ```bash
 nix develop        # racket 9.2 + just; or install them yourself
 just install       # gregor + markdown, then --link olai/
-just check         # validates $OLAI_HOME/*.rkt
+just check         # validates $OLAI_HOME/*.rkt (unset: examples + Roadmap)
 just tree examples/Example.rkt   # JSON forest for agents
 just serve                       # $OLAI_HOME on http://127.0.0.1:8080
 just agenda
@@ -136,8 +138,9 @@ just css-classes                 # regenerate olai/tests/classes.golden
 ```
 
 `olai serve DIR` serves `DIR/*.rkt` and runs the agent in `DIR`
-(default: `$PWD`; `just serve` passes `$OLAI_HOME`). Naming files
-instead still works — see docs/cli.md.
+(default: `$PWD`; `just serve` passes `$OLAI_HOME`, or names the repo's
+own outlines when it is unset). Naming files instead still works — see
+docs/cli.md.
 
 `serve` refuses to start without `OLAI_ACP_AGENT` — the path to an
 executable speaking the Agent Client Protocol. The Nix package defaults it

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -411,6 +411,17 @@ links people wrote by hand still resolve.
 
 Paths that climb out of `static/` are 404, not files.
 
+**Prefs** are a sidebar section, one row per preference — client state, stored
+in `localStorage` under `olai.<pref>`, never sent to the server (same standing
+as the collapse state) and therefore per browser. The first row is `theme`:
+`auto` plus one chip per theme (`light`, `dark`, `manuscript`, `chalk`,
+`pitch`). The sheet carries all of them, so picking one is a value on
+`<html data-theme>` and nothing else — no round trip, no re-render. `auto` is
+the default and follows the OS's `prefers-color-scheme`. A tiny inline script in
+`<head>` restores stored prefs before the first paint (`static/prefs.js` is the
+picker); each theme also declares its own `color-scheme`, so scrollbars and
+form controls follow.
+
 The chat panel (a `>_ agent` button, bottom right; open state remembered in
 `localStorage`) is server-rendered from the bridge's transcript on every page
 load — frames are ephemeral, so a reload or a second tab replays instead of

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -413,14 +413,15 @@ Paths that climb out of `static/` are 404, not files.
 
 **Prefs** are a sidebar section, one row per preference — client state, stored
 in `localStorage` under `olai.<pref>`, never sent to the server (same standing
-as the collapse state) and therefore per browser. The first row is `theme`:
-`auto` plus one chip per theme (`light`, `dark`, `manuscript`, `chalk`,
-`pitch`). The sheet carries all of them, so picking one is a value on
-`<html data-theme>` and nothing else — no round trip, no re-render. `auto` is
-the default and follows the OS's `prefers-color-scheme`. A tiny inline script in
-`<head>` restores stored prefs before the first paint (`static/prefs.js` is the
-picker); each theme also declares its own `color-scheme`, so scrollbars and
-form controls follow.
+as the collapse state) and therefore per browser. The first row is `theme`: one
+chip per theme in `olai/web/theme`'s table, and nothing else. The sheet carries
+all of them, so picking one is a value on `<html data-theme>` and nothing else
+— no round trip, no re-render. A page that has picked nothing reads in the
+default theme (the sheet's bare `:root`) and that chip is the lit one; the OS's
+`prefers-color-scheme` is never consulted, and a stored theme the sheet no
+longer carries is forgotten on sight. A tiny inline script in `<head>` restores
+stored prefs before the first paint (`static/prefs.js` is the picker); each
+theme declares its own `color-scheme`, so scrollbars and form controls follow.
 
 The chat panel (a `>_ agent` button, bottom right; open state remembered in
 `localStorage`) is server-rendered from the bridge's transcript on every page

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,17 +22,25 @@ the kinds are how the layer below talks about failure.
 
 ## Global
 
-- Default outline file when no paths given:
-  `$OLAI_HOME/Tasks.rkt` (default home:
-  `~/Dropbox/Selfflowy-Srid` — the author's data dir, not renamed with the
-  tool). `add` / `done` / `move` always target one file via `--file`, same
-  default.
+- Default outline file when no paths given: `$OLAI_HOME/Tasks.rkt`.
+  `add` / `done` / `move` always target one file via `--file`, same default.
+- **`OLAI_HOME` has no default.** Unset, any command that would need it —
+  the file defaults above, `daily` without `--home` — is a **usage error**
+  (exit 1, JSON on stderr under `--json`), nothing is read or written:
+
+  ```console
+  $ olai add --no-commit "buy milk"
+  olai: OLAI_HOME is not set; set it to your outline directory, or name the outline explicitly (a path argument, --file, --home)
+  ```
+
+  Naming files (or `--file` / `--home`) works with the variable unset.
 - **Read commands** (`check` / `tree` / `agenda` / `calendar` / `ics` /
   `serve`) accept **one or more** outline paths. The justfile defaults to
-  `$OLAI_HOME/*.rkt` (no `examples/` paths). `serve` also takes the
-  DIRECTORY and globs it itself — that is its front door, see below.
-- Personal data lives outside the repo. Override the directory with
-  `OLAI_HOME`. Auto-commit (`add` / `done` / `move` / `daily`) only runs
+  `$OLAI_HOME/*.rkt`, or the repo's own `examples/Example.rkt Roadmap.rkt`
+  when `OLAI_HOME` is unset. `serve` also takes the DIRECTORY and globs it
+  itself — that is its front door, see below.
+- Personal data lives outside the repo, in the directory `OLAI_HOME`
+  names. Auto-commit (`add` / `done` / `move` / `daily`) only runs
   when the directory of the file actually written is a git work tree;
   otherwise it no-ops (`committed: false`) and Dropbox (or your sync) is the history layer.
 - `--json` may appear after the subcommand where supported.
@@ -239,7 +247,8 @@ recursive walk would load every one of them twice), sorted, so the node keys
 minted against the set are stable. The glob is evaluated once at startup: a new
 top-level file is picked up by restarting, not while running. A directory with
 no `*.rkt` in it is refused, naming the directory, exit 3. `just serve` is this
-form over `$OLAI_HOME`.
+form over `$OLAI_HOME` (with it unset, `just serve` names the repo's own
+outlines instead).
 
 The agent runs **in that directory** — exactly it, not the base derived from
 the files. That is the point of the form: Claude Code keys its stored sessions
@@ -247,8 +256,8 @@ by the directory it was started in, so a stable one is what makes "the session
 you were last in" a thing that survives a restart (see *Sessions* below).
 
 ```console
-$ olai serve ~/Dropbox/Selfflowy-Srid
-olai serve http://127.0.0.1:8080 dir: /home/me/Dropbox/Selfflowy-Srid files: /.../Daily.rkt /.../Tasks.rkt
+$ olai serve ~/notes
+olai serve http://127.0.0.1:8080 dir: /home/me/notes files: /.../Daily.rkt /.../Tasks.rkt
 ```
 
 **Explicit `.rkt` files are the plumbing** — the roots are those files, and the

--- a/justfile
+++ b/justfile
@@ -3,14 +3,16 @@
 export PLTUSERHOME := env_var_or_default("PLTUSERHOME", justfile_directory() / ".plt-user")
 export PATH := PLTUSERHOME / ".local/share/racket/9.2/bin:" + env_var("PATH")
 
-# Personal outline data (outside the repo). Override with OLAI_HOME.
-# The default follows the user's data dir, which the rebrand did not move.
-olai_home := env_var_or_default("OLAI_HOME", env_var("HOME") + "/Dropbox/Selfflowy-Srid")
+# Personal outline data lives outside the repo: set OLAI_HOME to it. Unset,
+# the read recipes fall back to the repo's own outlines and the write ones
+# (add/done/move/daily) let olai say what is missing.
+olai_home := env_var_or_default("OLAI_HOME", "")
 
 # Top-level *.rkt in $OLAI_HOME are roots (Tasks, Daily, a Roadmap
 # @include, ...); include fragments live in subdirectories (Daily/), so the
 # glob never double-loads.
-default_outlines := olai_home + "/*.rkt"
+repo_outlines := "examples/Example.rkt Roadmap.rkt"
+default_outlines := if olai_home == "" { repo_outlines } else { olai_home + "/*.rkt" }
 
 default:
     @just --list
@@ -21,7 +23,7 @@ install:
     raco pkg install --auto --skip-installed gregor markdown css-expr
     raco pkg install --auto --skip-installed --link {{justfile_directory()}}/olai
 
-# Validate outline(s) (default: $OLAI_HOME/*.rkt)
+# Validate outline(s) (default: $OLAI_HOME/*.rkt, else the repo's own)
 check *args: install
     olai check {{if args == "" { default_outlines } else { args }}}
 
@@ -75,14 +77,14 @@ move *args: install
 daily *args: install
     olai daily {{args}}
 
-# serve takes the DIRECTORY, not the glob: it globs the top level itself, and
-# the agent then works in $OLAI_HOME (which is what makes its stored
-# sessions survive a restart). OLAI_ACP_AGENT comes from the nix dev
-# shell; serve will not start without it, so export it yourself outside
-# `nix develop`.
-# Serve the web view (default: $OLAI_HOME on 127.0.0.1:8080)
+# With OLAI_HOME set, serve takes the DIRECTORY, not the glob: it globs the
+# top level itself, and the agent then works in $OLAI_HOME (which is what makes
+# its stored sessions survive a restart). Unset, it serves the repo's own two
+# files by name. OLAI_ACP_AGENT comes from the nix dev shell; serve will not
+# start without it, so export it yourself outside `nix develop`.
+# Serve the web view (default: $OLAI_HOME, else the repo's own, on 127.0.0.1:8080)
 serve *args: install
-    olai serve {{if args == "" { olai_home } else { args }}}
+    olai serve {{if args != "" { args } else if olai_home != "" { olai_home } else { repo_outlines } }}
 
 # The server is how you run olai; it reloads an outline when it changes.
 alias run := serve

--- a/olai/cli.rkt
+++ b/olai/cli.rkt
@@ -31,18 +31,23 @@
 (define exit-validation 2)
 (define exit-not-found 3)
 
-;; Personal outline data lives outside the repo (Dropbox by default).
-;; Override with OLAI_HOME. Auto-commit only fires when that dir is
-;; a git work tree; Dropbox alone is the sync layer (no-op otherwise).
-;; The default path still spells the old name: it follows the user's
-;; data dir, which this rebrand deliberately did not move.
+;; Personal outline data lives outside the repo; OLAI_HOME names the directory.
+;; There is no default — the tool does not guess where your notes are — so an
+;; unset OLAI_HOME is a usage error (kind 'usage, like any other op failure),
+;; raised only when a command actually needs the home. Auto-commit fires when
+;; that dir is a git work tree; otherwise your sync layer is the history.
 (define (olai-home)
   (define env (getenv "OLAI_HOME"))
-  (if (and env (non-empty-string? env))
-      (expand-user-path env)
-      (build-path (expand-user-path "~") "Dropbox" "Selfflowy-Srid")))
+  (unless (and env (non-empty-string? env))
+    (raise (exn:fail:op
+            (string-append
+             "OLAI_HOME is not set; set it to your outline directory, "
+             "or name the outline explicitly (a path argument, --file, --home)")
+            (current-continuation-marks)
+            'usage #f #f #f)))
+  (expand-user-path env))
 
-(define default-file
+(define (default-file)
   (path->string (build-path (olai-home) "Tasks.rkt")))
 
 (define (die code msg #:json? json? #:file [file #f] #:line [line #f] #:col [col #f])
@@ -60,9 +65,10 @@
          #:file path))
   path)
 
-;; Resolve zero-or-more path args; empty => default Tasks.rkt.
+;; Resolve zero-or-more path args; empty => $OLAI_HOME/Tasks.rkt (run-op so an
+;; unset home dies as the usage error it is, in the mode asked for).
 (define (resolve-files file-args json?)
-  (define raw (if (null? file-args) (list default-file) file-args))
+  (define raw (if (null? file-args) (list (run-op json? default-file)) file-args))
   (map (λ (p) (resolve-path p json?)) raw))
 
 (define (load-outline path json?)
@@ -243,7 +249,7 @@
   (define r
     (run-op json?
             (λ ()
-              (ops-add! (or file-arg default-file) title
+              (ops-add! (or file-arg (default-file)) title
                         #:date date
                         #:description desc
                         #:parent parent
@@ -272,7 +278,7 @@
   (define r
     (run-op json?
             (λ ()
-              (ops-done! (or file-arg default-file) spec (today-iso)
+              (ops-done! (or file-arg (default-file)) spec (today-iso)
                          #:undo? undo?
                          #:commit? (not no-commit?)))))
   (if json?
@@ -297,7 +303,7 @@
   (define r
     (run-op json?
             (λ ()
-              (ops-move! (or file-arg default-file) spec date-arg
+              (ops-move! (or file-arg (default-file)) spec date-arg
                          #:clear? clear?
                          #:commit? (not no-commit?)))))
   (if json?
@@ -436,7 +442,7 @@
   (eprintf "usage: olai <command> [options] ...\n")
   (eprintf "\n")
   (eprintf "commands:\n")
-  (eprintf "  check    [--json] [file ...]  validate outline(s) (default: ~a)\n" default-file)
+  (eprintf "  check    [--json] [file ...]  validate outline(s) (default: $OLAI_HOME/Tasks.rkt)\n")
   (eprintf "  tree     [--json] [file ...]  outline(s) as JSON (human view: web)\n")
   (eprintf "  agenda   [--json] [file ...]  OVERDUE / TODAY / UPCOMING (merged)\n")
   (eprintf "  calendar [--json] [--month YYYY-MM] [file ...]  days with dated items\n")

--- a/olai/tests/classes.golden
+++ b/olai/tests/classes.golden
@@ -5,6 +5,7 @@ is-busy
 is-collapsed
 is-done
 is-error
+is-on
 is-open
 is-picked
 is-today
@@ -76,6 +77,11 @@ ol-outline
 ol-pane
 ol-pill
 ol-pre
+ol-pref
+ol-pref-label
+ol-pref-opt
+ol-pref-opts
+ol-prefs
 ol-row
 ol-sidebar
 ol-sidebar-empty

--- a/olai/tests/integration/cli-add.rkt
+++ b/olai/tests/integration/cli-add.rkt
@@ -122,6 +122,25 @@
        (check-equal? (file->string f) original))
      (λ () (delete-directory/files dir))))
 
+  ;; There is no default home. With OLAI_HOME unset and nothing named, the
+  ;; command that would have needed it says so and touches nothing — usage
+  ;; error on both sides of the CLI, JSON on stderr when asked for.
+  (test-case "unset OLAI_HOME is a usage error"
+    (parameterize ([current-environment-variables
+                    (let ([e (environment-variables-copy
+                              (current-environment-variables))])
+                      (environment-variables-set! e #"OLAI_HOME" #f)
+                      e)])
+      (define-values (code out err) (run-olai (list "add" "--no-commit" "x")))
+      (check-equal? code 1 (string-append out err))
+      (check-true (regexp-match? #px"OLAI_HOME" err) err)
+      (define-values (c2 o2 e2) (run-olai (list "check" "--json")))
+      (check-equal? c2 1 (string-append o2 e2))
+      (define j (parse-json e2))
+      (check-equal? (hash-ref j 'ok) #f)
+      (define msg (hash-ref (hash-ref j 'error) 'message))
+      (check-true (regexp-match? #px"OLAI_HOME" msg) msg)))
+
   ;; Every writer emits outline syntax, so the write path refuses a sexp file
   ;; rather than each command remembering to.
   (test-case "writes refuse a #lang olai/sexp file"

--- a/olai/tests/render.rkt
+++ b/olai/tests/render.rkt
@@ -13,6 +13,8 @@
          (only-in olai/lang/walk resolve-mirrors)
          olai/store
          olai/web/render
+         ;; the list the picker draws: the themes the sheet carries
+         (only-in olai/web/theme theme-names)
          ;; the chat panel is its own module now: presentation for the agent's
          ;; conversation, sitting on top of the outline's skin
          olai/web/chat-panel
@@ -36,6 +38,13 @@
 (define (xstr* xs) (string-join (map xstr xs) ""))
 
 (define (files . entries) entries)
+
+;; The sidebar over one trivial outline — what the prefs tests below read. The
+;; outline is not the subject there; the chrome around it is.
+(define (sidebar-html)
+  (xstr (render-sidebar (files (list "/tmp/Tasks.rkt" (list (tk "Inbox" #f #f '()))))
+                        #:home-href "/"
+                        #:today-href "/today")))
 
 (module+ test
 
@@ -334,6 +343,22 @@
     ;; sidebar collapse state is namespaced away from the main pane's
     (check-true (string-contains? s "data-collapse-key=\"tree-") s))
 
+  ;; Every theme the sheet carries, and the OS. Generated from theme-names, so
+  ;; a theme added to the table shows up in the picker or fails here.
+  (test-case "the sidebar's prefs list the theme row: every theme, plus auto"
+    (define s (sidebar-html))
+    (check-true (string-contains? s "Prefs") s)
+    (check-true (string-contains? s "ol-prefs") s)
+    ;; one row per pref, named: the script reads the name, not a class
+    (check-true (string-contains? s "<div class=\"ol-pref\" data-pref=\"theme\">") s)
+    (check-true (string-contains? s "data-value=\"auto\"") s)
+    (check-true (pair? theme-names))
+    (for ([t (in-list theme-names)])
+      (check-true (string-contains? s (string-append "data-value=\"" t "\"")) s))
+    ;; nothing is picked on the server: which theme you read in is the
+    ;; browser's, and prefs.js is what marks it
+    (check-false (string-contains? s "is-on") s))
+
   ;; ---- breadcrumbs / zoom -------------------------------------------------
 
   (test-case "breadcrumbs link the pairs and leave bare strings plain"
@@ -391,13 +416,18 @@
     (check-true (string-contains? s "src=\"/static/htmx.min.js\"") s)
     (check-true (string-contains? s "src=\"/static/sse.js\"") s)
     (check-true (string-contains? s "src=\"/static/collapse.js\"") s)
+    (check-true (string-contains? s "src=\"/static/prefs.js\"") s)
     (check-true (string-contains? s "src=\"/static/chat.js\"") s)
     (check-false (string-contains? s "tailwind") s)
     (check-false (string-contains? s "cdn.") s)
     (check-true (string-contains? s "<aside class=\"ol-sidebar\"") s)
     (check-true (string-contains? s "<main class=\"ol-main\">") s)
-    ;; no inline script: every asset is a cacheable file under /static/
-    (check-false (string-contains? s "localStorage") s)
+    ;; ONE inline script, and it is the prefs boot: everything else is a
+    ;; cacheable file under /static/. (A stored pref has to be on <html>
+    ;; before the first paint, and a deferred file lands after it.)
+    (check-equal? (length (regexp-match* #px"<script" s))
+                  (add1 (length web-scripts)) s)
+    (check-true (string-contains? s "localStorage.getItem('olai.'+p)") s)
     ;; served form carries the doctype (no quirks mode)
     (check-true (string-prefix? (page->html-string (render-page '(div))) "<!DOCTYPE html>")))
 
@@ -426,6 +456,37 @@
     (check-false (string-contains? js "require") js)
     (check-true (string-contains? js "olai.collapsed") js)
     (check-true (string-contains? js "localStorage") js))
+
+  ;; A pref is client state, like the collapse state: a value on <html>, stored
+  ;; here, never sent anywhere. The picker's script and the page's boot script
+  ;; spell the same storage key on two sides of a border the compiler does not
+  ;; cross — a mismatch is a picker that picks and a page that forgets. And the
+  ;; boot script has to NAME every pref, or the row that joined restores to
+  ;; nothing on the next load.
+  (test-case "prefs script stays tiny and shares the boot script's key"
+    (define js (file->string (build-path (web-static-dir) "prefs.js")))
+    (define boot (xstr (render-page '(div))))
+    (check-true (< (length (string-split js "\n")) 40) js)
+    (check-false (string-contains? js "require") js)
+    (check-true (string-contains? js "localStorage") js)
+    (check-true (string-contains? js "ol-pref") js)
+    ;; the key convention, spelled the same on both sides
+    (check-true (string-contains? js "'olai.'+p") js)
+    (check-true (string-contains? boot "'olai.'+p") boot)
+    ;; and every row the sidebar draws is a name the boot script restores
+    (for ([name (in-list (regexp-match* #px"data-pref=\"([a-z-]+)\"" (sidebar-html)
+                                        #:match-select cadr))])
+      (check-true (string-contains? boot (string-append "'" name "'")) boot)))
+
+  (test-case "a page can name a theme; unset leaves it to the OS"
+    (define named (xstr (render-page '(div) #:theme "pitch")))
+    (check-true (string-contains? named "<html lang=\"en\" data-theme=\"pitch\">") named)
+    ;; the default: nothing named, so the OS's preference and whatever this
+    ;; browser stored are what decide
+    (check-false (string-contains? (xstr (render-page '(div))) "data-theme") named)
+    ;; both ways, the browser is told the page has two faces before the sheet
+    ;; lands; the sheet is what narrows it per theme
+    (check-true (string-contains? named "content=\"light dark\"") named))
 
   ;; ---- chat panel ----------------------------------------------------------
   ;;

--- a/olai/tests/render.rkt
+++ b/olai/tests/render.rkt
@@ -13,8 +13,9 @@
          (only-in olai/lang/walk resolve-mirrors)
          olai/store
          olai/web/render
-         ;; the list the picker draws: the themes the sheet carries
-         (only-in olai/web/theme theme-names)
+         ;; the list the picker draws: the themes the sheet carries, and the
+         ;; one a page that picked nothing reads in
+         (only-in olai/web/theme theme-names theme-default)
          ;; the chat panel is its own module now: presentation for the agent's
          ;; conversation, sitting on top of the outline's skin
          olai/web/chat-panel
@@ -343,18 +344,29 @@
     ;; sidebar collapse state is namespaced away from the main pane's
     (check-true (string-contains? s "data-collapse-key=\"tree-") s))
 
-  ;; Every theme the sheet carries, and the OS. Generated from theme-names, so
-  ;; a theme added to the table shows up in the picker or fails here.
-  (test-case "the sidebar's prefs list the theme row: every theme, plus auto"
+  ;; Every theme the sheet carries, and nothing else. Generated from
+  ;; theme-names, so a theme added to the table shows up in the picker or fails
+  ;; here. There is no chip for "auto" and nothing to defer to: a page that
+  ;; picked nothing reads in the row's default, and prefs.js lights that chip.
+  (test-case "the sidebar's prefs list the theme row: one chip per theme"
     (define s (sidebar-html))
     (check-true (string-contains? s "Prefs") s)
     (check-true (string-contains? s "ol-prefs") s)
-    ;; one row per pref, named: the script reads the name, not a class
-    (check-true (string-contains? s "<div class=\"ol-pref\" data-pref=\"theme\">") s)
-    (check-true (string-contains? s "data-value=\"auto\"") s)
+    ;; one row per pref, named, carrying where this browser stores it and what
+    ;; is in force until it stores anything: the script reads all three, and
+    ;; never spells a class per pref, a key, or a theme
+    (check-true (string-contains?
+                 s (string-append
+                    "<div class=\"ol-pref\" data-pref=\"theme\""
+                    " data-store-key=\"olai.theme\""
+                    " data-default=\"" theme-default "\">"))
+                s)
+    (check-false (string-contains? s "data-value=\"auto\"") s)
     (check-true (pair? theme-names))
     (for ([t (in-list theme-names)])
       (check-true (string-contains? s (string-append "data-value=\"" t "\"")) s))
+    ;; exactly the themes: no sixth chip from anywhere
+    (check-equal? (length (regexp-match* #px"data-value=\"" s)) (length theme-names) s)
     ;; nothing is picked on the server: which theme you read in is the
     ;; browser's, and prefs.js is what marks it
     (check-false (string-contains? s "is-on") s))
@@ -427,7 +439,7 @@
     ;; before the first paint, and a deferred file lands after it.)
     (check-equal? (length (regexp-match* #px"<script" s))
                   (add1 (length web-scripts)) s)
-    (check-true (string-contains? s "localStorage.getItem('olai.'+p)") s)
+    (check-true (string-contains? s "localStorage.getItem") s)
     ;; served form carries the doctype (no quirks mode)
     (check-true (string-prefix? (page->html-string (render-page '(div))) "<!DOCTYPE html>")))
 
@@ -458,35 +470,37 @@
     (check-true (string-contains? js "localStorage") js))
 
   ;; A pref is client state, like the collapse state: a value on <html>, stored
-  ;; here, never sent anywhere. The picker's script and the page's boot script
-  ;; spell the same storage key on two sides of a border the compiler does not
-  ;; cross — a mismatch is a picker that picks and a page that forgets. And the
-  ;; boot script has to NAME every pref, or the row that joined restores to
-  ;; nothing on the next load.
-  (test-case "prefs script stays tiny and shares the boot script's key"
+  ;; here, never sent anywhere. The storage key is no longer spelled in either
+  ;; script — Racket builds it (olai/web/prefs) and hands it to both, the row in
+  ;; data-store-key and the boot script in its table — so what is left to check
+  ;; is that every row the sidebar draws is one the boot script restores.
+  (test-case "prefs script stays tiny, and the boot script names every row"
     (define js (file->string (build-path (web-static-dir) "prefs.js")))
     (define boot (xstr (render-page '(div))))
     (check-true (< (length (string-split js "\n")) 40) js)
     (check-false (string-contains? js "require") js)
     (check-true (string-contains? js "localStorage") js)
     (check-true (string-contains? js "ol-pref") js)
-    ;; the key convention, spelled the same on both sides
-    (check-true (string-contains? js "'olai.'+p") js)
-    (check-true (string-contains? boot "'olai.'+p") boot)
-    ;; and every row the sidebar draws is a name the boot script restores
+    ;; a hyphenated pref name is not a dataset key: both sides write the
+    ;; attribute itself, or the setter throws
+    (check-true (string-contains? js "setAttribute") js)
+    (check-true (string-contains? boot "setAttribute") boot)
     (for ([name (in-list (regexp-match* #px"data-pref=\"([a-z-]+)\"" (sidebar-html)
                                         #:match-select cadr))])
-      (check-true (string-contains? boot (string-append "'" name "'")) boot)))
+      (check-true (string-contains? boot (string-append "\"" name "\"")) boot)
+      (check-true (string-contains? boot (string-append "\"olai." name "\"")) boot)))
 
-  (test-case "a page can name a theme; unset leaves it to the OS"
-    (define named (xstr (render-page '(div) #:theme "pitch")))
-    (check-true (string-contains? named "<html lang=\"en\" data-theme=\"pitch\">") named)
-    ;; the default: nothing named, so the OS's preference and whatever this
-    ;; browser stored are what decide
-    (check-false (string-contains? (xstr (render-page '(div))) "data-theme") named)
-    ;; both ways, the browser is told the page has two faces before the sheet
-    ;; lands; the sheet is what narrows it per theme
-    (check-true (string-contains? named "content=\"light dark\"") named))
+  ;; The page never names a theme: which one you read in is the BROWSER's, and
+  ;; the boot script is the only thing that writes data-theme. What the page
+  ;; does carry is what to assume before the sheet lands, and it is TOLD that.
+  (test-case "the page names no theme, and carries the color-scheme it is told"
+    (define s (xstr (render-page '(div) #:color-scheme "light dark")))
+    (check-true (string-contains? s "<html lang=\"en\">") s)
+    (check-false (string-contains? s "data-theme=") s)
+    (check-true (string-contains? s "content=\"light dark\"") s)
+    ;; told nothing, it says nothing: a fragment test, never a served page
+    (check-false (string-contains? (xstr (render-page '(div))) "color-scheme")
+                 "an untold page invented a color-scheme"))
 
   ;; ---- chat panel ----------------------------------------------------------
   ;;

--- a/olai/tests/style.rkt
+++ b/olai/tests/style.rkt
@@ -7,7 +7,8 @@
 ;;
 ;; What this file asks, and what it does not: ordering questions are asked of
 ;; the REGISTRY (style-fragments, fragment-classes) and theme questions are
-;; generated from theme.rkt's own token list. css-expr's output text is pinned
+;; generated from theme.rkt's own tables and asked of the blocks it hands over
+;; (theme-blocks), never of the sheet's text. css-expr's output text is pinned
 ;; in exactly one test case, marked as the canary. A css-expr bump is allowed
 ;; to break that case and nothing else here.
 ;;
@@ -33,10 +34,12 @@
          ;; what it composes
          olai/web/skin
          ;; the skin's own vocabulary: the two classes named below, the token
-         ;; lists the theme tests fold over, and where a theme writes a value
+         ;; lists the theme tests fold over, and the themes themselves — their
+         ;; tables, their blocks, and which of them promise AA
          (only-in olai/web/theme
-                  ol-body ol-pill theme-names palette-tokens layout-tokens
-                  theme-token-property)
+                  ol-body ol-pill theme-names theme-default
+                  palette-tokens layout-tokens
+                  theme-entries theme-blocks aa-theme-names)
          ;; the renderers: what the skin is FOR, and the only honest answer to
          ;; "does anything wear this class"
          olai/web/render
@@ -333,49 +336,53 @@
 
   ;; ---- theme --------------------------------------------------------------
 
-  ;; A custom property, DECLARED: the name and whatever whitespace the
-  ;; serializer does or does not put around the colon.
-  (define (declares? css property)
-    (regexp-match? (regexp (string-append (regexp-quote property) "\\s*:")) css))
+  ;; A custom property, declared WITH ITS VALUE: the name, whatever whitespace
+  ;; the serializer puts around the colon, and what the table says it is.
+  ;; (--paper does not match --paper-2: the next character is a hyphen, not a
+  ;; colon.)
+  (define (declares? css property value)
+    (regexp-match? (regexp (string-append (regexp-quote (string-append "--" property))
+                                          "\\s*:\\s*" (regexp-quote value)))
+                   css))
 
-  ;; the skin's name for a token, pointed at one theme's value
-  (define (maps? css token property)
-    (regexp-match?
-     (regexp (string-append (regexp-quote (string-append "--" (symbol->string token)))
-                            "\\s*:\\s*var\\(\\s*" (regexp-quote property) "\\s*\\)"))
-     css))
+  ;; The block that puts ONE theme in force, as CSS. theme.rkt HANDS these
+  ;; over (theme-blocks) rather than leaving them to be found in the sheet by
+  ;; the selector they happen to be written with.
+  (define theme-css
+    (for/list ([entry (in-list (theme-blocks))])
+      (cons (car entry) (fragment->css (cdr entry)))))
 
-  ;; The block that puts ONE theme in force: found by the selector a page uses
-  ;; to ask for it, read as CSS. Scoping the mapping checks to it is what makes
-  ;; them a question about that theme rather than about the sheet — with five
-  ;; themes, "something somewhere maps --paper" is true no matter which one is
-  ;; broken.
-  (define (theme-block theme)
-    (define rx (regexp (string-append "data-theme\\s*=\\s*\"" theme "\"")))
-    (for/first ([f (in-list ordered-fragments)]
-                #:when (regexp-match? rx (fragment->css (cdr f))))
-      (fragment->css (cdr f))))
+  (define (theme-block theme) (cdr (assoc theme theme-css)))
+
+  (define (token-value theme token)
+    (format "~a" (cdr (assq token (theme-entries theme)))))
 
   ;; Generated from theme.rkt's own table: the tokens are its list and the
-  ;; property names are its spelling. A token added to the skin is checked in
-  ;; every theme the moment it is added, and a theme that forgets one fails
-  ;; here rather than resolving to nothing in a browser. Adding a THEME is the
-  ;; same: it is checked the moment it joins the table.
-  (test-case "every theme declares every token, and its own block maps them all"
+  ;; values are its values. A token added to the skin is checked in every theme
+  ;; the moment it is added, a theme that forgets one fails here rather than
+  ;; resolving to nothing in a browser, and a theme that carries someone else's
+  ;; color fails too. Adding a THEME is the same: it is checked the moment it
+  ;; joins the table.
+  (test-case "every theme's block carries that theme's own values, for every token"
     (define css (stylesheet))
     (check-true (pair? theme-names))
     (check-true (pair? palette-tokens))
+    (check-equal? (map car theme-css) theme-names)
     (for ([theme (in-list theme-names)])
-      (define block (or (theme-block theme) ""))
-      (check-true (non-empty-string? block)
+      (define block (theme-block theme))
+      (check-true (non-empty-string? block))
+      (check-true (string-contains? css block)
+                  (format "the ~a theme's block is not in the sheet" theme))
+      (check-true (regexp-match? (regexp (string-append "data-theme\\s*=\\s*\"" theme "\""))
+                                 block)
                   (format "no page can ask for the ~a theme" theme))
+      (check-equal? (map car (theme-entries theme)) palette-tokens
+                    (format "the ~a theme does not name the skin's tokens" theme))
       (for ([token (in-list palette-tokens)])
-        (define property (theme-token-property theme token))
-        (check-true (declares? css property)
-                    (format "the ~a theme declares no ~a" theme property))
-        (check-true (maps? block token property)
-                    (format "the ~a theme's block does not point --~a at ~a"
-                            theme token property)))))
+        (define value (token-value theme token))
+        (check-true (declares? block (symbol->string token) value)
+                    (format "the ~a theme's block does not say --~a: ~a"
+                            theme token value)))))
 
   ;; The browser paints the scrollbars, the form controls and the canvas, and
   ;; color-scheme is the only thing that tells it which way. A theme that put
@@ -383,7 +390,7 @@
   (test-case "every theme says which color-scheme it is"
     (for ([theme (in-list theme-names)])
       (check-true (regexp-match? #px"[^-]color-scheme\\s*:\\s*(light|dark)"
-                                 (or (theme-block theme) ""))
+                                 (theme-block theme))
                   (format "the ~a theme does not say which color-scheme it is"
                           theme))))
 
@@ -391,24 +398,74 @@
     (define css (stylesheet))
     (check-true (pair? layout-tokens))
     (for ([token (in-list layout-tokens)])
-      (define property (string-append "--" (symbol->string token)))
-      (check-true (declares? css property) (format "nothing declares ~a" property))))
+      (check-true (regexp-match?
+                   (regexp (string-append "--" (symbol->string token) "\\s*:"))
+                   css)
+                  (format "nothing declares --~a" token))))
 
-  (test-case "a page can name a theme, and the OS's preference is read"
-    (define css (stylesheet))
-    (check-true (regexp-match? #px"prefers-color-scheme\\s*:\\s*dark" css)
-                "no rule reads the OS's preference")
-    (for ([theme (in-list theme-names)])
-      (check-true (regexp-match? (regexp (string-append "data-theme\\s*=\\s*\"" theme "\"")) css)
-                  (format "no page can ask for the ~a theme" theme))))
+  ;; A page that picked nothing has no data-theme, so exactly one theme's block
+  ;; has to land on a bare :root as well — and it has to be the one everything
+  ;; else calls the default.
+  (test-case "one theme is what a page that picked nothing reads in"
+    (define bare
+      (for/list ([entry (in-list theme-css)]
+                 #:when (regexp-match? #px"(^|,):root[,{]" (cdr entry)))
+        (car entry)))
+    (check-equal? bare (list theme-default)
+                  "the sheet's bare :root is not the default theme's block"))
+
+  ;; A theme is a PICK. The sheet used to switch under you when the OS did,
+  ;; which meant two things could disagree about which dark you were in; now
+  ;; the page that picked nothing reads in the default, and nothing moves.
+  (test-case "the sheet asks the OS nothing about color"
+    (check-false (regexp-match? #px"prefers-color-scheme" (stylesheet))
+                 "a rule reads the OS's preference again"))
 
   ;; Two values, spelled out: the table in theme.rkt is the source, and this is
   ;; the spot check that says it reaches the sheet verbatim rather than through
   ;; some normalization. Same standing as the canary above.
   (test-case "canary: palette values reach the sheet verbatim (spot check)"
     (define css (stylesheet))
-    (check-true (string-contains? css "#E4ECCA") "light --paper")
+    (check-true (string-contains? css "#E4ECCA") "leaf --paper")
     (check-true (string-contains? css "#402028") "dark --rose-bg"))
+
+  ;; ---- contrast -----------------------------------------------------------
+  ;;
+  ;; A palette can say it clears WCAG AA (theme.rkt, #:aa?). That is a claim
+  ;; about pairs of its own values, so it is arithmetic, and this is the
+  ;; arithmetic: sRGB relative luminance, and the 4.5:1 line. Only the themes
+  ;; that make the claim are held to it.
+
+  (define (relative-luminance hex)
+    (define (channel i)
+      (define v (/ (string->number (substring hex i (+ i 2)) 16) 255.0))
+      (if (<= v 0.03928) (/ v 12.92) (expt (/ (+ v 0.055) 1.055) 2.4)))
+    (+ (* 0.2126 (channel 1)) (* 0.7152 (channel 3)) (* 0.0722 (channel 5))))
+
+  (define (contrast-ratio fg bg)
+    (define a (relative-luminance fg))
+    (define b (relative-luminance bg))
+    (/ (+ (max a b) 0.05) (+ (min a b) 0.05)))
+
+  ;; Every foreground the skin paints on a background, as pairs of tokens: the
+  ;; text colors on each of the three surfaces and on a pill, and each accent
+  ;; pill on its own ground.
+  (define contrast-pairs
+    '((ink paper) (ink paper-2) (ink panel) (ink pill-bg)
+      (dim paper) (dim paper-2) (dim panel) (dim pill-bg)
+      (green paper) (green paper-2) (green panel) (green pill-bg)
+      (amber-fg amber-bg) (blue-fg blue-bg) (rose-fg rose-bg)))
+
+  (test-case "a theme that promises AA keeps it, pair by pair"
+    (check-true (pair? aa-theme-names) "no theme claims AA any more")
+    (for* ([theme (in-list aa-theme-names)]
+           [pair (in-list contrast-pairs)])
+      (define ratio (contrast-ratio (token-value theme (car pair))
+                                    (token-value theme (cadr pair))))
+      (check-true (>= ratio 4.5)
+                  (format "~a: ~a on ~a is ~a:1, under AA"
+                          theme (car pair) (cadr pair)
+                          (real->decimal-string ratio 2)))))
 
   ;; ---- the class list -----------------------------------------------------
 

--- a/olai/tests/style.rkt
+++ b/olai/tests/style.rkt
@@ -427,7 +427,7 @@
   (test-case "canary: palette values reach the sheet verbatim (spot check)"
     (define css (stylesheet))
     (check-true (string-contains? css "#E4ECCA") "leaf --paper")
-    (check-true (string-contains? css "#402028") "dark --rose-bg"))
+    (check-true (string-contains? css "#773B3B") "dark --rose-bg"))
 
   ;; ---- contrast -----------------------------------------------------------
   ;;

--- a/olai/tests/style.rkt
+++ b/olai/tests/style.rkt
@@ -199,7 +199,7 @@
 ;; olai's own scripts plus the vendored sse extension. htmx itself is not in
 ;; the list: it spells no olai class, and scanning a minified bundle for
 ;; class-shaped names would find noise, not a border.
-(define script-names '("chat.js" "collapse.js" "sse.js"))
+(define script-names '("chat.js" "collapse.js" "prefs.js" "sse.js"))
 
 (define scripted-classes
   (for/fold ([acc (set)]) ([js (in-list script-names)])
@@ -345,21 +345,47 @@
                             "\\s*:\\s*var\\(\\s*" (regexp-quote property) "\\s*\\)"))
      css))
 
+  ;; The block that puts ONE theme in force: found by the selector a page uses
+  ;; to ask for it, read as CSS. Scoping the mapping checks to it is what makes
+  ;; them a question about that theme rather than about the sheet — with five
+  ;; themes, "something somewhere maps --paper" is true no matter which one is
+  ;; broken.
+  (define (theme-block theme)
+    (define rx (regexp (string-append "data-theme\\s*=\\s*\"" theme "\"")))
+    (for/first ([f (in-list ordered-fragments)]
+                #:when (regexp-match? rx (fragment->css (cdr f))))
+      (fragment->css (cdr f))))
+
   ;; Generated from theme.rkt's own table: the tokens are its list and the
   ;; property names are its spelling. A token added to the skin is checked in
   ;; every theme the moment it is added, and a theme that forgets one fails
-  ;; here rather than resolving to nothing in a browser.
-  (test-case "every theme declares every token, and every theme maps them all"
+  ;; here rather than resolving to nothing in a browser. Adding a THEME is the
+  ;; same: it is checked the moment it joins the table.
+  (test-case "every theme declares every token, and its own block maps them all"
     (define css (stylesheet))
     (check-true (pair? theme-names))
     (check-true (pair? palette-tokens))
-    (for* ([theme (in-list theme-names)]
-           [token (in-list palette-tokens)])
-      (define property (theme-token-property theme token))
-      (check-true (declares? css property)
-                  (format "the ~a theme declares no ~a" theme property))
-      (check-true (maps? css token property)
-                  (format "nothing points --~a at ~a" token property))))
+    (for ([theme (in-list theme-names)])
+      (define block (or (theme-block theme) ""))
+      (check-true (non-empty-string? block)
+                  (format "no page can ask for the ~a theme" theme))
+      (for ([token (in-list palette-tokens)])
+        (define property (theme-token-property theme token))
+        (check-true (declares? css property)
+                    (format "the ~a theme declares no ~a" theme property))
+        (check-true (maps? block token property)
+                    (format "the ~a theme's block does not point --~a at ~a"
+                            theme token property)))))
+
+  ;; The browser paints the scrollbars, the form controls and the canvas, and
+  ;; color-scheme is the only thing that tells it which way. A theme that put
+  ;; its colors in force and not this would read dark under light chrome.
+  (test-case "every theme says which color-scheme it is"
+    (for ([theme (in-list theme-names)])
+      (check-true (regexp-match? #px"[^-]color-scheme\\s*:\\s*(light|dark)"
+                                 (or (theme-block theme) ""))
+                  (format "the ~a theme does not say which color-scheme it is"
+                          theme))))
 
   (test-case "the layout vocabulary is declared, and does not vary by theme"
     (define css (stylesheet))

--- a/olai/web/prefs.rkt
+++ b/olai/web/prefs.rkt
@@ -1,0 +1,151 @@
+#lang racket/base
+
+;; Client prefs: the picker in the sidebar, and the script that restores it.
+;;
+;; The page is a VIEW, and what it looks like to YOU is CLIENT state: stored in
+;; this browser, never sent anywhere, exactly like the collapse state. The theme
+;; is the first one; density and type size are the obvious next ones, and they
+;; are meant to be rows here rather than a second mechanism.
+;;
+;; A pref is a NAME, a LABEL, the values it may take and the one that is in
+;; force when nothing is stored. The name is two things at once — a data
+;; attribute on <html> (data-theme) and the tail of the localStorage key
+;; (olai.theme) — which is what lets one script drive every row and one boot
+;; script restore them all (static/prefs.js, and prefs-boot-js below). The label
+;; is what a person reads; a name is for machines, and the day the two want to
+;; differ they can.
+;;
+;; Nothing stored is not a value of its own: it is the DEFAULT, which the sheet
+;; already draws (web/theme, the bare :root) and the row carries so the picker
+;; can light that chip. Every chip is a theme, and picking one is picking it —
+;; there is no OS to defer to and nothing to switch under you.
+
+(require racket/contract
+         racket/string
+         (only-in json jsexpr->string)
+         olai/web/style
+         (only-in olai/web/theme
+                  theme-attribute theme-names theme-default
+                  paper-2 pill-bg line ink dim green mono micro-size))
+
+(provide (contract-out
+          ;; the picker, for the sidebar to place. `list?` and not `xexpr?`:
+          ;; the shape check is the renderer's business (see web/render)
+          [prefs-xexpr (-> list?)]
+          ;; the <head> script that puts stored prefs on <html> before the
+          ;; first paint. A string of JS, generated from the list below
+          [prefs-boot-js (-> string?)]))
+
+;; ---- what a pref is -------------------------------------------------------
+
+(struct pref (name label values default) #:transparent)
+
+;; The key this browser stores a pref under. Spelled ONCE, here: the boot
+;; script is handed the finished key and the row carries it in an attribute, so
+;; neither .js has to know how one is built.
+(define (pref-storage-key p) (string-append "olai." (pref-name p)))
+
+;; The name is the tail of the attribute the sheet keys off — data-theme is
+;; the theme pref — so there is one string, and it is web/theme's.
+(define (attribute->pref-name attribute)
+  (unless (string-prefix? attribute "data-")
+    (error 'prefs "~a is not a data- attribute; a pref name is its tail" attribute))
+  (substring attribute (string-length "data-")))
+
+(define client-prefs
+  (list (pref (attribute->pref-name theme-attribute) "theme"
+              theme-names theme-default)))
+
+;; A pref name lands in three places that will not all complain: an attribute
+;; name ('data-'+name), a storage key, and a CSS selector. Anything outside
+;; this grammar breaks one of them quietly. And a default that is not one of
+;; the values is a row where nothing is ever lit.
+(for ([p (in-list client-prefs)])
+  (unless (regexp-match? #px"^[a-z][a-z0-9-]*$" (pref-name p))
+    (error 'prefs "~s is not a pref name: [a-z][a-z0-9-]*" (pref-name p)))
+  (when (null? (pref-values p))
+    (error 'prefs "the ~a pref offers no values" (pref-name p)))
+  (unless (member (pref-default p) (pref-values p))
+    (error 'prefs "the ~a pref defaults to ~s, which it does not offer"
+           (pref-name p) (pref-default p))))
+
+;; ---- the boot script ------------------------------------------------------
+
+;; INLINE-NESS IS LOAD-BEARING. A pref stored in this browser has to be on
+;; <html> before the first paint; every /static/ script is deferred, so it
+;; would land after it, which is a flash of the wrong colors on every load.
+;; This much runs in <head>, and nothing else does: the rows, and everything
+;; that happens after a click, are static/prefs.js.
+;;
+;; It writes with setAttribute, not dataset[name]: a hyphenated pref name is
+;; not a dataset key, and the setter throws rather than working.
+;;
+;; A future Content-Security-Policy has to hand this script a nonce (or hash
+;; it); there is no file to point script-src at.
+;;
+;; The pairs are generated from client-prefs, and each is [name, storage-key] —
+;; the key is built in Racket (pref-storage-key) so no .js spells 'olai.'.
+;; Written by the json library, which is what escapes them.
+(define (prefs-boot-js)
+  (string-append
+   "try{"
+   (jsexpr->string (for/list ([p (in-list client-prefs)])
+                     (list (pref-name p) (pref-storage-key p))))
+   ".forEach(function(p){"
+   "var v=localStorage.getItem(p[1]);"
+   "if(v)document.documentElement.setAttribute('data-'+p[0],v)})}catch(e){}"))
+
+;; ---- the picker -----------------------------------------------------------
+
+;; which value a row is in. Only the browser knows — the server draws the same
+;; rows for everyone — so prefs.js is what marks it.
+(define-modifier is-on)
+
+(define-component (pref-opt-xexpr value)
+  #:class ol-pref-opt
+  #:css (#:padding (0.0625rem 0.375rem)
+         #:border (1px solid ,line)
+         #:border-radius 9999px
+         #:background ,paper-2
+         #:color ,dim
+         #:font-family ,mono
+         #:font-size ,micro-size
+         #:cursor pointer
+         [(: & hover) #:color ,ink #:border-color ,dim]
+         ;; the one in force
+         [,(sel '& is-on) #:background ,pill-bg #:color ,green #:border-color ,green])
+  `(button ((type "button") (class ,ol-pref-opt) (data-value ,value)
+            (aria-pressed "false"))
+           ,value))
+
+(define-style ol-pref-opts #:display flex #:flex-wrap wrap #:gap 0.25rem)
+
+(define-style ol-pref-label
+  #:font-family ,mono
+  #:font-size ,micro-size
+  #:color ,dim)
+
+;; One row: what it is called, and every value it takes. `data-pref` is the
+;; name, `data-store-key` is where this browser keeps it, `data-default` is
+;; what is in force until it keeps anything — the script reads all three rather
+;; than knowing a class per pref, how a key is spelled, or which theme the
+;; sheet falls back to, which is what makes the second row cost nothing.
+(define-component (pref-row-xexpr p)
+  #:class ol-pref
+  #:css (#:display flex #:flex-direction column #:gap 0.25rem)
+  `(div ((class ,ol-pref)
+         (data-pref ,(pref-name p))
+         (data-store-key ,(pref-storage-key p))
+         (data-default ,(pref-default p)))
+        (div ((class ,ol-pref-label)) ,(pref-label p))
+        (div ((class ,ol-pref-opts))
+             ,@(for/list ([v (in-list (pref-values p))]) (pref-opt-xexpr v)))))
+
+(define-component (prefs-xexpr)
+  #:class ol-prefs
+  #:css (#:display flex
+         #:flex-direction column
+         #:gap 0.625rem
+         #:margin-left 0.5rem)
+  `(div ((class ,ol-prefs))
+        ,@(for/list ([p (in-list client-prefs)]) (pref-row-xexpr p))))

--- a/olai/web/render.rkt
+++ b/olai/web/render.rkt
@@ -17,11 +17,12 @@
 ;; re-key a permalink, a stored collapse state, or an SSE swap target.
 ;;
 ;; STYLES — every class this module draws is DEFINED here, next to the markup
-;; that wears it (olai/web/style). Two exceptions, both of them classes this
-;; module is not the only one to draw: .ol-pill's shape is the skin's
-;; (olai/web/theme), and the markdown classes are web/markdown's, which is what
-;; puts them on the markup. The chat panel is an overlay on all of this, so it
-;; requires this module, which is what puts its rules last in the cascade.
+;; that wears it (olai/web/style). The exceptions are classes this module does
+;; not own the markup of: .ol-pill's shape is the skin's (olai/web/theme), the
+;; markdown classes are web/markdown's, and the prefs picker is web/prefs' — the
+;; sidebar only places the block it hands back. The chat panel is an overlay on
+;; all of this, so it requires this module, which is what puts its rules last in
+;; the cascade.
 
 (require racket/contract
          racket/list
@@ -40,7 +41,11 @@
          ;; anything that leans on them (see style.rkt on ordering)
          olai/web/theme
          olai/web/style
-         olai/web/markdown)
+         olai/web/markdown
+         ;; the sidebar's picker and the boot script that restores what it
+         ;; picked. Last of the requires, so its rules land after the skin's
+         ;; and before this module's own; nothing else paints .ol-pref*
+         olai/web/prefs)
 
 ;; Contracts on the drawing surface check the INPUT shape — a task, a
 ;; files-data list, an ISO `today` string — and say only `list?` about the
@@ -76,9 +81,9 @@
            (->* (any/c)
                 (#:title string?
                  #:stylesheet-href (or/c string? #f)
-                 ;; a theme by name (web/theme's theme-names), or #f for "let
-                 ;; the OS and the browser decide"
-                 #:theme (or/c string? #f)
+                 ;; what the browser should assume before the sheet lands
+                 ;; (web/theme's theme-color-scheme), or #f for no such meta
+                 #:color-scheme (or/c string? #f)
                  #:sidebar (or/c list? #f)
                  #:banner (or/c list? #f)
                  #:sse-connect (or/c string? #f)
@@ -110,11 +115,12 @@
 ;; ---- static assets --------------------------------------------------------
 ;;
 ;; One owner for the whole /static/ surface: the directory the server mounts,
-;; the URL prefix it mounts it at, and the files the page pulls in. Almost no JS
-;; lives in this module — a script that changes with every SSE tweak has no
-;; business recompiling a Racket module, and browsers cannot cache it. The one
-;; exception is below, and it is one line: it has to run before the first paint,
-;; which is the one thing a cacheable deferred file cannot do.
+;; the URL prefix it mounts it at, and the files the page pulls in. NO JS lives
+;; in this module — a script that changes with every SSE tweak has no business
+;; recompiling a Racket module, and browsers cannot cache it. The one script the
+;; page carries inline is web/prefs' (it has to run before the first paint,
+;; which is the one thing a cacheable deferred file cannot do), and it is that
+;; module's, not this one's.
 ;;
 ;; The stylesheet is the other way round: it is NOT a file. It is generated
 ;; from the modules that draw the page (olai/web/skin), and this module cannot
@@ -127,23 +133,6 @@
 (define web-static-prefix "/static/")
 
 (define web-scripts '("htmx.min.js" "sse.js" "collapse.js" "prefs.js" "chat.js"))
-
-;; The ONE inline script in the page, and it is here for a reason a file cannot
-;; solve: a pref stored in this browser has to be on <html> before the first
-;; paint, and every script above is deferred — it would land after it, which is
-;; a flash of the wrong colors on every load. So this much runs in <head>, and
-;; nothing else does: the rows, and everything that happens after a click, are
-;; static/prefs.js.
-;;
-;; The key convention (olai.<pref>) is spelled there too. It is one string on
-;; both sides of a border the compiler does not cross (like a class name in a
-;; .js), and tests/render.rkt is what holds the two together. WHICH prefs there
-;; are is not: that list is below, and this is generated from it.
-(define (prefs-boot-js)
-  (string-append
-   "try{" (client-pref-names-js) ".forEach(function(p){"
-   "var v=localStorage.getItem('olai.'+p);"
-   "if(v)document.documentElement.dataset[p]=v})}catch(e){}"))
 
 (define (static-href name) (string-append web-static-prefix name))
 
@@ -766,88 +755,6 @@
    [(: & hover) #:background ,pill-bg]]
   [(> ,(sel ol-node is-tree) ,(sel ol-row) ,(sel ol-toggle)) #:height 1.25rem]))
 
-;; ---- preferences ----------------------------------------------------------
-;;
-;; The page is a VIEW, and what it looks like to YOU is CLIENT state: stored in
-;; this browser, never sent anywhere, exactly like the collapse state. The
-;; theme is the first one; density and type size are the obvious next ones, and
-;; they are meant to be rows here rather than a second mechanism.
-;;
-;; A pref is a NAME and the values it may take. The name is two things at once
-;; — a data attribute on <html> (data-theme) and the tail of a localStorage key
-;; (olai.theme) — which is what lets one script drive every row and one boot
-;; script restore them all (static/prefs.js, and the head script above).
-;;
-;; "auto" is not a value: it is the absence of one, which is why it is
-;; prepended rather than written into any list. Nothing is stored, no attribute
-;; is set, and the sheet's own default — the OS's preference, for the theme —
-;; is what decides.
-
-(struct pref (name values) #:transparent)
-
-(define pref-auto "auto")
-
-(define client-prefs (list (pref "theme" theme-names)))
-
-;; the pref names the boot script restores, as a JS array literal. Generated
-;; from the list above: a row nobody restored would be a pref that forgets
-;; itself on reload.
-(define (client-pref-names-js)
-  (string-append
-   "[" (string-join (for/list ([p (in-list client-prefs)])
-                      (string-append "'" (pref-name p) "'"))
-                    ",")
-   "]"))
-
-;; which value a row is in. Only the browser knows — the server draws the same
-;; rows for everyone — so prefs.js is what marks it.
-(define-modifier is-on)
-
-(define-component (pref-opt-xexpr value)
-  #:class ol-pref-opt
-  #:css (#:padding (0.0625rem 0.375rem)
-         #:border (1px solid ,line)
-         #:border-radius 9999px
-         #:background ,paper-2
-         #:color ,dim
-         #:font-family ,mono
-         #:font-size ,micro-size
-         #:cursor pointer
-         [(: & hover) #:color ,ink #:border-color ,dim]
-         ;; the one in force
-         [,(sel '& is-on) #:background ,pill-bg #:color ,green #:border-color ,green])
-  `(button ((type "button") (class ,ol-pref-opt) (data-value ,value)
-            (aria-pressed "false"))
-           ,value))
-
-(define-style ol-pref-opts #:display flex #:flex-wrap wrap #:gap 0.25rem)
-
-(define-style ol-pref-label
-  #:font-family ,mono
-  #:font-size ,micro-size
-  #:color ,dim)
-
-;; One row: what it is called, and every value it takes. `data-pref` is the
-;; name — the script reads it rather than knowing a class per pref, which is
-;; what makes the second row cost nothing.
-(define-component (pref-row-xexpr p)
-  #:class ol-pref
-  #:css (#:display flex #:flex-direction column #:gap 0.25rem)
-  `(div ((class ,ol-pref) (data-pref ,(pref-name p)))
-        (div ((class ,ol-pref-label)) ,(pref-name p))
-        (div ((class ,ol-pref-opts))
-             ,@(for/list ([v (in-list (cons pref-auto (pref-values p)))])
-                 (pref-opt-xexpr v)))))
-
-(define-component (prefs-xexpr)
-  #:class ol-prefs
-  #:css (#:display flex
-         #:flex-direction column
-         #:gap 0.625rem
-         #:margin-left 0.5rem)
-  `(div ((class ,ol-prefs))
-        ,@(for/list ([p (in-list client-prefs)]) (pref-row-xexpr p))))
-
 (define-style ol-tree-link
   #:flex (1 1 auto)
   #:min-width 0
@@ -996,27 +903,28 @@
                      ;; olai/web/skin). #f is a page with no skin at all — a
                      ;; fragment test, never a served page.
                      #:stylesheet-href [stylesheet-href #f]
-                     ;; A theme this page is SERVED in, named out loud. #f is
-                     ;; the normal case and means nobody has decided: the OS's
-                     ;; preference picks, and the browser's own choice (stored
-                     ;; by the picker) is stamped on by the boot script below.
-                     #:theme [theme #f]
+                     ;; What the browser should assume BEFORE the sheet lands.
+                     ;; The palettes decide it (web/theme, theme-color-scheme)
+                     ;; and the route layer passes it, like every other fact
+                     ;; this renderer is told rather than knows. Once the sheet
+                     ;; is in, each theme says which one it is and that wins.
+                     #:color-scheme [color-scheme #f]
                      #:sidebar [sidebar #f]
                      #:banner [banner #f]
                      #:sse-connect [sse-connect #f]
                      #:live-href [live-href #f]
                      #:head-extra [head-extra '()]
                      #:body-extra [body-extra '()])
-  `(html ((lang "en") ,@(if theme `((data-theme ,theme)) '()))
+  ;; No data-theme here: which theme you read in is the BROWSER's, and the boot
+  ;; script below is the only thing that writes it.
+  `(html ((lang "en"))
          (head
           (meta ((charset "utf-8")))
           (meta ((name "viewport")
                  (content "width=device-width, initial-scale=1, viewport-fit=cover")))
-          ;; What the browser should assume BEFORE the sheet lands, which is
-          ;; both, because a page that names no theme follows the OS. Once the
-          ;; sheet is in, every theme says which one it is (color-scheme in
-          ;; web/theme) and that is what wins.
-          (meta ((name "color-scheme") (content "light dark")))
+          ,@(if color-scheme
+                (list `(meta ((name "color-scheme") (content ,color-scheme))))
+                '())
           (title ,title)
           ;; before the sheet: it is the first paint this is racing
           (script () ,(cdata #f #f (prefs-boot-js)))

--- a/olai/web/render.rkt
+++ b/olai/web/render.rkt
@@ -28,6 +28,7 @@
          racket/match
          racket/path
          racket/runtime-path
+         racket/string
          (only-in xml cdata xexpr->string)
          (except-in olai/lang/expander #%module-begin)
          ;; the resolved shape of a mirror site (core owns the binding)
@@ -75,6 +76,9 @@
            (->* (any/c)
                 (#:title string?
                  #:stylesheet-href (or/c string? #f)
+                 ;; a theme by name (web/theme's theme-names), or #f for "let
+                 ;; the OS and the browser decide"
+                 #:theme (or/c string? #f)
                  #:sidebar (or/c list? #f)
                  #:banner (or/c list? #f)
                  #:sse-connect (or/c string? #f)
@@ -106,9 +110,11 @@
 ;; ---- static assets --------------------------------------------------------
 ;;
 ;; One owner for the whole /static/ surface: the directory the server mounts,
-;; the URL prefix it mounts it at, and the files the page pulls in. No JS lives
-;; in this module — a script that changes with every SSE tweak has no business
-;; recompiling a Racket module, and browsers cannot cache it.
+;; the URL prefix it mounts it at, and the files the page pulls in. Almost no JS
+;; lives in this module — a script that changes with every SSE tweak has no
+;; business recompiling a Racket module, and browsers cannot cache it. The one
+;; exception is below, and it is one line: it has to run before the first paint,
+;; which is the one thing a cacheable deferred file cannot do.
 ;;
 ;; The stylesheet is the other way round: it is NOT a file. It is generated
 ;; from the modules that draw the page (olai/web/skin), and this module cannot
@@ -120,7 +126,24 @@
 
 (define web-static-prefix "/static/")
 
-(define web-scripts '("htmx.min.js" "sse.js" "collapse.js" "chat.js"))
+(define web-scripts '("htmx.min.js" "sse.js" "collapse.js" "prefs.js" "chat.js"))
+
+;; The ONE inline script in the page, and it is here for a reason a file cannot
+;; solve: a pref stored in this browser has to be on <html> before the first
+;; paint, and every script above is deferred — it would land after it, which is
+;; a flash of the wrong colors on every load. So this much runs in <head>, and
+;; nothing else does: the rows, and everything that happens after a click, are
+;; static/prefs.js.
+;;
+;; The key convention (olai.<pref>) is spelled there too. It is one string on
+;; both sides of a border the compiler does not cross (like a class name in a
+;; .js), and tests/render.rkt is what holds the two together. WHICH prefs there
+;; are is not: that list is below, and this is generated from it.
+(define (prefs-boot-js)
+  (string-append
+   "try{" (client-pref-names-js) ".forEach(function(p){"
+   "var v=localStorage.getItem('olai.'+p);"
+   "if(v)document.documentElement.dataset[p]=v})}catch(e){}"))
 
 (define (static-href name) (string-append web-static-prefix name))
 
@@ -743,6 +766,88 @@
    [(: & hover) #:background ,pill-bg]]
   [(> ,(sel ol-node is-tree) ,(sel ol-row) ,(sel ol-toggle)) #:height 1.25rem]))
 
+;; ---- preferences ----------------------------------------------------------
+;;
+;; The page is a VIEW, and what it looks like to YOU is CLIENT state: stored in
+;; this browser, never sent anywhere, exactly like the collapse state. The
+;; theme is the first one; density and type size are the obvious next ones, and
+;; they are meant to be rows here rather than a second mechanism.
+;;
+;; A pref is a NAME and the values it may take. The name is two things at once
+;; — a data attribute on <html> (data-theme) and the tail of a localStorage key
+;; (olai.theme) — which is what lets one script drive every row and one boot
+;; script restore them all (static/prefs.js, and the head script above).
+;;
+;; "auto" is not a value: it is the absence of one, which is why it is
+;; prepended rather than written into any list. Nothing is stored, no attribute
+;; is set, and the sheet's own default — the OS's preference, for the theme —
+;; is what decides.
+
+(struct pref (name values) #:transparent)
+
+(define pref-auto "auto")
+
+(define client-prefs (list (pref "theme" theme-names)))
+
+;; the pref names the boot script restores, as a JS array literal. Generated
+;; from the list above: a row nobody restored would be a pref that forgets
+;; itself on reload.
+(define (client-pref-names-js)
+  (string-append
+   "[" (string-join (for/list ([p (in-list client-prefs)])
+                      (string-append "'" (pref-name p) "'"))
+                    ",")
+   "]"))
+
+;; which value a row is in. Only the browser knows — the server draws the same
+;; rows for everyone — so prefs.js is what marks it.
+(define-modifier is-on)
+
+(define-component (pref-opt-xexpr value)
+  #:class ol-pref-opt
+  #:css (#:padding (0.0625rem 0.375rem)
+         #:border (1px solid ,line)
+         #:border-radius 9999px
+         #:background ,paper-2
+         #:color ,dim
+         #:font-family ,mono
+         #:font-size ,micro-size
+         #:cursor pointer
+         [(: & hover) #:color ,ink #:border-color ,dim]
+         ;; the one in force
+         [,(sel '& is-on) #:background ,pill-bg #:color ,green #:border-color ,green])
+  `(button ((type "button") (class ,ol-pref-opt) (data-value ,value)
+            (aria-pressed "false"))
+           ,value))
+
+(define-style ol-pref-opts #:display flex #:flex-wrap wrap #:gap 0.25rem)
+
+(define-style ol-pref-label
+  #:font-family ,mono
+  #:font-size ,micro-size
+  #:color ,dim)
+
+;; One row: what it is called, and every value it takes. `data-pref` is the
+;; name — the script reads it rather than knowing a class per pref, which is
+;; what makes the second row cost nothing.
+(define-component (pref-row-xexpr p)
+  #:class ol-pref
+  #:css (#:display flex #:flex-direction column #:gap 0.25rem)
+  `(div ((class ,ol-pref) (data-pref ,(pref-name p)))
+        (div ((class ,ol-pref-label)) ,(pref-name p))
+        (div ((class ,ol-pref-opts))
+             ,@(for/list ([v (in-list (cons pref-auto (pref-values p)))])
+                 (pref-opt-xexpr v)))))
+
+(define-component (prefs-xexpr)
+  #:class ol-prefs
+  #:css (#:display flex
+         #:flex-direction column
+         #:gap 0.625rem
+         #:margin-left 0.5rem)
+  `(div ((class ,ol-prefs))
+        ,@(for/list ([p (in-list client-prefs)]) (pref-row-xexpr p))))
+
 (define-style ol-tree-link
   #:flex (1 1 auto)
   #:min-width 0
@@ -794,6 +899,13 @@
           (section ((class ,ol-sidebar-section))
                    (h3 ((class ,ol-sidebar-heading)) "Starred")
                    (p ((class ,ol-sidebar-empty)) "Nothing starred yet"))
+          ;; above the tree, not below it: the tree is the one section here
+          ;; whose length is the outline's, and a control under it would be a
+          ;; scroll away on a big one. A section, like Starred and Home — a
+          ;; disclosure would be new machinery for three lines of chrome.
+          (section ((class ,ol-sidebar-section))
+                   (h3 ((class ,ol-sidebar-heading)) "Prefs")
+                   ,(prefs-xexpr))
           (section ((class ,ol-sidebar-section))
                    (h3 ((class ,ol-sidebar-heading)) "Home")
                    ,@(for/list ([e (in-list entries)])
@@ -884,19 +996,30 @@
                      ;; olai/web/skin). #f is a page with no skin at all — a
                      ;; fragment test, never a served page.
                      #:stylesheet-href [stylesheet-href #f]
+                     ;; A theme this page is SERVED in, named out loud. #f is
+                     ;; the normal case and means nobody has decided: the OS's
+                     ;; preference picks, and the browser's own choice (stored
+                     ;; by the picker) is stamped on by the boot script below.
+                     #:theme [theme #f]
                      #:sidebar [sidebar #f]
                      #:banner [banner #f]
                      #:sse-connect [sse-connect #f]
                      #:live-href [live-href #f]
                      #:head-extra [head-extra '()]
                      #:body-extra [body-extra '()])
-  `(html ((lang "en"))
+  `(html ((lang "en") ,@(if theme `((data-theme ,theme)) '()))
          (head
           (meta ((charset "utf-8")))
           (meta ((name "viewport")
                  (content "width=device-width, initial-scale=1, viewport-fit=cover")))
+          ;; What the browser should assume BEFORE the sheet lands, which is
+          ;; both, because a page that names no theme follows the OS. Once the
+          ;; sheet is in, every theme says which one it is (color-scheme in
+          ;; web/theme) and that is what wins.
           (meta ((name "color-scheme") (content "light dark")))
           (title ,title)
+          ;; before the sheet: it is the first paint this is racing
+          (script () ,(cdata #f #f (prefs-boot-js)))
           ,@(if stylesheet-href
                 (list `(link ((rel "stylesheet") (href ,stylesheet-href))))
                 '())

--- a/olai/web/serve.rkt
+++ b/olai/web/serve.rkt
@@ -63,6 +63,9 @@
          olai/web/events
          ;; the sheet and its URL; which modules it is made of is skin's
          olai/web/skin
+         ;; the one fact about the palettes a page carries before the sheet
+         ;; lands, from the module that owns them
+         (only-in olai/web/theme theme-color-scheme)
          olai/web/render
          (only-in olai/web/chat-panel render-chat-panel)
          olai/web/watch)
@@ -155,6 +158,7 @@
     (render-page (render-empty-pane "No outline loaded." #:home-href home-href)
                  #:title "olai"
                  #:stylesheet-href stylesheet-href
+                 #:color-scheme theme-color-scheme
                  #:banner (error-banner err)
                  #:sse-connect events-href
                  #:live-href live-href
@@ -292,6 +296,7 @@
     (render-page main
                  #:title title
                  #:stylesheet-href stylesheet-href
+                 #:color-scheme theme-color-scheme
                  #:sidebar (render-sidebar files-data
                                            #:home-href home-href
                                            #:today-href today-href

--- a/olai/web/static/collapse.js
+++ b/olai/web/static/collapse.js
@@ -22,7 +22,9 @@
     var c=!n.classList.contains('is-collapsed');
     state[n.dataset.collapseKey]=c;
     set(n,c);
-    localStorage.setItem(KEY,JSON.stringify(state));
+    // same guard as the read above: storage can be full or forbidden, and a
+    // fold that threw would leave the click half-done
+    try{localStorage.setItem(KEY,JSON.stringify(state))}catch(e){}
   });
   // An outerHTML swap replaces the element the event would name, so re-apply
   // over the whole document rather than over e.target: a live re-render must

--- a/olai/web/static/prefs.js
+++ b/olai/web/static/prefs.js
@@ -1,0 +1,30 @@
+// Client prefs: one value per pref, as a data attribute on <html>
+// (data-theme, ...), persisted in this browser under olai.<pref>. Nothing goes
+// to the server — same as the collapse state. The <head> boot script
+// (olai/web/render) restores them before the first paint; from there the
+// element IS the state. A row carries its name in data-pref, so a second pref
+// is a second row and no change here.
+(function(){
+  var AUTO='auto',root=document.documentElement;
+  function mark(){
+    document.querySelectorAll('.ol-pref').forEach(function(row){
+      var v=root.dataset[row.dataset.pref]||AUTO;
+      row.querySelectorAll('.ol-pref-opt').forEach(function(b){
+        var on=b.dataset.value===v;
+        b.classList.toggle('is-on',on);
+        b.setAttribute('aria-pressed',on?'true':'false');
+      });
+    });
+  }
+  document.addEventListener('click',function(e){
+    var b=e.target.closest('.ol-pref-opt');if(!b)return;
+    var row=b.closest('.ol-pref');if(!row)return;
+    e.preventDefault();
+    var p=row.dataset.pref,v=b.dataset.value;
+    if(v===AUTO)delete root.dataset[p];else root.dataset[p]=v;
+    try{v===AUTO?localStorage.removeItem('olai.'+p):localStorage.setItem('olai.'+p,v)}
+    catch(e){}
+    mark();
+  });
+  mark();
+})();

--- a/olai/web/static/prefs.js
+++ b/olai/web/static/prefs.js
@@ -1,18 +1,27 @@
 // Client prefs: one value per pref, as a data attribute on <html>
-// (data-theme, ...), persisted in this browser under olai.<pref>. Nothing goes
-// to the server — same as the collapse state. The <head> boot script
-// (olai/web/render) restores them before the first paint; from there the
-// element IS the state. A row carries its name in data-pref, so a second pref
-// is a second row and no change here.
+// (data-theme, ...), stored in this browser under the row's data-store-key —
+// olai/web/prefs spells that key, here and in the boot script, so no .js
+// builds one. Never sent to the server, same as the collapse state: the boot
+// script restores it before the first paint, and the element IS the state.
+// Nothing stored is the row's data-default — the theme the sheet draws bare.
 (function(){
-  var AUTO='auto',root=document.documentElement;
+  // setAttribute, not dataset[name]: a hyphenated pref name is not a dataset
+  // key, and the setter throws rather than working.
+  var root=document.documentElement;function attr(p){return 'data-'+p}
+  function store(row,v){var k=row.dataset.storeKey;
+    try{v===null?localStorage.removeItem(k):localStorage.setItem(k,v)}catch(e){}}
   function mark(){
     document.querySelectorAll('.ol-pref').forEach(function(row){
-      var v=root.dataset[row.dataset.pref]||AUTO;
-      row.querySelectorAll('.ol-pref-opt').forEach(function(b){
-        var on=b.dataset.value===v;
-        b.classList.toggle('is-on',on);
-        b.setAttribute('aria-pressed',on?'true':'false');
+      var p=row.dataset.pref,v=root.getAttribute(attr(p)),
+          opts=row.querySelectorAll('.ol-pref-opt'),known=false;
+      opts.forEach(function(b){if(b.dataset.value===v)known=true});
+      // a value no chip offers (theme renamed, theme dropped): forget it
+      if(v!==null&&!known){root.removeAttribute(attr(p));store(row,null);v=null}
+      var on=v===null?row.dataset.default:v;
+      opts.forEach(function(b){
+        var lit=b.dataset.value===on;
+        b.classList.toggle('is-on',lit);
+        b.setAttribute('aria-pressed',lit?'true':'false');
       });
     });
   }
@@ -20,11 +29,11 @@
     var b=e.target.closest('.ol-pref-opt');if(!b)return;
     var row=b.closest('.ol-pref');if(!row)return;
     e.preventDefault();
-    var p=row.dataset.pref,v=b.dataset.value;
-    if(v===AUTO)delete root.dataset[p];else root.dataset[p]=v;
-    try{v===AUTO?localStorage.removeItem('olai.'+p):localStorage.setItem('olai.'+p,v)}
-    catch(e){}
-    mark();
+    // a chip is a theme: picking one picks it, and there is nothing else to be
+    var v=b.dataset.value;root.setAttribute(attr(row.dataset.pref),v);
+    store(row,v);mark();
   });
+  // an outerHTML swap replaces the rows: re-mark over the whole document
+  document.addEventListener('htmx:afterSwap',function(){mark()});
   mark();
 })();

--- a/olai/web/theme.rkt
+++ b/olai/web/theme.rkt
@@ -135,21 +135,6 @@
                    (blue-bg   . |#D8E8EF|)
                    (rose-fg   . |#A84A5E|)
                    (rose-bg   . |#F5DBDF|)))
-   (make-palette "dark" #:scheme 'dark
-                 '((paper     . |#1E2417|)
-                   (paper-2   . |#252D1D|)
-                   (panel     . |#272F1E|)
-                   (ink       . |#DBE7C9|)
-                   (dim       . |#8FA077|)
-                   (line      . |#33402A|)
-                   (pill-bg   . |#2A3320|)
-                   (green     . |#8FD08A|)
-                   (amber-fg  . |#E6B366|)
-                   (amber-bg  . |#3D310F|)
-                   (blue-fg   . |#7DB8D8|)
-                   (blue-bg   . |#1D3340|)
-                   (rose-fg   . |#E396A5|)
-                   (rose-bg   . |#402028|)))
    ;; aged palm leaf, iron-gall ink: the outline as a manuscript. Warm paper,
    ;; brown-black ink, and accents pulled back to what a dye would give.
    (make-palette "manuscript" #:scheme 'light
@@ -201,7 +186,236 @@
                    (blue-fg   . |#6FAECE|)
                    (blue-bg   . |#122633|)
                    (rose-fg   . |#D68B9A|)
-                   (rose-bg   . |#301820|)))))
+                   (rose-bg   . |#301820|)))
+
+   ;; ---- imported palettes --------------------------------------------------
+   ;;
+   ;; The rows below are the WorkFlowy desktop themes' COLOR VALUES, read off
+   ;; the palettes their app ships and written here as olai rows. Nothing else
+   ;; came across: WorkFlowy paints a different app, and none of its rules,
+   ;; names or markup are ours to keep. A hex is a fact about a color.
+   ;;
+   ;; ONE rule maps their vocabulary onto ours, and every row below follows it
+   ;; unless it is named as an exception in that row's own comment:
+   ;;
+   ;;   paper     <- background-primary     the page itself
+   ;;   paper-2   <- background-secondary   one step along the paper ramp
+   ;;   panel     <- background-tertiary    the third surface (chat panel)
+   ;;   ink       <- text-primary
+   ;;   dim       <- text-tertiary          their muted body text
+   ;;   line      <- border-primary
+   ;;   pill-bg   <- background-selected    (= background-info in every theme)
+   ;;   green     <- text-green             the checkmark, the focus ring
+   ;;   amber-fg  <- text-yellow            #tag
+   ;;   amber-bg  <- background-yellow
+   ;;   blue-fg   <- text-blue              a date
+   ;;   blue-bg   <- background-blue
+   ;;   rose-fg   <- text-red               a mirror, an error
+   ;;   rose-bg   <- background-red
+   ;;
+   ;; Two of their slots are deliberately NOT the source. text-quinary is a
+   ;; placeholder tone that is invisible on the page in half their themes, so
+   ;; dim comes from text-tertiary; and the semantic accents (text-success,
+   ;; text-danger, text-warning) are pale mints and pinks that only work on a
+   ;; dark ground, so the accents come from their named color ramp instead —
+   ;; the one they pair a background with.
+   ;;
+   ;; Themes of theirs that are a photograph or a pane of glass over one of
+   ;; these palettes are not here: without the image they are a duplicate row.
+
+   ;; their default: white page, blue-gray ink.
+   (make-palette "light" #:scheme 'light
+                 '((paper     . |#FFFFFF|)
+                   (paper-2   . |#F3F4F4|)
+                   (panel     . |#DCE0E2|)
+                   (ink       . |#2A3135|)
+                   (dim       . |#868C90|)
+                   (line      . |#DCE0E2|)
+                   (pill-bg   . |#C1E1F2|)
+                   (green     . |#057A55|)
+                   (amber-fg  . |#9F580A|)
+                   (amber-bg  . |#FCE96A|)
+                   (blue-fg   . |#1C64F2|)
+                   (blue-bg   . |#C3DDFD|)
+                   (rose-fg   . |#E02424|)
+                   (rose-bg   . |#FBD5D5|)))
+   ;; their dark: charcoal, white ink, a slate-blue chip.
+   (make-palette "dark" #:scheme 'dark
+                 '((paper     . |#2A3135|)
+                   (paper-2   . |#353C3F|)
+                   (panel     . |#5C6062|)
+                   (ink       . |#FFFFFF|)
+                   (dim       . |#9EA1A2|)
+                   (line      . |#5C6062|)
+                   (pill-bg   . |#336677|)
+                   (green     . |#31C48D|)
+                   (amber-fg  . |#E3A008|)
+                   (amber-bg  . |#8C7146|)
+                   (blue-fg   . |#76A9FA|)
+                   (blue-bg   . |#405580|)
+                   (rose-fg   . |#F98080|)
+                   (rose-bg   . |#773B3B|)))
+   ;; paper on a gray desk. EXCEPTION: paper is their background-ambient, the
+   ;; only body value vintage does not share with their default — the rest of
+   ;; what makes it vintage is a dark app frame, and olai has no frame.
+   (make-palette "vintage" #:scheme 'light
+                 '((paper     . |#ECEEF0|)
+                   (paper-2   . |#F3F4F4|)
+                   (panel     . |#DCE0E2|)
+                   (ink       . |#2A3135|)
+                   (dim       . |#868C90|)
+                   (line      . |#DCE0E2|)
+                   (pill-bg   . |#C1E1F2|)
+                   (green     . |#057A55|)
+                   (amber-fg  . |#9F580A|)
+                   (amber-bg  . |#FCE96A|)
+                   (blue-fg   . |#1C64F2|)
+                   (blue-bg   . |#C3DDFD|)
+                   (rose-fg   . |#E02424|)
+                   (rose-bg   . |#FBD5D5|)))
+   ;; the mocha one: plum-black page, lavender ink, pastel accents over it.
+   ;; EXCEPTION: pill-bg is their background-quaternary — the selected blue-gray
+   ;; is close enough to their muted text to swallow a pill's label.
+   (make-palette "catppuccin" #:scheme 'dark
+                 '((paper     . |#1E1E2E|)
+                   (paper-2   . |#343546|)
+                   (panel     . |#45475A|)
+                   (ink       . |#CDD6F4|)
+                   (dim       . |#9399B2|)
+                   (line      . |#313244|)
+                   (pill-bg   . |#313244|)
+                   (green     . |#A6E3A1|)
+                   (amber-fg  . |#F9E2AF|)
+                   (amber-bg  . |#F9E2AF99|)
+                   (blue-fg   . |#89B4FA|)
+                   (blue-bg   . |#89B4FA99|)
+                   (rose-fg   . |#F38BA8|)
+                   (rose-bg   . |#F38BA899|)))
+   ;; cocoa and cream: warm paper, near-black cocoa ink, a honey chip.
+   (make-palette "chocolate" #:scheme 'light
+                 '((paper     . |#FFEFE2|)
+                   (paper-2   . |#F0DAC9|)
+                   (panel     . |#E6CDBB|)
+                   (ink       . |#281603|)
+                   (dim       . |#7D5E47|)
+                   (line      . |#A1836B53|)
+                   (pill-bg   . |#FBDA8A|)
+                   (green     . |#2DA044|)
+                   (amber-fg  . |#C99A00|)
+                   (amber-bg  . |#FFF3C4|)
+                   (blue-fg   . |#1A73E8|)
+                   (blue-bg   . |#D4E8FF|)
+                   (rose-fg   . |#D93636|)
+                   (rose-bg   . |#FFE0E0|)))
+   ;; a phosphor terminal: black page, lime ink, a green-on-green ramp. The
+   ;; accents are the ones they hand every dark theme.
+   (make-palette "hacker" #:scheme 'dark
+                 '((paper     . |#000000|)
+                   (paper-2   . |#002200|)
+                   (panel     . |#003300|)
+                   (ink       . |#00FF00|)
+                   (dim       . |#009900|)
+                   (line      . |#005500|)
+                   (pill-bg   . |#005500|)
+                   (green     . |#31C48D|)
+                   (amber-fg  . |#E3A008|)
+                   (amber-bg  . |#8C7146|)
+                   (blue-fg   . |#76A9FA|)
+                   (blue-bg   . |#405580|)
+                   (rose-fg   . |#F98080|)
+                   (rose-bg   . |#773B3B|)))
+   ;; tea powder: green page, darker green ink. TWO EXCEPTIONS, both because
+   ;; matcha has one muted tone and one dark surface: dim is their text-quinary
+   ;; (text-tertiary is text-primary here, so the rule leaves nothing dim), and
+   ;; paper-2 is their background-tertiary (background-secondary is a saturated
+   ;; mid-green that leaves a chip's label at 1.5:1).
+   (make-palette "matcha" #:scheme 'light
+                 '((paper     . |#DDEABE|)
+                   (paper-2   . |#EEF6CF|)
+                   (panel     . |#EEF6CF|)
+                   (ink       . |#415915|)
+                   (dim       . |#85AC41|)
+                   (line      . |#85AC41|)
+                   (pill-bg   . |#EEF6CF|)
+                   (green     . |#3D8828|)
+                   (amber-fg  . |#A88510|)
+                   (amber-bg  . |#F0E4A8|)
+                   (blue-fg   . |#2868A0|)
+                   (blue-bg   . |#C0D8F0|)
+                   (rose-fg   . |#C43838|)
+                   (rose-bg   . |#F5D0C8|)))
+   ;; moonlight: blush paper, lilac ink. EXCEPTION: pill-bg is their
+   ;; background-completed — the selected lilac is a mid tone, and a date's
+   ;; green on it is 1.4:1.
+   (make-palette "moon" #:scheme 'light
+                 '((paper     . |#FDF6F6|)
+                   (paper-2   . |#ECE7EE|)
+                   (panel     . |#DFDEF2|)
+                   (ink       . |#615F7F|)
+                   (dim       . |#8B6FA8|)
+                   (line      . |#E4D8EA|)
+                   (pill-bg   . |#EFEEF5|)
+                   (green     . |#5FA876|)
+                   (amber-fg  . |#C9A84F|)
+                   (amber-bg  . |#F9ECC7|)
+                   (blue-fg   . |#6B8BC9|)
+                   (blue-bg   . |#C9D8F4|)
+                   (rose-fg   . |#C85B5B|)
+                   (rose-bg   . |#FDCDC8|)))
+   ;; neutral near-black, no hue in the grays at all.
+   (make-palette "neo" #:scheme 'dark
+                 '((paper     . |#141414|)
+                   (paper-2   . |#2D2D2D|)
+                   (panel     . |#373737|)
+                   (ink       . |#DCDBDB|)
+                   (dim       . |#9EA1A2|)
+                   (line      . |#242424|)
+                   (pill-bg   . |#286C8E|)
+                   (green     . |#8DBD6A|)
+                   (amber-fg  . |#F1C068|)
+                   (amber-bg  . |#F1C06899|)
+                   (blue-fg   . |#76A9FA|)
+                   (blue-bg   . |#76A9FA99|)
+                   (rose-fg   . |#CF4653|)
+                   (rose-bg   . |#CF465399|)))
+   ;; the editor palette, by way of their port of it: blue-gray page, muted
+   ;; everything. Its one dim tone is dim on purpose and stays that way.
+   (make-palette "one-dark" #:scheme 'dark
+                 '((paper     . |#282C33|)
+                   (paper-2   . |#2F343E|)
+                   (panel     . |#3B4048|)
+                   (ink       . |#C8CCD4|)
+                   (dim       . |#5D636F|)
+                   (line      . |#3B4048|)
+                   (pill-bg   . |#293B5B|)
+                   (green     . |#A1C181|)
+                   (amber-fg  . |#DFC184|)
+                   (amber-bg  . |#DFC18499|)
+                   (blue-fg   . |#73ADE9|)
+                   (blue-bg   . |#73ADE999|)
+                   (rose-fg   . |#D07277|)
+                   (rose-bg   . |#D0727799|)))
+   ;; black steel, orange readout, red frame. THE EXCEPTIONS, all of them
+   ;; forced: robot paints its accent BACKGROUNDS the same solid color as its
+   ;; accent TEXT (a chip whose label is its own ground), so the three accent
+   ;; grounds are the washes it draws behind text instead; dim is its gray
+   ;; rather than its red, which is already the frame and the error; and a
+   ;; pill's ground is its own near-black rather than the lime selection wash.
+   (make-palette "robot" #:scheme 'dark
+                 '((paper     . |#000000|)
+                   (paper-2   . |#1A2B2B|)
+                   (panel     . |#FEA14320|)
+                   (ink       . |#FEA143|)
+                   (dim       . |#7A8A8A|)
+                   (line      . |#E8393F|)
+                   (pill-bg   . |#151413|)
+                   (green     . |#4ED8A3|)
+                   (amber-fg  . |#DFE361|)
+                   (amber-bg  . |#FAFF7A26|)
+                   (blue-fg   . |#3580D3|)
+                   (blue-bg   . |#A9E9F126|)
+                   (rose-fg   . |#E8393F|)
+                   (rose-bg   . |#E8393F65|)))))
 
 (define theme-names (map palette-name palettes))
 

--- a/olai/web/theme.rkt
+++ b/olai/web/theme.rkt
@@ -85,15 +85,21 @@
 ;; is the same fourteen lines copied once per theme, which is one place per
 ;; theme for a new token to be forgotten.
 
-(struct palette (name prefix entries) #:transparent)
+(struct palette (name prefix scheme entries) #:transparent)
 
 ;; The prefix is the name's first letter: short, and nothing to keep in step.
-(define (make-palette name entries)
-  (palette name (substring name 0 1) entries))
+;;
+;; `scheme` is the one thing about a theme a browser has to be told in its own
+;; words: form controls, scrollbars and the canvas behind the page are the UA's
+;; to paint, and `color-scheme` is how it is told which way. It rides in the
+;; table because it is a fact about the palette — a theme that changed its mind
+;; about being dark and forgot this would keep the OS's scrollbars.
+(define (make-palette name #:scheme scheme entries)
+  (palette name (substring name 0 1) scheme entries))
 
 (define palettes
   (list
-   (make-palette "light"
+   (make-palette "light" #:scheme 'light
                  '((paper     . |#E4ECCA|)
                    (paper-2   . |#EDF2DC|)
                    (panel     . |#EFF4DC|)
@@ -108,7 +114,7 @@
                    (blue-bg   . |#D8E8EF|)
                    (rose-fg   . |#A84A5E|)
                    (rose-bg   . |#F5DBDF|)))
-   (make-palette "dark"
+   (make-palette "dark" #:scheme 'dark
                  '((paper     . |#1E2417|)
                    (paper-2   . |#252D1D|)
                    (panel     . |#272F1E|)
@@ -122,7 +128,58 @@
                    (blue-fg   . |#7DB8D8|)
                    (blue-bg   . |#1D3340|)
                    (rose-fg   . |#E396A5|)
-                   (rose-bg   . |#402028|)))))
+                   (rose-bg   . |#402028|)))
+   ;; aged palm leaf, iron-gall ink: the outline as a manuscript. Warm paper,
+   ;; brown-black ink, and accents pulled back to what a dye would give.
+   (make-palette "manuscript" #:scheme 'light
+                 '((paper     . |#F0E7D2|)
+                   (paper-2   . |#F5EDDD|)
+                   (panel     . |#F7F0E2|)
+                   (ink       . |#3D2F1B|)
+                   (dim       . |#8C7B5C|)
+                   (line      . |#DCCEAC|)
+                   (pill-bg   . |#FAF4E6|)
+                   (green     . |#5A7A34|)
+                   (amber-fg  . |#A05A16|)
+                   (amber-bg  . |#F3E2BC|)
+                   (blue-fg   . |#2F6580|)
+                   (blue-bg   . |#DCE7E4|)
+                   (rose-fg   . |#9E4444|)
+                   (rose-bg   . |#F1DBD2|)))
+   ;; near-white, high contrast: every foreground/background pair clears AA.
+   ;; The one to reach for on a bad screen or in bright light.
+   (make-palette "chalk" #:scheme 'light
+                 '((paper     . |#FAFAF6|)
+                   (paper-2   . |#F2F2EC|)
+                   (panel     . |#F5F5F0|)
+                   (ink       . |#15180F|)
+                   (dim       . |#555E4C|)
+                   (line      . |#C9CDBF|)
+                   (pill-bg   . |#EDEFE6|)
+                   (green     . |#2A6626|)
+                   (amber-fg  . |#8F5200|)
+                   (amber-bg  . |#F5E4BE|)
+                   (blue-fg   . |#134F75|)
+                   (blue-bg   . |#D4E5EF|)
+                   (rose-fg   . |#8E3348|)
+                   (rose-bg   . |#F4D7DD|)))
+   ;; true black: an OLED panel spends nothing on #000000, and the outline is
+   ;; mostly background. Everything else is the dark theme, one step quieter.
+   (make-palette "pitch" #:scheme 'dark
+                 '((paper     . |#000000|)
+                   (paper-2   . |#0D110A|)
+                   (panel     . |#10140C|)
+                   (ink       . |#C9D6B4|)
+                   (dim       . |#77836A|)
+                   (line      . |#242B1E|)
+                   (pill-bg   . |#161B10|)
+                   (green     . |#7FC97A|)
+                   (amber-fg  . |#D9A85A|)
+                   (amber-bg  . |#2C230B|)
+                   (blue-fg   . |#6FAECE|)
+                   (blue-bg   . |#122633|)
+                   (rose-fg   . |#D68B9A|)
+                   (rose-bg   . |#301820|)))))
 
 (define theme-names (map palette-name palettes))
 
@@ -168,12 +225,17 @@
    (for/list ([entry (in-list (palette-entries p))])
      (list (custom-property (prefixed p (car entry))) (cdr entry)))))
 
-;; --paper: var(--l-paper); ... — the skin's names, pointed at one theme
+;; --paper: var(--l-paper); ... — the skin's names, pointed at one theme, and
+;; the one declaration that is not a custom property: color-scheme is what the
+;; BROWSER paints from (form controls, scrollbars, the canvas), and it belongs
+;; wherever a theme is put in force, which is exactly here.
 (define (palette-mapping p)
-  (append*
-   (for/list ([token (in-list palette-tokens)])
-     (list (custom-property (symbol->string token))
-           (list 'apply 'var (string->symbol (string-append "--" (prefixed p token))))))))
+  (append
+   (list '#:color-scheme (palette-scheme p))
+   (append*
+    (for/list ([token (in-list palette-tokens)])
+      (list (custom-property (symbol->string token))
+            (list 'apply 'var (string->symbol (string-append "--" (prefixed p token)))))))))
 
 ;; every theme's raw values, one block
 (register-base!

--- a/olai/web/theme.rkt
+++ b/olai/web/theme.rkt
@@ -13,6 +13,7 @@
 
 (require racket/list
          racket/contract
+         racket/string
          olai/web/style)
 
 (provide (contract-out
@@ -24,13 +25,28 @@
           ;; here with the rest of the shared vocabulary; each kind repaints
           ;; it in the module that draws it
           [ol-pill string?]
-          ;; every theme the sheet carries, in cascade order. The page picks
-          ;; one with data-theme; this is the list of what it may say
+          ;; every theme the sheet carries, in table order. The page picks one
+          ;; by name; this is the list of what it may say, and the picker's rows
           [theme-names (listof string?)]
-          ;; where one theme's value for a token is written: --l-paper for
-          ;; ("light", 'paper). The prefix rule is this module's (make-palette
-          ;; below), and a reader that recomputed it would be a second one
-          [theme-token-property (-> string? symbol? string?)]))
+          ;; the attribute a page names a theme with. The picker writes it and
+          ;; the sheet keys off it, so it is one string, spelled here
+          [theme-attribute string?]
+          ;; the theme a page with no attribute reads in — the sheet's bare
+          ;; :root. The picker needs it to light a chip before anyone picks
+          [theme-default string?]
+          ;; what <meta name="color-scheme"> should say before the sheet lands:
+          ;; every way the themes come, said once
+          [theme-color-scheme string?]
+          ;; the themes that promise AA contrast on every foreground it paints
+          ;; on a background. A claim, so something can check it
+          [aa-theme-names (listof string?)]
+          ;; one theme's table: (token . value), the row the sheet below is
+          ;; generated from. `list?` and not the shape: the shape is what the
+          ;; load-time guards check, once, rather than on every read
+          [theme-entries (-> string? list?)]
+          ;; name -> the css fragment that puts that theme in force. What
+          ;; lands in the sheet, handed over rather than found in its text
+          [theme-blocks (-> list?)]))
 
 ;; The tokens themselves are bound and provided by define-tokens below.
 
@@ -79,27 +95,32 @@
 ;; ---- the themes -----------------------------------------------------------
 ;;
 ;; A theme is a palette with a name, and the whole file is generated from this
-;; table: adding a theme is adding a row. Values are written ONCE, under a
-;; one-letter prefix (--l-paper, --d-paper), and the mapping that points the
-;; skin's names at one of them is emitted per theme — in hand-written CSS that
-;; is the same fourteen lines copied once per theme, which is one place per
-;; theme for a new token to be forgotten.
+;; table: adding a theme is adding a row, deleting one is deleting a row, and
+;; neither touches a line of CSS. A theme's values are written once, in the
+;; block that puts that theme in force — which in hand-written CSS is the same
+;; fourteen lines copied once per theme, and one place per theme for a new
+;; token to be forgotten.
 
-(struct palette (name prefix scheme entries) #:transparent)
+(struct palette (name scheme aa? entries) #:transparent)
 
-;; The prefix is the name's first letter: short, and nothing to keep in step.
-;;
 ;; `scheme` is the one thing about a theme a browser has to be told in its own
 ;; words: form controls, scrollbars and the canvas behind the page are the UA's
 ;; to paint, and `color-scheme` is how it is told which way. It rides in the
 ;; table because it is a fact about the palette — a theme that changed its mind
 ;; about being dark and forgot this would keep the OS's scrollbars.
-(define (make-palette name #:scheme scheme entries)
-  (palette name (substring name 0 1) scheme entries))
+;;
+;; `aa?` is a PROMISE, and only some themes make it: every foreground this
+;; palette paints on a background clears WCAG AA (4.5:1). Said here so the
+;; suite can hold the palette to it — a color nudged by two digits is exactly
+;; the edit that quietly drops a pair under the line.
+(define (make-palette name #:scheme scheme #:aa? [aa? #f] entries)
+  (palette name scheme aa? entries))
 
 (define palettes
   (list
-   (make-palette "light" #:scheme 'light
+   ;; the leaf the outline is written on: dried palm green, dark-green ink.
+   ;; The name is the palette; nothing here is "light".
+   (make-palette "leaf" #:scheme 'light
                  '((paper     . |#E4ECCA|)
                    (paper-2   . |#EDF2DC|)
                    (panel     . |#EFF4DC|)
@@ -147,8 +168,9 @@
                    (rose-fg   . |#9E4444|)
                    (rose-bg   . |#F1DBD2|)))
    ;; near-white, high contrast: every foreground/background pair clears AA.
-   ;; The one to reach for on a bad screen or in bright light.
-   (make-palette "chalk" #:scheme 'light
+   ;; The DEFAULT — what a page reads in before anyone picks — because the one
+   ;; nobody chose should be the one that is legible on any screen.
+   (make-palette "chalk" #:scheme 'light #:aa? #t
                  '((paper     . |#FAFAF6|)
                    (paper-2   . |#F2F2EC|)
                    (panel     . |#F5F5F0|)
@@ -183,11 +205,13 @@
 
 (define theme-names (map palette-name palettes))
 
-;; Two themes whose names start with the same letter would declare the same
-;; --x-token twice, and the second would win everywhere.
-(let ([prefixes (map palette-prefix palettes)])
-  (unless (= (length prefixes) (length (remove-duplicates prefixes)))
-    (error 'theme "two themes share a prefix: ~s" prefixes)))
+(define aa-theme-names
+  (for/list ([p (in-list palettes)] #:when (palette-aa? p)) (palette-name p)))
+
+;; Two themes with one name is one block overwriting the other, and a picker
+;; with two chips that do the same thing.
+(unless (= (length theme-names) (length (remove-duplicates theme-names)))
+  (error 'theme "two themes share a name: ~s" theme-names))
 
 ;; A token a theme forgets is a var(--x) that resolves to nothing the moment
 ;; that theme is picked. Cheap to check here, invisible in a browser.
@@ -198,50 +222,50 @@
 
 ;; ---- policy ---------------------------------------------------------------
 ;;
-;; Which theme a page gets when it says nothing, and which one the OS means
-;; when it says it prefers dark. Named, because the generators below only know
-;; that some theme fills each role.
+;; Which theme a page gets when it says nothing. Named, because the generators
+;; below only know that some theme fills the role — and the picker needs it
+;; too, to light the chip that is in force before anyone has picked one.
+;;
+;; The OS does not vote. `prefers-color-scheme` chose the theme once, and it
+;; meant two ways to be dark that could disagree; a theme is a PICK, and an
+;; unpicked page reads in the default.
 
-(define default-theme "light")
-(define os-dark-theme "dark")
+(define theme-default "chalk")
+
+;; How a page says which theme it is in: one attribute, keyed on by the sheet,
+;; written by the picker (web/prefs), and spelled here.
+(define theme-attribute "data-theme")
+(define theme-attribute-datum (string->symbol theme-attribute))
+
+;; What the browser should assume BEFORE the sheet lands, which is every way
+;; these themes come — it cannot know yet which one this page is in. Once the
+;; sheet is in, each theme's own color-scheme is what wins.
+(define theme-color-scheme
+  (string-join
+   (remove-duplicates (for/list ([p (in-list palettes)])
+                        (symbol->string (palette-scheme p))))
+   " "))
 
 (define (theme-named name)
   (or (findf (λ (p) (equal? (palette-name p) name)) palettes)
       (error 'theme "no theme named ~a" name)))
 
+(define (theme-entries name) (palette-entries (theme-named name)))
+
 ;; ---- the generators -------------------------------------------------------
 
 (define (custom-property name) (string->keyword (string-append "--" name)))
 
-(define (prefixed p token)
-  (string-append (palette-prefix p) "-" (symbol->string token)))
-
-(define (theme-token-property name token)
-  (string-append "--" (prefixed (theme-named name) token)))
-
-;; --l-paper: #E4ECCA; ... — one theme's values, spelled out
-(define (palette-declarations p)
-  (append*
-   (for/list ([entry (in-list (palette-entries p))])
-     (list (custom-property (prefixed p (car entry))) (cdr entry)))))
-
-;; --paper: var(--l-paper); ... — the skin's names, pointed at one theme, and
-;; the one declaration that is not a custom property: color-scheme is what the
-;; BROWSER paints from (form controls, scrollbars, the canvas), and it belongs
-;; wherever a theme is put in force, which is exactly here.
+;; --paper: #E4ECCA; ... — one theme's values, in force, and the one
+;; declaration that is not a custom property: color-scheme is what the BROWSER
+;; paints from (form controls, scrollbars, the canvas), and it belongs wherever
+;; a theme is put in force, which is exactly here.
 (define (palette-mapping p)
   (append
    (list '#:color-scheme (palette-scheme p))
    (append*
-    (for/list ([token (in-list palette-tokens)])
-      (list (custom-property (symbol->string token))
-            (list 'apply 'var (string->symbol (string-append "--" (prefixed p token)))))))))
-
-;; every theme's raw values, one block
-(register-base!
- (css-expr
-  [(: root)
-   ,@(append* (for/list ([p (in-list palettes)]) (palette-declarations p)))]))
+    (for/list ([entry (in-list (palette-entries p))])
+      (list (custom-property (symbol->string (car entry))) (cdr entry))))))
 
 ;; shape and type: the same in every theme, so its own block
 (register-base!
@@ -257,27 +281,35 @@
    #:--indent 1.375rem
    #:--radius 0.375rem]))
 
-;; the default, and the page that names it out loud — one block, because they
-;; are the same mapping
-(register-base!
- (css-expr
-  [(: root) (attribute (: root) (= data-theme ,default-theme))
-   ,@(palette-mapping (theme-named default-theme))]))
+;; The block that puts ONE theme in force. Every theme's is the selector a page
+;; asks for it by; the DEFAULT's also lands on a bare :root, because a page that
+;; picked nothing is in it — same mapping, so one block rather than two.
+;;
+;; Handed out below (theme-blocks) as well as registered: a reader that went
+;; looking for these in the sheet's text would be finding them by the spelling
+;; they happen to have rather than being given them.
+(define (theme-block p)
+  (if (equal? (palette-name p) theme-default)
+      (css-expr [(: root)
+                 (attribute (: root) (= ,theme-attribute-datum ,(palette-name p)))
+                 ,@(palette-mapping p)])
+      (css-expr [(attribute (: root) (= ,theme-attribute-datum ,(palette-name p)))
+                 ,@(palette-mapping p)])))
 
-;; the OS's preference, for a page that named nothing
-(register-base!
- (css-expr
-  [@ media (#:prefers-color-scheme dark)
-     [(: root) ,@(palette-mapping (theme-named os-dark-theme))]]))
+(define theme-block-alist
+  (for/list ([p (in-list palettes)]) (cons (palette-name p) (theme-block p))))
 
-;; and every other theme, for a page that asked for it. The default is already
-;; spelled above; repeating it here would be the same declarations twice.
-(for ([p (in-list palettes)]
-      #:unless (equal? (palette-name p) default-theme))
-  (register-base!
-   (css-expr
-    [(attribute (: root) (= data-theme ,(palette-name p)))
-     ,@(palette-mapping p)])))
+(define (theme-blocks) theme-block-alist)
+
+(define (theme-block-named name) (cdr (assoc name theme-block-alist)))
+
+;; the default first: it is what a page with no theme reads in
+(register-base! (theme-block-named theme-default))
+
+;; and every other theme, for a page that asked for it by name. Last, so the
+;; named theme wins over the bare :root above.
+(for ([name (in-list theme-names)] #:unless (equal? name theme-default))
+  (register-base! (theme-block-named name)))
 
 ;; ---- base -----------------------------------------------------------------
 


### PR DESCRIPTION
## What

Three things, one branch:

**Themes.** theme.rkt's palette table grows from 2 to 15 rows: 4 house palettes (`chalk` — the new default, high-contrast light with an enforced AA test; `leaf` — the renamed original palm-leaf light; `manuscript`; `pitch`) plus 11 derived from WorkFlowy's desktop themes (`light`, `dark`, `vintage`, `catppuccin`, `chocolate`, `hacker`, `matcha`, `moon`, `neo`, `one-dark`, `robot`). Values only — one documented wf→olai token mapping rule, deviations only where the mapped value collapses on its own ground (each forced by contrast arithmetic; robot's accent pills shipped at 1.00:1). glass/space/steel/wood skipped: their identity is background images/translucency; flat, they duplicate light or dark. The prefix indirection is gone — each theme's block carries its values directly, so a theme is one table row, and no `:root` mega-block ships 15 palettes to every visitor.

**Prefs panel.** New `web/prefs.rkt` owns the mechanism: a pref is a name + label + values + default; the sidebar Prefs section renders one row per pref (theme is the first); `static/prefs.js` is generic over rows (a future density/font-size pref is one list entry, zero JS). Theme is pure client state: an inline boot script (generated via write-json, storage keys spelled once) stamps `data-theme` from localStorage before first paint; the server renders nothing lit and never learns your theme. No `auto`, no OS-follow: nothing stored means the default (`chalk`, chip lit); `prefers-color-scheme` is consulted nowhere, and a test asserts that. Stale stored themes (a deleted candidate) self-heal to the default.

**De-personalized defaults.** The maintainer's data dir is no longer named anywhere (code, justfile, docs, .gitignore). `OLAI_HOME` set → unchanged behavior. Unset → read commands and `just run`/`serve` fall back to the repo's own `examples/Example.rkt` + `Roadmap.rkt`, and write commands raise a clear usage error (existing exit-code + JSON error shape) instead of inventing a path.

## Review

Hickey and Lowy passes ran as independent reviews on the theme work; all findings applied — among them: the `dataset[p]` hyphen trap (would have silently broken the module's own named next pref), the unused `#:theme` render-page parameter deleted, cascade/`htmx:afterSwap`/self-heal fixes in prefs.js, chalk's AA claim converted from a comment into a 15-pair contrast test, and the prefix-namespace deletion above.

Also in this branch: CLAUDE.md workflow updates (agents run `just test` only; CI carries integration).

## Test plan

- [x] `just test` — 190 unit tests green
- [x] `nix build` offline + binary smoke (`olai check`, `olai css`)
- [x] Serve smoke: 15 chips rendered, nothing lit server-side; `prefs.js` behavior driven under node (fresh load lights chalk; click sets+persists; stale value sweeps to default)
- [x] `env -u OLAI_HOME`: `just tree`/`serve` target examples+Roadmap; `olai add` errors with the documented message/exit code/JSON shape
- [x] `grep Selfflowy-Srid` → zero hits
- [ ] CI green (linux+macos; integration suite incl. the new unset-OLAI_HOME test runs there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)