### PR TITLE
nix: embed olai/sexp reader in the packaged binary

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,12 +101,13 @@
 
       checks = forAllSystems ({ pkgs, system }: {
         build = self.packages.${system}.olai;
-        # The runCommand script lives in nix/smoke.nix; the example outline
-        # and fake-agent paths are repo-root relative, so the flake passes
-        # them in rather than nix/smoke.nix guessing its own location.
+        # The runCommand script lives in nix/smoke.nix; example + fake-agent
+        # paths are repo-root relative, so the flake passes them in rather
+        # than nix/smoke.nix guessing its own location.
         smoke = pkgs.callPackage ./nix/smoke.nix {
           olai = self.packages.${system}.olai;
           exampleOutline = ./examples/Example.rkt;
+          exampleSexpOutline = ./examples/Example.sexp.rkt;
           fakeAcpAgentSrc = ./olai/tests/integration/fake-acp-agent.rkt;
         };
       });

--- a/nix/olai.nix
+++ b/nix/olai.nix
@@ -63,7 +63,14 @@ stdenv.mkDerivation {
     raco pkg install --copy --no-docs --deps force ./olai-pkg
 
     mkdir -p $out/bin
-    raco exe ++lang olai -o $out/bin/.olai-wrapped \
+    # Embed language readers so #lang modules resolve with no collection
+    # paths at runtime. ++lang olai is enough for the outline reader.
+    # ++lang olai/sexp is NOT: raco maps multi-segment langs via
+    # (lib "…/sexp.rkt") + relative "lang/reader.rkt", which collapses
+    # to olai/lang/reader — the wrong module, declared, so the flag
+    # silently no-ops. ++lib names the real reader path.
+    raco exe ++lang olai ++lib olai/sexp/lang/reader \
+      -o $out/bin/.olai-wrapped \
       "$(racket -e '(display (path->string (collection-file-path "cli.rkt" "olai")))')"
     chmod +x $out/bin/.olai-wrapped
 

--- a/nix/smoke.nix
+++ b/nix/smoke.nix
@@ -1,9 +1,7 @@
-# `./examples/Example.rkt` and `./olai/tests/integration/fake-acp-agent.rkt`
-# used to be relative paths in flake.nix, resolving from the repo root. Moved
-# here verbatim they'd resolve from nix/ instead (nix/examples, nix/olai/...),
-# which don't exist — so the flake passes the two repo paths in as arguments
-# (`exampleOutline`, `fakeAcpAgentSrc`) instead of this file spelling them out.
-{ runCommand, olai, racket, curl, tzdata, exampleOutline, fakeAcpAgentSrc }:
+# Repo-root paths resolve from the caller's dir, not nix/; the flake passes
+# them in (`exampleOutline`, `exampleSexpOutline`, `fakeAcpAgentSrc`).
+{ runCommand, olai, racket, curl, tzdata
+, exampleOutline, exampleSexpOutline, fakeAcpAgentSrc }:
 
 runCommand "olai-smoke"
   {
@@ -16,6 +14,18 @@ runCommand "olai-smoke"
   ''
     export TZDIR="${tzdata}/share/zoneinfo"
     olai check ${exampleOutline}
+
+    # #lang olai/sexp needs its reader embedded in the raco-exe binary
+    # (++lib olai/sexp/lang/reader; see nix/olai.nix). Without it this
+    # fails with collection not found for olai/sexp/lang/reader.
+    olai check ${exampleSexpOutline}
+    olai tree ${exampleSexpOutline} > tree-sexp.json
+    racket -e '(require json)
+               (define j (call-with-input-file "tree-sexp.json" read-json))
+               (unless (and (= 1 (hash-ref j (quote version)))
+                            (string? (hash-ref j (quote file)))
+                            (pair? (hash-ref j (quote tasks))))
+                 (error (quote smoke) "unexpected sexp tree JSON"))'
 
     # Parse the JSON; never grep it (key order is not a contract).
     olai tree ${exampleOutline} > tree.json
@@ -116,7 +126,7 @@ runCommand "olai-smoke"
     # The agent loop, over HTTP: the page carries the panel, a POST is
     # accepted with no body of its own, and what the panel draws comes
     # back as `chat` frames on the stream above.
-    grep -q 'id="sf-chat"' page.html
+    grep -q 'id="ol-chat"' page.html
     test "$(curl -s -o /dev/null -w '%{http_code}' \
               --data-urlencode 'text=smoke hello' \
               http://127.0.0.1:8099/chat)" = 204
@@ -159,7 +169,7 @@ runCommand "olai-smoke"
     printf '  @date not-a-date\n' >> live.rkt
     curl -sf -o page3.html http://127.0.0.1:8099/
     grep -q "Smoke reload marker" page3.html
-    grep -q "sf-error" page3.html
+    grep -q "ol-error" page3.html
     test "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8099/api/tree)" = 500
 
     kill $events_pid || true

--- a/olai/store.rkt
+++ b/olai/store.rkt
@@ -77,10 +77,13 @@
 
 ;; Shared with every reload: attaching (not re-requiring) keeps one `task`
 ;; struct type and works inside the packaged binary, where these modules are
-;; embedded and cannot be found by collection path.
+;; embedded and cannot be found by collection path. Both #lang readers —
+;; outline and s-expression — must be here; the sexp one is embedded via
+;; ++lib (see nix/olai.nix), not ++lang.
 (define attached-modules
   '(olai/lang/expander
-    olai/lang/reader))
+    olai/lang/reader
+    olai/sexp/lang/reader))
 
 (define (make-outline-namespace src)
   (define ns (parameterize ([current-namespace src]) (make-base-empty-namespace)))


### PR DESCRIPTION
## Summary

Fixes [#7](https://github.com/juspay/olai/issues/7): the nix-built binary could not load `#lang olai/sexp` files (`collection not found for module path: olai/sexp/lang/reader`).

- **Root cause:** `++lang olai/sexp` does not embed the sexp reader. For multi-segment language names, raco resolves the reader relative to `(lib "olai/sexp.rkt")`, which collapses to `olai/lang/reader` — the outline reader, already declared — so the flag silently no-ops.
- **Fix:** embed the real module with `++lib olai/sexp/lang/reader`, and attach it in the store's reload namespaces.
- **Smoke:** check `examples/Example.sexp.rkt` from the packaged binary (would have failed red before this). Also retarget `sf-chat` / `sf-error` → `ol-chat` / `ol-error` so smoke matches the post-#6 class names.

Verified: `nix build .#olai` then `./result/bin/olai check examples/Example.sexp.rkt`, and `nix build .#checks.x86_64-linux.smoke`.

## Test plan

- [x] `nix build .#olai`
- [x] `./result/bin/olai check examples/Example.sexp.rkt` → ok
- [x] `./result/bin/olai check examples/Example.rkt` still ok
- [x] `nix build .#checks.x86_64-linux.smoke` green (includes sexp check + serve)
- [ ] CI green on this PR