### PR TITLE
web: fix outline text wrap regression (chat gutter was padding inside .ol-main max-width)

### DIFF
--- a/olai/tests/style.rkt
+++ b/olai/tests/style.rkt
@@ -334,6 +334,21 @@
     (check-equal? (fragment-layer (last (class-positions ol-main))) 'overlay)
     (check-true (< (at ol-main) (last (class-positions ol-main)))))
 
+  ;; The chat panel is position:fixed, so it takes no flow space and the reading
+  ;; column reserves the gutter itself. WHICH box that gutter lands in is the
+  ;; whole question: .ol-main is border-box with `max-width: 56rem`, so padding
+  ;; comes out of the cap — with --chat-w at max(21rem, 33vw) a wide screen left
+  ;; ~13rem of text and a gutter of dead space beside it. A margin is outside the
+  ;; box, so the cap still measures the text. A property question, not a
+  ;; serialization one: the canary above owns css-expr's output text.
+  (test-case "the chat gutter is reserved outside the reading column's box"
+    (define overlay
+      (fragment->css (cdr (list-ref ordered-fragments (last (class-positions ol-main))))))
+    (check-true (regexp-match? #px"margin-right\\s*:\\s*calc\\(\\s*var\\(--chat-w\\)" overlay)
+                "the panel's gutter is no longer a margin on the reading column")
+    (check-false (regexp-match? #px"padding-right" overlay)
+                 "the gutter is padding again: border-box takes it out of max-width"))
+
   ;; ---- theme --------------------------------------------------------------
 
   ;; A custom property, declared WITH ITS VALUE: the name, whatever whitespace

--- a/olai/web/chat-panel.rkt
+++ b/olai/web/chat-panel.rkt
@@ -136,13 +136,21 @@
 ;; it takes. The SUBJECT here is another module's — the document and the
 ;; outline's pane — which is what 'overlay says, and what puts this after
 ;; everything web/render registered.
+;;
+;; MARGIN, not padding. .ol-main is border-box with `max-width: 56rem`, so a
+;; padding gutter is taken out of that cap rather than out of the free space
+;; beside it: --chat-w is max(21rem, 33vw), so on a 1920px screen the gutter ate
+;; 41rem of the 56rem and the text wrapped into what was left, three words to a
+;; line, with the gutter sitting empty next to it. A margin is outside the
+;; border box, so the cap still measures the reading column and the flex box
+;; gives up the width the panel takes.
 (register-fragment!
  #:layer 'overlay
  (css-expr
   [((: ,(sel 'body ol-body) (apply has ,(sel ol-chat is-open))) ,(sel ol-main))
-   #:padding-right (apply calc (+ ,chat-w 1.5rem))
+   #:margin-right (apply calc (+ ,chat-w 1.5rem))
    ;; on a phone the sheet covers it anyway, so there is nothing to make room for
-   [@ media (#:max-width ,phone-max) #:padding-right 1rem]]))
+   [@ media (#:max-width ,phone-max) #:margin-right 0]]))
 
 (define-style ol-chat-head
   #:display flex


### PR DESCRIPTION
## Symptom

With the chat panel open, the outline's title and note text wrapped three or
four words to a line on a desktop viewport, with a wide band of empty space to
its right before the pane edge. Daily notes and notes under Tasks alike. The
sidebar was fine; only the main column was squeezed.

## Root cause

Three rules, all correct on their own:

```css
*,*::before,*::after{box-sizing:border-box;}
.ol-main{flex:1 1 auto;min-width:0;padding:2rem 2rem 6rem;max-width:56rem;}
body.ol-body:has(.ol-chat.is-open) .ol-main{padding-right:calc(var(--chat-w) + 1.5rem);}
```

The chat panel is `position: fixed`, so it takes no flow space and the reading
column has to reserve the gutter beside it. That gutter was `padding-right` —
and `.ol-main` is border-box with `max-width: 56rem`, so the gutter came out of
the 56rem cap rather than out of the free space beside it.

`--chat-w` is `max(21rem, 33vw)`, so the wider the screen the worse it gets. At
1920px the gutter is 33vw + 1.5rem ≈ 41rem, leaving `56 - 2 - 41 ≈ 13rem` of
content box — a ~200px text column, three or four words per line. The dead
space to the right is the gutter itself (inside `.ol-main`) plus the gap
between the 56rem cap and the panel's edge. A phone never showed it: the panel
is a full-width sheet there and the media query already zeroed the gutter.

## Which commit

Not #13. Generating the sheet at `b8e78c1` (pre-#13) and at `a0eab31` and
diffing them, the desktop `.ol-main` rule and the `:has(.ol-chat.is-open)`
overlay are byte-identical; #13 only touched phone-scoped padding, safe-area
insets, `100vh`→`100dvh` and touch targets.

It dates to `3cdedd2` — *web: the agent — chat panel over ACP, live outline
over SSE (#1)* — where the hand-written `olai/web/static/app.css` first paired
`.sf-main{max-width:56rem}` with `padding-right:calc(var(--chat-w) + 1.5rem)`
under the same border-box reset. `754c32e` (#6, CSS as code) transcribed it
verbatim into `olai/web/chat-panel.rkt`.

## Fix

`olai/web/chat-panel.rkt` — reserve the gutter as `margin-right`, not
`padding-right` (and `margin-right: 0` in the phone override). A margin sits
outside the border box, so `max-width: 56rem` still measures the reading
column, the flex box hands the panel the width it takes, and the text gets the
full column back. Same selector, same `'overlay` layer, one property.

Generated sheet, before and after:

```css
-body.ol-body:has(.ol-chat.is-open) .ol-main{padding-right:calc(var(--chat-w) + 1.5rem);}
-@media (max-width:48rem){body.ol-body:has(.ol-chat.is-open) .ol-main{padding-right:1rem;}}
+body.ol-body:has(.ol-chat.is-open) .ol-main{margin-right:calc(var(--chat-w) + 1.5rem);}
+@media (max-width:48rem){body.ol-body:has(.ol-chat.is-open) .ol-main{margin-right:0;}}
```

## Tested

`olai/tests/style.rkt` gains *"the chat gutter is reserved outside the reading
column's box"*, next to the ordering test that already has this overlay
fragment as its subject: the overlay declares `margin-right: calc(var(--chat-w)
…)` and declares no `padding-right` at all. It asks a property question, not a
serialization one — the canary in that file still owns css-expr's output text.
The test fails on the old rule and passes on the new one.

`just test`: 193 tests passed. Verified live as well — `olai serve` over
`examples/`, `GET /static/app.css` carries the margin form and no
`padding-right` on `.ol-main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)