### PR TITLE
toolchain: just build before test, kill the stale-.zo trap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # CLAUDE.md
 
-Read README.md and docs/*.md first. This file is only what you can't infer.
+Read README.md and docs/*.md first (especially docs/hacking.md for the
+edit-verify loop and css-expr). This file is only what you can't infer.
 
 ## HARD RULES
 
@@ -66,6 +67,11 @@ Read README.md and docs/*.md first. This file is only what you can't infer.
 * just check / tree / agenda / serve / test — recipes handle PLTUSERHOME +
   raco link (`run`/`watch` alias `serve`). Racket comes from the nix dev
   shell (nixpkgs 9.2). Don't fight raco setup; PLTUSERHOME must be writable.
+* `just test` runs `just build` first (`raco setup --pkgs olai`) so
+  compiled/*.zo exist and stay coherent after edits. `just install` alone
+  does not recompile. Linklet mismatch → `just clean && just build` (see
+  docs/hacking.md). Repo-specific facts agents rediscover otherwise live
+  in docs/hacking.md — read it before probing css-expr or the toolchain.
 * `just test` is the only test command you run. It is the fast set; CI
   runs everything else on the PR.
 * Branch + PR for every change (agents included); CI green before merge.

--- a/README.md
+++ b/README.md
@@ -125,15 +125,17 @@ author does. Repo demos live in `examples/` (see `examples/Daily.rkt` for
 ```bash
 nix develop        # racket 9.2 + just; or install them yourself
 just install       # gregor + markdown, then --link olai/
+just build         # raco setup --pkgs olai (bytecode; test depends on it)
 just check         # validates $OLAI_HOME/*.rkt (unset: examples + Roadmap)
 just tree examples/Example.rkt   # JSON forest for agents
 just serve                       # $OLAI_HOME on http://127.0.0.1:8080
 just agenda
 just calendar --month 2026-08
 just daily                       # today's node in Daily/YYYY-MM.rkt
-just test                        # unit tests (in-process)
+just test                        # unit tests (in-process; builds first)
 just test-integration            # subprocess CLI + servers
 just test-all                    # both
+just clean                       # drop olai/**/compiled
 just css-classes                 # regenerate olai/tests/classes.golden
 ```
 
@@ -158,6 +160,9 @@ No ANSI. Humans use the web app.
 (`racket/cmdline`, `json`, `gregor`, `markdown`, `xml` xexprs,
 `web-server` for routing and static files) over home-grown parsers,
 routers and escape codes.
+
+Toolchain traps, css-expr spelling, and the stale-`.zo` symptom:
+**docs/hacking.md**.
 
 Patches welcome. Keep it small, keep it boring. The interesting part is
 the DSL; write good expander error messages -- the agents read them.

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -1,0 +1,96 @@
+# Hacking
+
+Facts an agent cannot infer from the code and would otherwise probe for.
+Not a tutorial. Read README and docs/cli.md first.
+
+## Toolchain
+
+* Racket comes from `nix develop` (nixpkgs 9.2). `just` recipes set
+  `PLTUSERHOME` to `$PWD/.plt-user` so user packages and the `olai` link
+  live in the worktree, not `~`. That directory must be writable.
+* `just install` — deps + `raco pkg install --skip-installed --link olai/`.
+  Cheap to repeat. Does **not** recompile after you edit sources.
+* `just build` — `raco setup --pkgs olai`. Writes `compiled/*.zo` for the
+  collection and its tests, and keeps them coherent after edits.
+  Incremental when nothing changed. `just test` / `test-integration` /
+  `test-all` depend on it.
+* `just clean` — delete every `olai/**/compiled`. Escape hatch only.
+
+### Why build exists
+
+This Racket does **not** write `.zo` on load. `racket -e '(require …)'`
+and a bare `raco test` leave no bytecode on disk; every run recompiles
+in memory. Measured baseline (16 cores, 184 unit tests):
+
+| path | wall |
+|---|---|
+| `just test` with no `.zo` | ~22 s |
+| `just test` after `just build` | ~5.5–6 s |
+| edit `olai/web/style.rkt` → `just test` (with build) | ~6–9 s |
+
+So the agent edit-verify loop is dominated by missing bytecode, not by
+the suite. Build once; keep it.
+
+### Stale `.zo` / linklet mismatch
+
+Symptom:
+
+```
+instantiate-linklet: mismatch;
+ reference to a variable that is not exported
+  …
+  possible reason: modules need to be recompiled because dependencies changed
+  possible solution: running `racket -y`, `raco make`, or `raco setup`
+```
+
+Cause: a low-level module was recompiled (or its exports changed) while
+a dependent's `.zo` still expects the old linklet — classic after
+editing `web/style.rkt` / `web/theme.rkt` and only partially rebuilding.
+
+Cure, in order:
+
+1. `just build` (what `just test` already runs)
+2. if still broken: `just clean && just build`
+3. never hand-delete a single `*_rkt.zo` and leave the rest
+
+## css-expr (web/style.rkt and friends)
+
+The sheet is generated; the serializer is css-expr's. Rules that are not
+obvious from the package docs:
+
+* **Hex colors** must be escaped symbols: `|#E4ECCA|`, not `"#E4ECCA"`
+  or `#E4ECCA`. See the theme tables in `olai/web/theme.rkt`.
+* **Multi-value properties** (e.g. `box-shadow` layers, `transition`
+  lists) are **comma**-joined by the serializer.
+* **Parenthesized groups** inside a property (function args, nested
+  value lists) are **space**-joined.
+* **`@media` / `@keyframes`** are spelled as css-expr at-rules, not raw
+  strings when the form can express them:
+
+  ```racket
+  [@ media (#:max-width ,phone-max) #:padding-right 1rem]
+  [@ keyframes ol-spin [to #:transform (apply rotate 360deg)]]
+  ```
+
+* **`apply`** is css-expr's way to emit a CSS function:
+  `(apply color-mix (in srgb) (,green 45%) transparent)` →
+  `color-mix(in srgb, …)`.
+* **Raw CSS strings** are the escape hatch (`register-fragment!` with a
+  string). Use only when css-expr cannot spell it; comment why. The
+  generated-file banner in `theme.rkt` is the one permanent example.
+* **Cascade order** is not CSS `@layer`. It is (1) fragment layer
+  `'base` | `'component` | `'overlay`, then (2) module instantiation
+  order (= require order through `olai/web/skin.rkt`). A class is
+  defined in the module that **draws** it.
+
+Class-name renames: run `just css-classes` to regenerate
+`olai/tests/classes.golden`; never edit the golden by hand.
+
+## Tests
+
+* `just test` — unit, in-process, `olai/tests/*.rkt`
+* `just test-integration` — spawns `olai`, boots servers
+* `just test-all` — both, one `-j` pool
+* Parse JSON with `read-json`. Never string-match JSON.
+* Personal outline data is `$OLAI_HOME` (outside the repo). CI and
+  tests use `examples/` only.

--- a/justfile
+++ b/justfile
@@ -17,11 +17,21 @@ default_outlines := if olai_home == "" { repo_outlines } else { olai_home + "/*.
 default:
     @just --list
 
-# Runtime deps (gregor, markdown, css-expr) + raco link ./olai; cheap to repeat
+# Deps + raco link ./olai (cheap; does not recompile — use `just build`)
 install:
     mkdir -p "{{PLTUSERHOME}}"
     raco pkg install --auto --skip-installed gregor markdown css-expr
     raco pkg install --auto --skip-installed --link {{justfile_directory()}}/olai
+
+# raco setup --pkgs olai: write .zo and keep them coherent (see docs/hacking.md)
+build: install
+    raco setup --pkgs olai
+
+# Drop olai/**/compiled (linklet-mismatch escape hatch; prefer `just build`)
+clean:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    find olai -type d -name compiled -print0 | xargs -0 rm -rf
 
 # Validate outline(s) (default: $OLAI_HOME/*.rkt, else the repo's own)
 check *args: install
@@ -102,13 +112,13 @@ css-classes: install
     racket -e '(require olai/web/skin (only-in olai/web/style class-names)) (for-each displayln (sort (class-names) string<?))' > olai/tests/classes.golden
 
 # Unit tests: in-process, no subprocesses (olai/tests/*.rkt)
-test: install
+test: build
     raco test -j {{ num_cpus() }} olai/tests/*.rkt
 
 # Integration tests: subprocess CLI + real servers (olai/tests/integration/)
-test-integration: install
+test-integration: build
     raco test -j {{ num_cpus() }} olai/tests/integration/
 
 # Everything, in one -j pool so the slow files start first
-test-all: install
+test-all: build
     raco test -j {{ num_cpus() }} olai/tests/integration/ olai/tests/*.rkt


### PR DESCRIPTION
Closes #8.

## Summary

Agents lose wall time to a missing compile step, not to the suite:

- This Racket does **not** write `compiled/*.zo` on load. A bare `raco test` recompiles in memory every run and leaves no cache.
- `just install` uses `--skip-installed --link` and never recompiles after edits, so it cannot keep bytecode coherent.
- Low-level edits (e.g. `web/style.rkt`) plus partial rebuilds produce `instantiate-linklet: mismatch` that looks like a real bug; agents independently rediscovered `rm -rf olai/**/compiled`.

**Fix:** `just build` (`raco setup --pkgs olai`) writes and refreshes `.zo` for the collection and tests. `just test` / `test-integration` / `test-all` depend on it. `just clean` is the escape hatch. `docs/hacking.md` captures the toolchain trap and css-expr spelling facts agents otherwise re-probe.

## Before / after (16 cores, unit suite, Racket 9.2 CS)

| Scenario | Before | After |
|---|---|---|
| cold `just test` (no `.zo`) | **22–23 s** | **14.2 s** (build + test) |
| warm no-op `just test` | **22–23 s** (no cache) | **6.2 s** |
| edit `web/style.rkt` → `just test` | **~27 s** (no `.zo`) / trap risk | **6.5 s**, no mismatch |
| agent cure `rm -rf compiled` + test | 22–26 s | still works via `just clean` |

Warm `just build` alone: ~3.2 s. Baseline detail: https://github.com/juspay/olai/issues/8#issuecomment-5198406984

## Changes

- `just build` → `raco setup --pkgs olai` (after `install`)
- `just clean` → drop `olai/**/compiled`
- `test` / `test-integration` / `test-all` depend on `build` instead of `install`
- `docs/hacking.md` — fact sheet (toolchain, stale-`.zo`, css-expr rules)
- README / CLAUDE.md pointers

## Test plan

- [x] `just clean && just test` — cold path green (~14 s)
- [x] `just test` warm — ~6 s, 190 passed
- [x] edit `olai/web/style.rkt` comment → `just test` — green, no linklet mismatch
- [ ] CI green on this PR