### PR TITLE
cli: shrink to the agent surface — JSON always, no plain mode, no css

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,18 +16,20 @@ edit-verify loop and css-expr). This file is only what you can't infer.
 * No hand-rolling where a maintained library exists. In use: racket/cmdline,
   json (write-json/read-json), xml (xexprs), gregor (dates), markdown
   (title/note formatting in the web view only).
-* No ANSI. Human view is the web app: `olai serve` (routes in
+* No ANSI, no plain mode. Human view is the web app: `olai serve` (routes in
   docs/cli.md; `just serve` / `just run` / `just watch` all launch it).
-  Agents use `--json` (and `tree`, which is JSON-only).
+  The CLI is the agent surface and the write-safety layer: every command
+  answers JSON but `ics` (the format IS the reply) and `serve`. `--json` is
+  accepted everywhere it used to be, and does nothing.
 * The LANGUAGE is the only validator (closed grammar): one checker
   (lang/graph) runs over a module's syntax at compile time, and over the whole
   spliced tree at run time when it has `@include`s (cross-file anchors exist
   only after the splice). Same rules, same messages, both ways. Readers just
   translate to (t ...) forms. Never validate in the reader, the CLI, the
   store, or the web layer.
-* Agents are the primary CLI users: every command gets --json where it makes
-  sense; errors are JSON on stderr in --json mode; exit codes are contract
-  (see docs/cli.md). JSON fields are append-only within a "version".
+* Agents are the only CLI users: replies and errors are JSON (errors on
+  stderr); exit codes are contract (see docs/cli.md). JSON fields are
+  append-only within a "version".
 * Error messages carry file:line:col of the OFFENDING form. srcloc fidelity
   has tests; keep them passing.
 * Module boundaries ship with `contract-out` (flat, cheap checks — never a

--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ needs the network (SSE + agent). Live with it, or open your laptop.
 
 ## STATUS
 
-Outline `#lang olai` + sexp core + agent CLI (`check` / `tree` JSON /
-`agenda` / `calendar` / `add` / `done` / `move` / `daily` / `ics` /
-`serve` / `css`). Done status, mirrors and `@include` composition are first class;
+Outline `#lang olai` + sexp core + agent CLI (`check` / `tree` / `agenda` /
+`calendar` / `add` / `done` / `move` / `daily` / `ics` / `serve` — all JSON but
+`ics` and `serve`; the human-facing plain output and the `css` dump are
+retired). Done status, mirrors and `@include` composition are first class;
 mirrors reach anchors anywhere in the loaded tree, fragments included. The
 human view is the web app served by `olai serve` — htmx, no auth (bind
 it to localhost or Tailscale). It reloads an outline when the file changes
@@ -155,8 +156,9 @@ to the bundled, pinned Claude Code adapter (`--set-default`); `nix develop`
 
 ## CLI (agents)
 
-Machine-readable contract (`--json`, exit codes, `add`): **docs/cli.md**.
-No ANSI. Humans use the web app.
+Machine-readable contract (JSON shapes, exit codes, `add`): **docs/cli.md**.
+No ANSI, no plain mode — the CLI is the agent surface and the write-safety
+layer, and it answers in JSON. Humans use the web app.
 
 ## HACKING
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,24 +1,28 @@
 # olai CLI — agent contract
 
-Agents are the primary users. Prefer `--json`. Fields within a `version` are
-**append-only**; a bump of `version` is a breaking change.
+Agents are the only users. Every command that has a reply emits **JSON**,
+always — `--json` is still accepted and does nothing. Fields within a
+`version` are **append-only**; a bump of `version` is a breaking change.
 
-**Human view is the web app** (`olai/web`). There is no ANSI terminal
-tree and no static HTML export. Agents use `tree` / `check` / `agenda --json`.
+**Human view is the web app** (`olai/web`). There is no ANSI terminal tree, no
+static HTML export, and no plain-text mode: what was printed for a person to
+read at a terminal is gone. The two commands that do not answer JSON are the
+ones whose output IS a format — `ics` (RFC 5545) — and `serve`, which serves
+the web view; their errors are `olai: message` on stderr.
 
 ## Exit codes
 
 | Code | Meaning |
 |------|---------|
 | 0 | success |
-| 1 | usage: unknown command, bad flags, missing TITLE, a malformed `--date` / `--month` / `--port` |
+| 1 | usage: unknown command (`css` and `html` are retired), bad flags, missing TITLE, a malformed `--date` / `--month` / `--port` |
 | 2 | the outline said no: load or validation error, no such task, ambiguous title, already done, a write aimed at a `#lang olai/sexp` file |
 | 3 | file not found |
 
-Same codes for plain and `--json` modes. The write commands know nothing about
-exit codes: an op (`olai/ops`) fails with a KIND — usage, validation,
-not-found — and the CLI maps the kind to a code. The codes are the contract;
-the kinds are how the layer below talks about failure.
+The write commands know nothing about exit codes: an op (`olai/ops`) fails with
+a KIND — usage, validation, not-found — and the CLI maps the kind to a code.
+The codes are the contract; the kinds are how the layer below talks about
+failure.
 
 ## Global
 
@@ -26,11 +30,12 @@ the kinds are how the layer below talks about failure.
   `add` / `done` / `move` always target one file via `--file`, same default.
 - **`OLAI_HOME` has no default.** Unset, any command that would need it —
   the file defaults above, `daily` without `--home` — is a **usage error**
-  (exit 1, JSON on stderr under `--json`), nothing is read or written:
+  (exit 1, the error object on stderr), nothing is read or written:
 
-  ```console
-  $ olai add --no-commit "buy milk"
-  olai: OLAI_HOME is not set; set it to your outline directory, or name the outline explicitly (a path argument, --file, --home)
+  ```json
+  {"version":1,"ok":false,
+   "error":{"file":null,"line":null,"col":null,
+            "message":"OLAI_HOME is not set; set it to your outline directory, or name the outline explicitly (a path argument, --file, --home)"}}
   ```
 
   Naming files (or `--file` / `--home`) works with the variable unset.
@@ -43,22 +48,15 @@ the kinds are how the layer below talks about failure.
   names. Auto-commit (`add` / `done` / `move` / `daily`) only runs
   when the directory of the file actually written is a git work tree;
   otherwise it no-ops (`committed: false`) and Dropbox (or your sync) is the history layer.
-- `--json` may appear after the subcommand where supported.
+- `--json` may appear after the subcommand everywhere it used to; it is a
+  no-op, kept so an invocation an agent already knows does not become a
+  usage error.
 
-## `check [--json] [file ...]`
+## `check [file ...]`
 
 Validate `#lang olai` or `#lang olai/sexp` module(s).
 
-Plain — one ok-line per file; if any fail, all are reported then exit 2.
-Anchor / mirror / include counts are appended only when non-zero:
-
-```console
-$ olai check examples/Example.rkt examples/Daily.rkt
-ok: .../Example.rkt (12 tasks, 1 anchor, 1 mirror)
-ok: .../Daily.rkt (18 tasks, 2 anchors, 1 mirror, 2 includes)
-```
-
-JSON — **single file** keeps the historical shape:
+**Single file** keeps the historical shape:
 
 ```json
 {"version":1,"ok":true,"file":".../Example.rkt","tasks":12,"anchors":1,"mirrors":1}
@@ -92,10 +90,9 @@ Top-level `ok` is false if any file failed. Per-file errors ride in the array
 on **stdout** and nothing goes to stderr — the single-file shape is the one
 that reports on stderr (see *Errors*). Exit is still 2.
 
-## `tree [--json] [file ...]`
+## `tree [file ...]`
 
-**Always JSON** (the task forest). `--json` is accepted as a no-op for compat.
-Humans should use the web app.
+The task forest.
 
 Single file:
 
@@ -181,24 +178,15 @@ Load the files you always load (`serve` keys against the set it was given) and
 keys are stable. The web view addresses nodes by this key (element ids,
 permalinks, stored collapse state).
 
-## `agenda [--json] [file ...]`
+## `agenda [file ...]`
 
 Dated tasks relative to local today, **merged across all given files**. **Done
 tasks are excluded** even if they still have a `@date`. When more than one file
 is given, breadcrumbs are rooted at each file's basename
-(`Tasks.rkt > Inbox > Buy milk`). Plain mode is unstyled text. Empty groups are
-omitted in plain mode, and an agenda with nothing in it prints `no dated tasks`;
-JSON always includes all three arrays (possibly empty).
+(`Tasks.rkt > Inbox > Buy milk`). All three arrays are always present, possibly
+empty.
 
-Plain:
-
-```text
-OVERDUE
-  [2026-01-15T08:00]  Buy milk
-         Tasks.rkt > Inbox > Buy milk
-```
-
-JSON stdout:
+Stdout:
 
 ```json
 {
@@ -210,7 +198,7 @@ JSON stdout:
 }
 ```
 
-## `calendar [--json] [--month YYYY-MM] [file ...]`
+## `calendar [--month YYYY-MM] [file ...]`
 
 Group **dated** tasks by calendar day for one month (default: current).
 **Done tasks are included** (JSON `done` is `true` or a timestamp, `status` is
@@ -409,8 +397,8 @@ Routes:
 | `GET /chat/sessions` | the agent's stored conversations for this directory, JSON (see *Sessions*); `503` while the agent is gone |
 | `POST /chat/load` | load one of them; form field `id` (missing is `400`). `204` — the reset, the replayed turns and the `session` frame come back over `/events`. `409` while a turn or another load is running, `503` when the agent is gone |
 | `GET /api/tree` | byte-identical to `olai tree` |
-| `GET /api/agenda` | byte-identical to `olai agenda --json` |
-| `GET /static/app.css` | the skin, `text/css`, `Cache-Control: no-cache`. Generated from the Racket modules that draw the page — `olai/web/skin` composes them — not a file on disk. `olai css` prints the same bytes |
+| `GET /api/agenda` | byte-identical to `olai agenda` |
+| `GET /static/app.css` | the skin, `text/css`, `Cache-Control: no-cache`. Generated from the Racket modules that draw the page — `olai/web/skin` composes them — not a file on disk. This route is the only way to get those bytes; there is no `css` command |
 | `GET /static/manifest.webmanifest` | web app manifest (`application/manifest+json`); name, icons, `display: standalone`, default theme colours |
 | `GET /static/*` | files under `olai/web/static/` (icons, htmx, scripts, `pwa.js`) |
 | anything else | `404`, terse `text/plain` |
@@ -470,7 +458,7 @@ re-fetch themselves and swap the pane and the error banner — no refresh.
 
 A file is broken for a moment during every edit, so the two surfaces differ:
 
-- `/api/*` answers `500` with the JSON error object (same shape as `--json`
+- `/api/*` answers `500` with the JSON error object (same shape as the CLI's
   errors, `file` / `line` / `col` / `message`) — agents never get stale data
   quietly.
 - `/` keeps rendering the **last good** snapshot and puts the error, with its
@@ -488,13 +476,7 @@ exist, or a directory holds no top-level `*.rkt`.
 There is no static HTML export — `curl http://127.0.0.1:8080/ > snap.html`
 if you want one.
 
-## `css`
-
-The generated stylesheet on stdout — byte for byte what `GET /static/app.css`
-serves, composed by `olai/web/skin` out of the modules that draw the page. No
-`--json`: CSS is the output. Exit 0.
-
-## `add [--json] [--file F] [--date ISO] [--description TEXT] [--parent TITLE|^anchor] [--no-commit] TITLE...`
+## `add [--file F] [--date ISO] [--description TEXT] [--parent TITLE|^anchor] [--no-commit] TITLE...`
 
 `--date` accepts `YYYY-MM-DD` or a datetime (`YYYY-MM-DDTHH:MM` / `…:SS`; a space
 instead of `T` is fine).
@@ -508,14 +490,7 @@ words join with spaces (no shell quoting required).
   message `capture: TITLE` unless `--no-commit`.
 - Never prompts; never opens an editor.
 
-Plain:
-
-```console
-$ olai add --no-commit buy oat milk
-added "buy oat milk" under Inbox in .../Tasks.rkt (line 12)
-```
-
-JSON stdout:
+Stdout:
 
 ```json
 {
@@ -536,7 +511,7 @@ JSON stdout:
 the file actually written — with `--parent ^anchor` that may be an `@include`
 fragment, not `--file`.
 
-## `done [--json] [--file F] [--undo] [--no-commit] TITLE...|^anchor`
+## `done [--file F] [--undo] [--no-commit] TITLE...|^anchor`
 
 Mark a task done by exact title match or `^anchor` (or undo). **One file only**
 (`--file`). Writes **outline** syntax only — same safety as `add`: write temp →
@@ -554,14 +529,7 @@ re-validate → rename; restore on failure.
 - Auto-commit `done: TITLE` / `undone: TITLE` in a git work tree unless
   `--no-commit`.
 
-Plain:
-
-```console
-$ olai done --no-commit Buy milk
-done "Buy milk" in .../Tasks.rkt (line 5)
-```
-
-JSON stdout:
+Stdout:
 
 ```json
 {
@@ -578,7 +546,7 @@ JSON stdout:
 
 On `--undo`, `done` is `null` and `undone` is `true`.
 
-## `move [--json] [--file F] [--no-commit] [--clear] TITLE...|^anchor DATE`
+## `move [--file F] [--no-commit] [--clear] TITLE...|^anchor DATE`
 
 Set or rewrite `@date` on a task (same write-safety as `add`/`done`). `DATE`
 is ISO date or datetime. `--clear` removes `@date` instead (no DATE arg).
@@ -593,11 +561,16 @@ never the raw `^anchor` you passed.
 
 ## `ics [--out PATH] [file ...]`
 
-RFC 5545 `VCALENDAR` of all dated tasks (done included). Minimal writer —
-no catalog ics package. UID is `anchor@olai` when present, else a
-stable hash of path/title/date. `DTSTART` is `VALUE=DATE` or local datetime.
+RFC 5545 `VCALENDAR` of all dated tasks (done included) on stdout, or into
+`--out PATH` (which prints the path it wrote). Minimal writer — no catalog ics
+package. UID is `anchor@olai` when present, else a stable hash of
+path/title/date. `DTSTART` is `VALUE=DATE` or local datetime.
 
-## `daily [--json] [--date YYYY-MM-DD] [--home DIR] [--no-commit]`
+The one command whose output is neither JSON nor the web view: nothing else
+produces a calendar feed, so a calendar client is the consumer and the format
+is the reply. Errors are plain (`olai: ...`), exit codes as above.
+
+## `daily [--date YYYY-MM-DD] [--home DIR] [--no-commit]`
 
 Ensure a day node exists in the personal Daily structure under `$OLAI_HOME`
 (or `--home`):
@@ -624,9 +597,10 @@ Both `created_*` are `false` on every run after the first for that day, and
 tree (including fragments), then edit the **defining file** of that node.
 JSON `file` fields on tree nodes show where agents should write.
 
-## Errors (`--json`)
+## Errors
 
-Single object on **stderr**, exit non-zero:
+Single object on **stderr**, exit non-zero — for every command that replies in
+JSON, which is every one but `ics` and `serve`:
 
 ```json
 {
@@ -663,6 +637,22 @@ prefix in front of the answer. Agents must not regex pretty-printed messages.
 - Top-level objects always include `"version": 1`.
 - Within v1, new keys may appear; existing keys keep meaning and type.
 - Removing or renaming a key requires a version bump.
+- The JSON is the contract; the plain text that used to come out without
+  `--json` was not, and is gone. No key changed with it.
+
+## Retired
+
+The web app is the daily surface, so the CLI keeps only what an agent calls and
+what guards a write:
+
+| Gone | Instead |
+|------|---------|
+| plain output on `check` / `agenda` / `calendar` / `add` / `done` / `move` / `daily` | the same command, which now always emits its JSON |
+| `css` | `GET /static/app.css` from a running `serve`; in-tree, `racket -e '(require olai/web/skin) (displayln (stylesheet))'` |
+| `html` (earlier) | `serve`, or `curl http://127.0.0.1:8080/ > snap.html` |
+
+`--json` still parses everywhere it did. An invocation of a retired COMMAND is
+an unknown command: exit 1.
 
 ## Nix build note
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,9 +6,9 @@ always — `--json` is still accepted and does nothing. Fields within a
 
 **Human view is the web app** (`olai/web`). There is no ANSI terminal tree, no
 static HTML export, and no plain-text mode: what was printed for a person to
-read at a terminal is gone. The two commands that do not answer JSON are the
-ones whose output IS a format — `ics` (RFC 5545) — and `serve`, which serves
-the web view; their errors are `olai: message` on stderr.
+read at a terminal is gone. Two commands do not answer JSON — `ics`, whose
+output IS a format (RFC 5545), and `serve`, which serves the web view. Their
+errors are `olai: message` on stderr.
 
 ## Exit codes
 

--- a/justfile
+++ b/justfile
@@ -33,20 +33,23 @@ clean:
     set -euo pipefail
     find olai -type d -name compiled -print0 | xargs -0 rm -rf
 
+# The CLI answers in JSON (the human view is `just serve`); these recipes only
+# spell the default outlines.
+
 # Validate outline(s) (default: $OLAI_HOME/*.rkt, else the repo's own)
 check *args: install
     olai check {{if args == "" { default_outlines } else { args }}}
 
-# Outline(s) as JSON (agents; human view is the web app)
+# Outline(s) as JSON
 tree *args: install
     olai tree {{if args == "" { default_outlines } else { args }}}
 
-# Dated tasks: OVERDUE / TODAY / UPCOMING (merged across files, done excluded)
+# Dated tasks as JSON: overdue / today / upcoming (merged, done excluded)
 agenda *args: install
     olai agenda {{if args == "" { default_outlines } else { args }}}
 
 # Flags-only invocations (e.g. --month 2026-08) keep the default outlines.
-# Calendar days with dated items (default: current month, done included)
+# Calendar days as JSON (default: current month, done included)
 calendar *args: install
     #!/usr/bin/env bash
     set -euo pipefail

--- a/olai/agenda.rkt
+++ b/olai/agenda.rkt
@@ -1,18 +1,16 @@
 #lang racket/base
 
 ;; Pure agenda: collect dated tasks, sort by date, group vs a today string.
-;; Plain-text formatting only (no ANSI). Printing/clock live in the CLI.
+;; Rendering is the web view's or json/reply's; the clock is the CLI's.
 
-(require racket/string
-         (except-in olai/lang/expander #%module-begin) ; task
+(require (except-in olai/lang/expander #%module-begin) ; task
          olai/dates
          olai/query)
 
 (provide (struct-out dated-task)
          collect-dated
          agenda-groups
-         agenda-groups-from-files
-         format-agenda)
+         agenda-groups-from-files)
 
 ;; date: ISO date or datetime string (YYYY-MM-DD[THH:MM[:SS]])
 ;; title: task title
@@ -58,31 +56,3 @@
    (with-file-roots file-entries
                     (λ (tasks root) (collect-dated tasks #:root root)))
    today))
-
-(define (group-header sym)
-  (case sym
-    [(overdue) "OVERDUE"]
-    [(today) "TODAY"]
-    [(upcoming) "UPCOMING"]
-    [else (symbol->string sym)]))
-
-(define (format-dated-task it)
-  (define line1
-    (format "  [~a]  ~a" (dated-task-date it) (dated-task-title it)))
-  (define line2
-    (string-append "         " (dated-task-breadcrumb it)))
-  (string-append line1 "\n" line2))
-
-;; Render grouped agenda to a string. Empty => "no dated tasks".
-(define (format-agenda groups)
-  (if (null? groups)
-      "no dated tasks"
-      (string-join
-       (for/list ([g (in-list groups)])
-         (define header (group-header (car g)))
-         (define body
-           (string-join
-            (map format-dated-task (cdr g))
-            "\n"))
-         (string-append header "\n" body))
-       "\n\n")))

--- a/olai/calendar.rkt
+++ b/olai/calendar.rkt
@@ -26,8 +26,7 @@
          month-grid-cells
          parse-year-month
          shift-year-month
-         format-year-month
-         format-calendar)
+         format-year-month)
 
 ;; done:   the stored field, #f | #t | ISO timestamp (what JSON serializes)
 ;; status: what that MEANS — 'open | 'done, derived once (lang/expander)
@@ -139,27 +138,3 @@
   (if (zero? rem)
       cells
       (append cells (make-list (- 7 rem) #f))))
-
-(define (format-calendar cal-hash)
-  (define lines
-    (cons
-     (format "CALENDAR ~a" (hash-ref cal-hash 'month))
-     (append*
-      (for/list ([d (in-list (hash-ref cal-hash 'days))])
-        (define date (hash-ref d 'date))
-        (define node? (hash-ref d 'day_node #f))
-        (define head
-          (string-append date (if node? "  (day notes)" "")))
-        (cons head
-              (for/list ([it (in-list (hash-ref d 'items))])
-                (define mark
-                  (case (cal-item-status it)
-                    [(done) "  [x] "]
-                    [else "  - "]))
-                (string-append
-                 mark (cal-item-title it)
-                 "  [" (cal-item-date it) "]"
-                 (if (non-empty-string? (cal-item-breadcrumb it))
-                     (string-append "\n         " (cal-item-breadcrumb it))
-                     ""))))))))
-  (string-join lines "\n"))

--- a/olai/cli.rkt
+++ b/olai/cli.rkt
@@ -1,6 +1,9 @@
 #lang racket/base
 
-;; olai CLI — agent-first: check | tree | agenda | add | done | move | css
+;; olai CLI — the agent tool surface and the write-safety layer, nothing else.
+;; The human view is the web app (`olai serve`), so every command that has a
+;; JSON reply emits it always: --json is accepted and does nothing. `ics`
+;; (its output IS the format) and `serve` are the exceptions and talk plain.
 ;; Exit codes: 0 ok, 1 usage, 2 validation/load, 3 not found.
 ;; Arg parsing: racket/cmdline. JSON: json package write-json.
 
@@ -23,8 +26,6 @@
          olai/ops
          (only-in olai/paths dir-roots)
          (only-in olai/acp acp-command-problem)
-         ;; the skin, for `css`: the same string the server answers with
-         (only-in olai/web/skin stylesheet)
          olai/web/serve)
 (define exit-ok 0)
 (define exit-usage 1)
@@ -50,6 +51,10 @@
 (define (default-file)
   (path->string (build-path (olai-home) "Tasks.rkt")))
 
+;; Two error surfaces, one per output kind: the error object on stderr for the
+;; JSON commands (everything an agent drives), `olai: message` for the two that
+;; do not speak JSON at all — `ics` and `serve`, which have no envelope to put
+;; it in.
 (define (die code msg #:json? json? #:file [file #f] #:line [line #f] #:col [col #f])
   (if json?
       (write-json-stderr (err-hash msg #:file file #:line line #:col col))
@@ -91,23 +96,7 @@
 (define (today-iso)
   (today-iso-string))
 
-(define (format-check-plain path n anchors mirrors includes)
-  (define extras
-    (filter values
-            (list (and (positive? anchors)
-                       (format "~a anchor~a" anchors (if (= anchors 1) "" "s")))
-                  (and (positive? mirrors)
-                       (format "~a mirror~a" mirrors (if (= mirrors 1) "" "s")))
-                  (and (positive? (length includes))
-                       (format "~a include~a" (length includes)
-                               (if (= (length includes) 1) "" "s"))))))
-  (if (null? extras)
-      (format "ok: ~a (~a task~a)\n" path n (if (= n 1) "" "s"))
-      (format "ok: ~a (~a task~a, ~a)\n"
-              path n (if (= n 1) "" "s")
-              (string-join extras ", "))))
-
-(define (cmd-check paths json?)
+(define (cmd-check paths)
   (define results
     (for/list ([path (in-list paths)])
       (match (try-load-outline path)
@@ -120,64 +109,53 @@
         [(load-error msg src line col)
          (list 'error path msg src line col)])))
   (define any-bad? (ormap (λ (r) (eq? (car r) 'error)) results))
-  (cond
-    [json?
-     (if (= (length paths) 1)
-         (match (car results)
-           [(list 'ok path n ac mc includes)
-            (write-json-stdout
-             (let ([h (ok-hash 'file (path->string path)
-                               'tasks n
-                               'anchors ac
-                               'mirrors mc)])
-               (if (null? includes)
-                   h
-                   (hash-set h 'includes
-                             (for/list ([p includes])
-                               (hash 'file p))))))]
-           [(list 'error path msg src line col)
-            (die exit-validation msg #:json? #t #:file src #:line line #:col col)])
-         (let ([files
-                (for/list ([r (in-list results)])
-                  (match r
-                    [(list 'ok path n ac mc includes)
-                     (define h
-                       (hash 'file (path->string path)
-                             'ok #t
-                             'tasks n
-                             'anchors ac
-                             'mirrors mc))
-                     (if (null? includes)
-                         h
-                         (hash-set h 'includes
-                                   (for/list ([p includes])
-                                     (hash 'file p))))]
-                    [(list 'error path msg src line col)
-                     (hash 'file (path->string path)
-                           'ok #f
-                           'error (hash 'file (nullish (and src
-                                                            (if (path? src)
-                                                                (path->string src)
-                                                                src)))
-                                        'line (nullish line)
-                                        'col (nullish col)
-                                        'message msg))]))])
-           (write-json-stdout
-            (hash 'version json-reply-version
-                  'ok (not any-bad?)
-                  'files files))
-           (when any-bad? (exit exit-validation))))]
-    [else
-     (for ([r (in-list results)])
-       (match r
-         [(list 'ok path n ac mc includes)
-          (display (format-check-plain path n ac mc includes))]
-         [(list 'error path msg src line col)
-          (eprintf "olai: failed to load ~a\n~a\n" path msg)]))
-     (when any-bad? (exit exit-validation))]))
+  (if (= (length paths) 1)
+      (match (car results)
+        [(list 'ok path n ac mc includes)
+         (write-json-stdout
+          (let ([h (ok-hash 'file (path->string path)
+                            'tasks n
+                            'anchors ac
+                            'mirrors mc)])
+            (if (null? includes)
+                h
+                (hash-set h 'includes
+                          (for/list ([p includes])
+                            (hash 'file p))))))]
+        [(list 'error path msg src line col)
+         (die exit-validation msg #:json? #t #:file src #:line line #:col col)])
+      (let ([files
+             (for/list ([r (in-list results)])
+               (match r
+                 [(list 'ok path n ac mc includes)
+                  (define h
+                    (hash 'file (path->string path)
+                          'ok #t
+                          'tasks n
+                          'anchors ac
+                          'mirrors mc))
+                  (if (null? includes)
+                      h
+                      (hash-set h 'includes
+                                (for/list ([p includes])
+                                  (hash 'file p))))]
+                 [(list 'error path msg src line col)
+                  (hash 'file (path->string path)
+                        'ok #f
+                        'error (hash 'file (nullish (and src
+                                                         (if (path? src)
+                                                             (path->string src)
+                                                             src)))
+                                     'line (nullish line)
+                                     'col (nullish col)
+                                     'message msg))]))])
+        (write-json-stdout
+         (hash 'version json-reply-version
+               'ok (not any-bad?)
+               'files files))
+        (when any-bad? (exit exit-validation)))))
 
-;; tree is JSON-only (human view is the web app). --json is accepted as a no-op.
-(define (cmd-tree paths json?)
+(define (cmd-tree paths)
   (define entries
     (mint-outline-keys
      (for/list ([path (in-list paths)])
@@ -185,32 +163,25 @@
        (outline path tasks anchors includes))))
   (write-json-stdout (outlines->jsexpr entries)))
 
-(define (cmd-agenda paths json?)
+(define (cmd-agenda paths)
   (define entries
     (for/list ([path (in-list paths)])
-      (cons path (load-tasks path json?))))
+      (cons path (load-tasks path #t))))
   (define today (today-iso))
-  (define groups (agenda-groups-from-files entries today))
-  (if json?
-      (write-json-stdout (agenda-groups->jsexpr groups today))
-      (displayln (format-agenda groups))))
+  (write-json-stdout
+   (agenda-groups->jsexpr (agenda-groups-from-files entries today) today)))
 
-(define (cmd-calendar paths json? month)
+(define (cmd-calendar paths month)
   (define entries
     (for/list ([path (in-list paths)])
-      (cons path (load-tasks path json?))))
-  (define today (today-iso))
-  (define ym
-    (or month (substring today 0 7)))
+      (cons path (load-tasks path #t))))
+  (define ym (or month (substring (today-iso) 0 7)))
   (define-values (y m) (parse-year-month ym))
   (unless y
     (die exit-usage
          (format "invalid --month ~s; expected YYYY-MM" ym)
-         #:json? json?))
-  (define cal (calendar-from-files entries ym))
-  (if json?
-      (write-json-stdout (calendar->jsexpr cal))
-      (displayln (format-calendar cal))))
+         #:json? #t))
+  (write-json-stdout (calendar->jsexpr (calendar-from-files entries ym))))
 
 ;; ---- write commands: parse, call the op, render --------------------------
 ;;
@@ -239,111 +210,77 @@
         (λ (e) (die exit-validation (exn-message e) #:json? json?))])
     (thunk)))
 
-(define (committed-suffix committed?)
-  (if committed? ", committed" ""))
-
-(define (cmd-add json? file-arg date desc no-commit? parent title-parts)
+(define (cmd-add file-arg date desc no-commit? parent title-parts)
   (when (null? title-parts)
-    (die exit-usage "add requires a TITLE" #:json? json?))
+    (die exit-usage "add requires a TITLE" #:json? #t))
   (define title (string-join title-parts " "))
   (define r
-    (run-op json?
+    (run-op #t
             (λ ()
               (ops-add! (or file-arg (default-file)) title
                         #:date date
                         #:description desc
                         #:parent parent
                         #:commit? (not no-commit?)))))
-  (if json?
-      (write-json-stdout
-       (ok-hash 'file (add-result-file r)
-                'title (add-result-title r)
-                'date (nullish (add-result-date r))
-                'description (nullish (add-result-description r))
-                'parent (nullish (add-result-parent r))
-                'line (add-result-line r)
-                'created_inbox (add-result-created-inbox? r)
-                'committed (add-result-committed? r)))
-      (printf "added ~s under ~a in ~a (line ~a)~a\n"
-              (add-result-title r)
-              (or (add-result-parent r) "Inbox")
-              (add-result-file r)
-              (add-result-line r)
-              (committed-suffix (add-result-committed? r)))))
+  (write-json-stdout
+   (ok-hash 'file (add-result-file r)
+            'title (add-result-title r)
+            'date (nullish (add-result-date r))
+            'description (nullish (add-result-description r))
+            'parent (nullish (add-result-parent r))
+            'line (add-result-line r)
+            'created_inbox (add-result-created-inbox? r)
+            'committed (add-result-committed? r))))
 
-(define (cmd-done json? file-arg undo? no-commit? title-parts)
+(define (cmd-done file-arg undo? no-commit? title-parts)
   (when (null? title-parts)
-    (die exit-usage "done requires a TITLE" #:json? json?))
+    (die exit-usage "done requires a TITLE" #:json? #t))
   (define spec (string-join title-parts " "))
   (define r
-    (run-op json?
+    (run-op #t
             (λ ()
               (ops-done! (or file-arg (default-file)) spec (today-iso)
                          #:undo? undo?
                          #:commit? (not no-commit?)))))
-  (if json?
-      (write-json-stdout
-       (ok-hash 'file (done-result-file r)
-                'title (done-result-title r)
-                'line (done-result-line r)
-                'done (nullish (done-result-done r))
-                'undone (done-result-undone? r)
-                'committed (done-result-committed? r)))
-      (printf "~a ~s in ~a (line ~a)~a\n"
-              (if (done-result-undone? r) "undone" "done")
-              (done-result-title r)
-              (done-result-file r)
-              (done-result-line r)
-              (committed-suffix (done-result-committed? r)))))
+  (write-json-stdout
+   (ok-hash 'file (done-result-file r)
+            'title (done-result-title r)
+            'line (done-result-line r)
+            'done (nullish (done-result-done r))
+            'undone (done-result-undone? r)
+            'committed (done-result-committed? r))))
 
-(define (cmd-move json? file-arg no-commit? clear? title-parts date-arg)
+(define (cmd-move file-arg no-commit? clear? title-parts date-arg)
   (when (null? title-parts)
-    (die exit-usage "move requires TITLE|^anchor" #:json? json?))
+    (die exit-usage "move requires TITLE|^anchor" #:json? #t))
   (define spec (string-join title-parts " "))
   (define r
-    (run-op json?
+    (run-op #t
             (λ ()
               (ops-move! (or file-arg (default-file)) spec date-arg
                          #:clear? clear?
                          #:commit? (not no-commit?)))))
-  (if json?
-      (write-json-stdout
-       (ok-hash 'file (move-result-file r)
-                'title (move-result-title r)
-                'line (move-result-line r)
-                'date (nullish (move-result-date r))
-                'committed (move-result-committed? r)))
-      (printf "moved ~s in ~a (line ~a)~a~a\n"
-              (move-result-title r)
-              (move-result-file r)
-              (move-result-line r)
-              (if (move-result-date r)
-                  (format " -> ~a" (move-result-date r))
-                  " date cleared")
-              (committed-suffix (move-result-committed? r)))))
+  (write-json-stdout
+   (ok-hash 'file (move-result-file r)
+            'title (move-result-title r)
+            'line (move-result-line r)
+            'date (nullish (move-result-date r))
+            'committed (move-result-committed? r))))
 
-(define (cmd-daily json? date-arg home-arg no-commit?)
+(define (cmd-daily date-arg home-arg no-commit?)
   (define r
-    (run-op json?
+    (run-op #t
             (λ ()
               (ops-daily! (or home-arg (path->string (olai-home)))
                           (or date-arg (today-iso))
                           #:commit? (not no-commit?)))))
-  (if json?
-      (write-json-stdout
-       (ok-hash 'day (daily-result-day r)
-                'file (daily-result-file r)
-                'created_month (daily-result-created-month? r)
-                'created_day (daily-result-created-day? r)
-                'line (daily-result-line r)
-                'committed (daily-result-committed? r)))
-      (printf "daily ~a in ~a (line ~a)~a~a~a\n"
-              (daily-result-day r)
-              (daily-result-file r)
-              (daily-result-line r)
-              (if (daily-result-created-month? r) ", created month" "")
-              (if (daily-result-created-day? r) ", created day" "")
-              (committed-suffix (daily-result-committed? r)))))
+  (write-json-stdout
+   (ok-hash 'day (daily-result-day r)
+            'file (daily-result-file r)
+            'created_month (daily-result-created-month? r)
+            'created_day (daily-result-created-day? r)
+            'line (daily-result-line r)
+            'committed (daily-result-committed? r))))
 
 (define (cmd-ics paths out-path)
   (define entries
@@ -432,81 +369,77 @@
   (custodian-shutdown-all cust)
   (exit exit-ok))
 
-;; The skin on stdout, the same bytes /static/app.css serves. No --json: CSS
-;; is the output, and a diff of two of these is how you read a skin change.
-(define (cmd-css)
-  (displayln (stylesheet))
-  (exit exit-ok))
-
 (define (usage)
   (eprintf "usage: olai <command> [options] ...\n")
   (eprintf "\n")
   (eprintf "commands:\n")
-  (eprintf "  check    [--json] [file ...]  validate outline(s) (default: $OLAI_HOME/Tasks.rkt)\n")
-  (eprintf "  tree     [--json] [file ...]  outline(s) as JSON (human view: web)\n")
-  (eprintf "  agenda   [--json] [file ...]  OVERDUE / TODAY / UPCOMING (merged)\n")
-  (eprintf "  calendar [--json] [--month YYYY-MM] [file ...]  days with dated items\n")
+  (eprintf "  check    [file ...]  validate outline(s) (default: $OLAI_HOME/Tasks.rkt)\n")
+  (eprintf "  tree     [file ...]  outline(s) as JSON\n")
+  (eprintf "  agenda   [file ...]  overdue / today / upcoming (merged)\n")
+  (eprintf "  calendar [--month YYYY-MM] [file ...]  days with dated items\n")
   (eprintf "  serve    [--port N] [--bind ADDR] [DIR | file ...]  web view (Ctrl-C to stop)\n")
   (eprintf "           DIR (default: .) serves DIR/*.rkt; the agent works in DIR\n")
-  (eprintf "  add      [--json] [--file F] [--date ISO] [--description TEXT]\n")
+  (eprintf "  add      [--file F] [--date ISO] [--description TEXT]\n")
   (eprintf "           [--parent TITLE|^anchor] [--no-commit] TITLE...\n")
-  (eprintf "  done     [--json] [--file F] [--undo] [--no-commit] TITLE|^anchor\n")
-  (eprintf "  move     [--json] [--file F] [--no-commit] [--clear] TITLE|^anchor DATE\n")
-  (eprintf "  daily    [--json] [--date YYYY-MM-DD] [--home DIR] [--no-commit]\n")
+  (eprintf "  done     [--file F] [--undo] [--no-commit] TITLE|^anchor\n")
+  (eprintf "  move     [--file F] [--no-commit] [--clear] TITLE|^anchor DATE\n")
+  (eprintf "  daily    [--date YYYY-MM-DD] [--home DIR] [--no-commit]\n")
   (eprintf "           ensure today in Daily/\n")
   (eprintf "  ics      [--out PATH] [file ...]  RFC 5545 VCALENDAR of dated tasks\n")
-  (eprintf "  css      the generated stylesheet on stdout (what serve answers)\n")
   (eprintf "\n")
+  (eprintf "everything but ics and serve replies in JSON; --json does nothing.\n")
+  (eprintf "the human view is the web app: olai serve\n")
   (eprintf "exit codes: 0 ok | 1 usage | 2 validation/load | 3 not found\n")
   (eprintf "agent contract: docs/cli.md\n"))
 
 ;; ---- subcommand parsers via racket/cmdline ----
+;;
+;; `--json` is what agents already type. The output is JSON either way now, so
+;; the flag stays as a no-op rather than turning a working invocation into a
+;; usage error.
+(define json-noop "No-op (the reply is always JSON)")
 
 (define (cli-check)
-  (define json? #f)
   (define file-args '())
   (command-line
    #:program "olai check"
    #:once-each
-   [("--json") "Emit versioned JSON on stdout" (set! json? #t)]
+   [("--json") "No-op (the reply is always JSON)" (void)]
    #:args paths
    (set! file-args paths))
-  (cmd-check (resolve-files file-args json?) json?))
+  (cmd-check (resolve-files file-args #t)))
 
 (define (cli-tree)
-  (define json? #t) ; always JSON; flag kept as no-op for agents
   (define file-args '())
   (command-line
    #:program "olai tree"
    #:once-each
-   [("--json") "No-op (tree is always JSON)" (set! json? #t)]
+   [("--json") "No-op (the reply is always JSON)" (void)]
    #:args paths
    (set! file-args paths))
-  (cmd-tree (resolve-files file-args #t) #t))
+  (cmd-tree (resolve-files file-args #t)))
 
 (define (cli-agenda)
-  (define json? #f)
   (define file-args '())
   (command-line
    #:program "olai agenda"
    #:once-each
-   [("--json") "Emit versioned JSON on stdout" (set! json? #t)]
+   [("--json") "No-op (the reply is always JSON)" (void)]
    #:args paths
    (set! file-args paths))
-  (cmd-agenda (resolve-files file-args json?) json?))
+  (cmd-agenda (resolve-files file-args #t)))
 
 (define (cli-calendar)
-  (define json? #f)
   (define month #f)
   (define file-args '())
   (command-line
    #:program "olai calendar"
    #:once-each
-   [("--json") "Emit versioned JSON on stdout" (set! json? #t)]
+   [("--json") "No-op (the reply is always JSON)" (void)]
    [("--month") m "Month YYYY-MM (default: current)" (set! month m)]
    #:args paths
    (set! file-args paths))
-  (cmd-calendar (resolve-files file-args json?) json? month))
+  (cmd-calendar (resolve-files file-args #t) month))
 
 (define (cli-serve)
   (define port 8080)
@@ -528,7 +461,6 @@
   (cmd-serve roots dir port (if (string=? bind "") #f bind)))
 
 (define (cli-add)
-  (define json? #f)
   (define file-arg #f)
   (define date #f)
   (define desc #f)
@@ -538,7 +470,7 @@
   (command-line
    #:program "olai add"
    #:once-each
-   [("--json") "Emit versioned JSON on stdout" (set! json? #t)]
+   [("--json") "No-op (the reply is always JSON)" (void)]
    [("--file") f "Outline file (default: $OLAI_HOME/Tasks.rkt)" (set! file-arg f)]
    [("--date") d "ISO date or datetime (YYYY-MM-DD[THH:MM[:SS]])" (set! date d)]
    [("--description") t "Description text" (set! desc t)]
@@ -546,10 +478,9 @@
    [("--no-commit") "Do not auto-commit even in a git repo" (set! no-commit? #t)]
    #:args title-words
    (set! titles title-words))
-  (cmd-add json? file-arg date desc no-commit? parent titles))
+  (cmd-add file-arg date desc no-commit? parent titles))
 
 (define (cli-done)
-  (define json? #f)
   (define file-arg #f)
   (define undo? #f)
   (define no-commit? #f)
@@ -557,16 +488,15 @@
   (command-line
    #:program "olai done"
    #:once-each
-   [("--json") "Emit versioned JSON on stdout" (set! json? #t)]
+   [("--json") "No-op (the reply is always JSON)" (void)]
    [("--file") f "Outline file (default: $OLAI_HOME/Tasks.rkt)" (set! file-arg f)]
    [("--undo") "Remove done state instead of marking done" (set! undo? #t)]
    [("--no-commit") "Do not auto-commit even in a git repo" (set! no-commit? #t)]
    #:args title-words
    (set! titles title-words))
-  (cmd-done json? file-arg undo? no-commit? titles))
+  (cmd-done file-arg undo? no-commit? titles))
 
 (define (cli-move)
-  (define json? #f)
   (define file-arg #f)
   (define no-commit? #f)
   (define clear? #f)
@@ -574,7 +504,7 @@
   (command-line
    #:program "olai move"
    #:once-each
-   [("--json") "Emit versioned JSON on stdout" (set! json? #t)]
+   [("--json") "No-op (the reply is always JSON)" (void)]
    [("--file") f "Outline file (default: $OLAI_HOME/Tasks.rkt)" (set! file-arg f)]
    [("--no-commit") "Do not auto-commit even in a git repo" (set! no-commit? #t)]
    [("--clear") "Remove @date instead of setting one" (set! clear? #t)]
@@ -583,13 +513,13 @@
   ;; Last arg is DATE unless --clear; rest is TITLE.
   (cond
     [clear?
-     (cmd-move json? file-arg no-commit? #t words #f)]
+     (cmd-move file-arg no-commit? #t words #f)]
     [(null? words)
-     (die exit-usage "move requires TITLE|^anchor DATE" #:json? json?)]
+     (die exit-usage "move requires TITLE|^anchor DATE" #:json? #t)]
     [else
      (define date-arg (last words))
      (define title-parts (drop-right words 1))
-     (cmd-move json? file-arg no-commit? #f title-parts date-arg)]))
+     (cmd-move file-arg no-commit? #f title-parts date-arg)]))
 
 (define (cli-ics)
   (define out-path #f)
@@ -602,28 +532,20 @@
    (set! file-args paths))
   (cmd-ics (resolve-files file-args #f) out-path))
 
-(define (cli-css)
-  (command-line
-   #:program "olai css"
-   #:args ()
-   (void))
-  (cmd-css))
-
 (define (cli-daily)
-  (define json? #f)
   (define date-arg #f)
   (define home-arg #f)
   (define no-commit? #f)
   (command-line
    #:program "olai daily"
    #:once-each
-   [("--json") "Emit versioned JSON on stdout" (set! json? #t)]
+   [("--json") "No-op (the reply is always JSON)" (void)]
    [("--date") d "Day YYYY-MM-DD (default: today)" (set! date-arg d)]
    [("--home") h "Outline home (default: $OLAI_HOME)" (set! home-arg h)]
    [("--no-commit") "Do not auto-commit even in a git repo" (set! no-commit? #t)]
    #:args ()
    (void))
-  (cmd-daily json? date-arg home-arg no-commit?))
+  (cmd-daily date-arg home-arg no-commit?))
 
 (define (main)
   (define argv (current-command-line-arguments))
@@ -654,7 +576,6 @@
            [("move") (cli-move)]
            [("daily") (cli-daily)]
            [("ics") (cli-ics)]
-           [("css") (cli-css)]
            [else
             (die exit-usage (format "unknown command ~s" cmd) #:json? #f)])))]))
 

--- a/olai/tests/agenda.rkt
+++ b/olai/tests/agenda.rkt
@@ -71,9 +71,6 @@
     (check-equal? (map car (agenda-groups only-past "2026-08-03"))
                   '(overdue)))
 
-  (test-case "format-agenda empty message"
-    (check-equal? (format-agenda '()) "no dated tasks"))
-
   (test-case "datetime on today buckets as TODAY; sorts by full timestamp"
     (define sample
       (list

--- a/olai/tests/calendar.rkt
+++ b/olai/tests/calendar.rkt
@@ -2,7 +2,6 @@
 
 (require rackunit
          racket/set
-         racket/string
          (except-in olai/lang/expander #%module-begin)
          olai/calendar
          olai/dates)
@@ -75,15 +74,4 @@
   (test-case "shift-year-month"
     (check-equal? (shift-year-month "2026-08" -1) "2026-07")
     (check-equal? (shift-year-month "2026-01" -1) "2025-12")
-    (check-equal? (shift-year-month "2026-12" 1) "2027-01"))
-
-  (test-case "format-calendar plain"
-    (define cal
-      (calendar-for-month
-       (list (cal-item "2026-08-04" "X" "A > X" #f 'open #f))
-       (set)
-       "2026-08"))
-    (define s (format-calendar cal))
-    (check-true (string-contains? s "CALENDAR 2026-08") s)
-    (check-true (string-contains? s "2026-08-04") s)
-    (check-true (string-contains? s "X") s)))
+    (check-equal? (shift-year-month "2026-12" 1) "2027-01")))

--- a/olai/tests/integration/cli-multi.rkt
+++ b/olai/tests/integration/cli-multi.rkt
@@ -32,12 +32,6 @@
        (check-equal? (hash-ref j1 'ok) #t)
        (check-true (list? (hash-ref j1 'files)))
        (check-equal? (length (hash-ref j1 'files)) 2)
-       (define-values (cplain oplain eplain)
-         (run-olai
-          (list "check" (path->string good) (path->string other))))
-       (check-equal? cplain 0 eplain)
-       (check-true (regexp-match? #rx"ok:.*good\\.rkt" oplain) oplain)
-       (check-true (regexp-match? #rx"ok:.*other\\.rkt" oplain) oplain)
        ;; one bad
        (display-to-file "#lang olai\nX\n  @date bogus\n" bad
                         #:exists 'truncate)
@@ -52,12 +46,12 @@
        (check-equal? (length files) 2)
        (check-equal? (hash-ref (car files) 'ok) #t)
        (check-equal? (hash-ref (cadr files) 'ok) #f)
-       (define-values (c3 o3 e3)
-         (run-olai
-          (list "check" (path->string good) (path->string bad))))
-       (check-equal? c3 2)
-       (check-true (regexp-match? #rx"ok:.*good\\.rkt" o3) o3)
-       (check-true (regexp-match? #rx"(?i:fail|date)" e3) e3))
+       ;; per-file errors ride the array on stdout; stderr stays empty
+       (check-equal? (string-trim e2) "" e2)
+       (define err2 (hash-ref (cadr files) 'error))
+       (check-true (hash-has-key? err2 'message))
+       (check-true (regexp-match? #rx"(?i:date)" (hash-ref err2 'message))
+                   (hash-ref err2 'message)))
      (λ () (delete-directory/files dir))))
 
   (test-case "multi-file tree JSON shape"

--- a/olai/tests/integration/cli-read.rkt
+++ b/olai/tests/integration/cli-read.rkt
@@ -9,20 +9,43 @@
          "cli-util.rkt")
 
 (module+ test
-  (test-case "check example succeeds"
+  ;; There is no plain mode left to test: the reply is JSON with or without
+  ;; the flag agents already type.
+  (test-case "check is always JSON (with or without --json)"
     (define-values (code out err) (run-olai (list "check" (path->string example))))
-    (check-equal? code 0 out)
-    (check-regexp-match #rx"^ok:" out))
-
-  (test-case "check --json shape"
-    (define-values (code out err)
-      (run-olai (list "check" "--json" (path->string example))))
     (check-equal? code 0 (string-append out err))
     (define j (parse-json out))
     (check-equal? (hash-ref j 'version) 1)
     (check-equal? (hash-ref j 'ok) #t)
     (check-true (hash-has-key? j 'file))
-    (check-true (exact-positive-integer? (hash-ref j 'tasks))))
+    (check-true (exact-positive-integer? (hash-ref j 'tasks)))
+    (define-values (c2 o2 e2)
+      (run-olai (list "check" "--json" (path->string example))))
+    (check-equal? c2 0 (string-append o2 e2))
+    (check-equal? (hash-ref (parse-json o2) 'ok) #t))
+
+  (test-case "agenda is always JSON"
+    (define-values (code out err)
+      (run-olai (list "agenda" (path->string example))))
+    (check-equal? code 0 (string-append out err))
+    (define j (parse-json out))
+    (check-equal? (hash-ref j 'version) 1)
+    (check-true (list? (hash-ref j 'overdue))))
+
+  (test-case "calendar is always JSON"
+    (define-values (code out err)
+      (run-olai (list "calendar" "--month" "2026-08" (path->string example))))
+    (check-equal? code 0 (string-append out err))
+    (define j (parse-json out))
+    (check-equal? (hash-ref j 'version) 1)
+    (check-equal? (hash-ref j 'month) "2026-08")
+    (check-true (list? (hash-ref j 'days))))
+
+  ;; The retired commands are gone, not quietly ignored.
+  (test-case "css is not a command"
+    (define-values (code out err) (run-olai (list "css")))
+    (check-equal? code 1)
+    (check-true (regexp-match? #rx"unknown command" err) err))
 
   (test-case "tree is always JSON (with or without --json)"
     (define-values (code out err)
@@ -62,20 +85,17 @@
     (check-true (hash-has-key? item 'date))
     (check-true (hash-has-key? item 'breadcrumb)))
 
-  (test-case "check missing file exits 3"
-    (define-values (code out err)
-      (run-olai (list "check" "/tmp/olai-no-such-file-xyz.rkt")))
-    (check-equal? code 3)
-    (check-regexp-match #rx"not found" err))
-
-  (test-case "check missing file --json exits 3 with error object"
-    (define-values (code out err)
-      (run-olai (list "check" "--json" "/tmp/olai-no-such-file-xyz.rkt")))
-    (check-equal? code 3)
-    (define j (parse-json err))
-    (check-equal? (hash-ref j 'ok) #f)
-    (check-equal? (hash-ref j 'version) 1)
-    (check-true (hash-has-key? (hash-ref j 'error) 'message)))
+  ;; Errors are the error object on stderr, flag or no flag.
+  (test-case "check missing file exits 3 with error object"
+    (for ([args (in-list (list (list "check" "/tmp/olai-no-such-file-xyz.rkt")
+                               (list "check" "--json"
+                                     "/tmp/olai-no-such-file-xyz.rkt")))])
+      (define-values (code out err) (run-olai args))
+      (check-equal? code 3)
+      (define j (parse-json err))
+      (check-equal? (hash-ref j 'ok) #f)
+      (check-equal? (hash-ref j 'version) 1)
+      (check-true (hash-has-key? (hash-ref j 'error) 'message))))
 
   (test-case "check invalid date exits 2"
     (define tmp (make-temporary-file "sf~a.rkt"))

--- a/site/index.html
+++ b/site/index.html
@@ -254,11 +254,12 @@ error messages:</p>
 
 <h2>Agents are the primary CLI users</h2>
 
-<p>Every command that can carry <code>--json</code> does. Errors are JSON on
-stderr in <code>--json</code> mode. Exit codes are contract: <b>0</b> ok,
+<p>They are the only ones. Every command replies in JSON — always, with or
+without <code>--json</code>, which is still accepted and does nothing — and
+errors are the error object on stderr. Exit codes are contract: <b>0</b> ok,
 <b>1</b> usage, <b>2</b> the outline said no, <b>3</b> file not found. JSON
 fields are append-only within a <code>version</code>. No ANSI, no terminal
-tree — the human view is the web app.</p>
+tree, no plain mode — the human view is the web app.</p>
 
 <pre><code>$ olai tree examples/Example.rkt
 {
@@ -289,7 +290,7 @@ renaming the node or any ancestor. The web view addresses nodes by it.</p>
 <table>
   <tr><th>command</th><th>what it does</th></tr>
   <tr><td><code>check</code></td><td>validate the module(s); the language is the only validator</td></tr>
-  <tr><td><code>tree</code></td><td>the task forest, JSON-only</td></tr>
+  <tr><td><code>tree</code></td><td>the task forest</td></tr>
   <tr><td><code>agenda</code></td><td>overdue / today / upcoming, merged across files</td></tr>
   <tr><td><code>calendar</code>, <code>ics</code></td><td>dated tasks by day; feed for your calendar app</td></tr>
   <tr><td><code>add</code>, <code>done</code>, <code>move</code>, <code>daily</code></td><td>the write path — auto-commits when the file's dir is a git work tree</td></tr>


### PR DESCRIPTION
Roadmap: **shrink the CLI** — "Once the web app is the daily surface, retire
the human-facing CLI commands; the CLI remains as the agent tool surface and
write-safety layer."

The line I drew: a thing is human-facing if it exists only so a person can
read it at a terminal, or if the web app already serves the same bytes.
Everything an agent parses, every exit code, every JSON key stays exactly
where it was.

## The retirement list, command by command

| Command | Verdict | Why |
|---|---|---|
| `check` | **kept**, plain mode retired | Validation is the agent's edit-verify loop and exit 2 is contract. The `ok: … (12 tasks, 1 anchor)` lines were for a person; JSON now comes out with or without `--json`. |
| `tree` | kept as-is | Already JSON-only. Untouched. |
| `agenda` | **kept**, plain mode retired | `--json` is an agent surface and `/api/agenda` is byte-identical to it. The `OVERDUE / TODAY / UPCOMING` text block was terminal decoration; `format-agenda` is deleted. |
| `calendar` | **kept**, plain mode retired | Same: JSON is what agents and deep-links use; `format-calendar` (the `CALENDAR 2026-08` dump) is deleted. |
| `add` / `done` / `move` / `daily` | **kept**, plain mode retired | This IS the write-safety layer (validate → rename → restore, auto-commit) and the web mutation routes will call the same ops. Only the `added "x" under Inbox …` printf lines went. |
| `serve` | kept | Not a human-facing CLI output — it is how the human surface starts. |
| `ics` | **kept** | Not human-facing by the test above: nobody reads VCALENDAR at a prompt, the consumer is a calendar client, and nothing else in the project produces the feed. Retiring it would delete a capability, not a rendering. |
| `css` | **retired** | Byte-for-byte what `GET /static/app.css` already serves. It existed only to dump the sheet in a terminal. In-tree replacement: `racket -e '(require olai/web/skin) (displayln (stylesheet))'` — the idiom `just css-classes` already uses. |
| `help` / `-h` / `--help` | kept, trimmed | Agents read usage too. Now names the JSON rule and drops `css`. |
| `--json` (every flag) | **kept as a no-op** | Agents already type it. Removing it would turn a working invocation into exit 1 for no gain. Documented as a no-op, like `tree --json` always was. |

## What did not move

- No JSON key added, removed or retyped; both `version` counters stay `1`.
- Exit codes unchanged (0/1/2/3), including `check`'s multi-file "errors ride
  the array on stdout, nothing on stderr".
- Errors are the same error object, now on stderr for every JSON command
  rather than only under `--json`. `ics` and `serve` have no envelope to put
  one in, so they keep `olai: message`.
- `ops.rkt` untouched: the CLI is still parse → call an op → render → map kind
  to exit code.
- srcloc fidelity, contract/blame and multi-file tests all pass unchanged.

## Docs

`docs/cli.md` rewritten to match (plain examples out, `css` section out, a
terse **Retired** table naming the replacement for each). README STATUS/CLI,
CLAUDE.md's two stale contract lines, the justfile recipe comments, and the
landing page's `--json` paragraph follow it.

## Verification

`just test` — 191 passed. The four CLI integration files (`cli-read`,
`cli-multi`, `cli-add`, `cli-done`) — 25 passed; the plain-output assertions
in them became JSON assertions parsed with `read-json`, plus new cases that
`check` / `agenda` / `calendar` are JSON with and without the flag and that
`css` is now an unknown command. `nix/smoke.nix` needed no change (it checks
`olai check`'s exit code, never its stdout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
