### PR TITLE
web: WP7 — per-node zoom + breadcrumbs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,10 @@ edit-verify loop and css-expr). This file is only what you can't infer.
   map kind -> exit code. The web mutation routes will call the same ops.
 * Node keys are minted in the load layer, not the expander (see docs/cli.md);
   store.rkt owns snapshots and binds mirror sites before anything draws them.
+  index.rkt inverts the keys (key -> node + its parent's key) and derives the
+  trail above a node on demand — what /n/<key> and its breadcrumbs are drawn
+  from. Addressing is not snapshotting: the store builds one index per load
+  and asks it nothing.
 * Live view: store (what) -> web/watch.rkt (when) -> web/events.rkt (generic
   SSE hub); they meet only in serve.rkt, and the chat rides the same hub.
 * olai/acp.rkt speaks ACP: one subprocess, typed events out of one

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ Outline `#lang olai` + sexp core + agent CLI (`check` / `tree` JSON /
 `serve` / `css`). Done status, mirrors and `@include` composition are first class;
 mirrors reach anchors anywhere in the loaded tree, fragments included. The
 human view is the web app served by `olai serve` — htmx, no auth (bind
-it to localhost or Tailscale). It reloads an outline when the file changes
+it to localhost or Tailscale). Every node has a permalink that zooms to
+it, breadcrumbs and all. It reloads an outline when the file changes
 and pushes that over SSE, so open tabs redraw with no refresh, and it carries
 a chat panel driving Claude Code over ACP (`OLAI_ACP_AGENT`). Installable
 as a PWA (manifest, icons, theme-color; no offline shell). The page itself

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -401,7 +401,8 @@ Routes:
 | Route | Body |
 |-------|------|
 | `GET /` | HTML page (Workflowy-style skin from `olai/web/render.rkt`) |
-| `GET /today` | the first node titled with today's ISO date (the Daily day node), zoomed; terse empty state when there is none yet |
+| `GET /n/<key>` | one node, zoomed: breadcrumbs (home, the file, each ancestor) plus that subtree and nothing else. `key` as in `tree` JSON. A key the current snapshot has no node for is a page saying so, with a `200` — a node can be deleted while a tab sits zoomed on it, and that tab re-fetches this page to find out |
+| `GET /today` | the first node titled with today's ISO date (the Daily day node), zoomed — the same view as `/n/<key>`, with today's key looked up per request; terse empty state when there is none yet |
 | `GET /events` | `text/event-stream`, never ends. `event: outline` with the store revision as its data whenever a watched file reloaded, plus one at local midnight; `event: chat` with one JSON frame from the agent per line; a `:hb` comment on connect and every 15s after, so a client knows it is subscribed and proxies leave it alone |
 | `POST /chat` | prompt the agent; form field `text` (empty after trimming is `400`). `204` — what the panel draws comes back over `/events`, so every open tab stays in step. `409` with a terse `text/plain` body while a turn is running, `503` when the agent is gone |
 | `POST /chat/new` | new chat: the agent-side context goes away, `204`, and a `reset` frame clears every panel |
@@ -415,9 +416,15 @@ Routes:
 | `GET /static/*` | files under `olai/web/static/` (icons, htmx, scripts, `pwa.js`) |
 | anything else | `404`, terse `text/plain` |
 
-A node's permalink is `/#n-<key>` (`key` as in `tree` JSON). Anchored nodes and
-bare-ISO day nodes also keep a plain `#<anchor>` / `#<YYYY-MM-DD>` target, so
-links people wrote by hand still resolve.
+A node's permalink is `/n/<key>` (`key` as in `tree` JSON): every bullet in the
+outline and every entry in the sidebar tree links to that node's own zoom page.
+A key survives a rename — of the node or of any ancestor — but an unanchored
+node keys off its position, so moving it to a new ordinal mints a new key and
+the old link stops resolving. `^anchor` a node whose link has to outlive that.
+
+Within a page, anchored nodes and bare-ISO day nodes also keep a plain
+`#<anchor>` / `#<YYYY-MM-DD>` target, so links people wrote by hand still
+resolve, and every node carries `id="n-<key>"`.
 
 Paths that climb out of `static/` are 404, not files.
 

--- a/olai/index.rkt
+++ b/olai/index.rkt
@@ -19,21 +19,21 @@
 (require racket/contract
          racket/list
          (except-in olai/lang/expander #%module-begin)
-         olai/lang/walk
-         ;; one owner for how a file is named in the UI (core, not web)
-         (only-in olai/paths file-label))
+         olai/lang/walk)
 
 (provide (contract-out
           [struct node-entry ([task task?]
                               [parent (or/c string? #f)]
-                              [file string?])]
+                              [file (or/c path? string?)])]
           [outline-index (-> list? hash?)]
           [node-ancestors (-> hash? node-entry? list?)]))
 
 ;; One node, addressed: the node itself, the KEY of its parent (#f at a file's
-;; top level), and the label of the file it was reached through. Parent as a
-;; key rather than a node is what keeps the trail a walk over this hash
-;; instead of a second tree hanging off it.
+;; top level), and the file it was reached through, as the loaded set named it.
+;; Parent as a key rather than a node is what keeps the trail a walk over this
+;; hash instead of a second tree hanging off it. The file is kept as a file —
+;; what a human should READ it as is the drawing layer's call (olai/paths,
+;; file-label), and a basename here would be an address nothing could write to.
 (struct node-entry (task parent file) #:transparent)
 
 ;; files-data (see olai/store) -> hash key -> node-entry. Keys come from the
@@ -43,12 +43,13 @@
 (define (outline-index files-data)
   (define idx (make-hash))
   (for ([e (in-list files-data)])
-    (define label (file-label (car e)))
+    (define file (car e))
     (fold-tasks
      (cadr e)
      (λ (tk path acc)
-       (unless (hash-has-key? idx (task-key tk))
-         (hash-set! idx (task-key tk) (node-entry tk (parent-key path) label)))
+       (define key (task-key tk))
+       (unless (hash-has-key? idx key)
+         (hash-set! idx key (node-entry tk (parent-key path) file)))
        acc)
      idx))
   idx)
@@ -59,26 +60,27 @@
   (and (pair? path) (task-key (last path))))
 
 ;; The trail ABOVE a node, outermost first, not including the node itself: the
-;; file it was reached through as a bare label, then one (list title key) per
-;; ancestor. That is exactly what render-breadcrumbs draws — a label with
-;; nowhere to go, then crumbs that are nodes.
+;; file it was reached through, then one (list title key) per ancestor — a
+;; name and the address that name is at.
 ;;
 ;; It takes an ENTRY, not a key: this is asked about a node you have. A key the
 ;; index does not know names no node, and whoever looked it up already has to
 ;; say so — answering "no trail" here would be a second, quieter way to find
 ;; out, in the module least able to do anything about it.
 ;;
-;; O(depth), asked about the one node someone zoomed to. Keeping the whole
-;; trail for every node in the index would pay for it per LOAD instead — a
-;; file save's worth of work for a question a page asks about one node.
+;; O(depth), walked for the one node someone zoomed to. Keeping every node's
+;; trail in the index instead would build it per LOAD and hold it for the life
+;; of the snapshot — a file save's worth of work, and O(nodes × depth) of live
+;; list, for a question a page asks about one node at a time.
 (define (node-ancestors index entry)
-  (let up ([k (node-entry-parent entry)] [file (node-entry-file entry)] [acc '()])
+  ;; The file is the entry's own: a parent is indexed in the same walk as its
+  ;; children, so nothing above a node can have been reached through another.
+  (let up ([k (node-entry-parent entry)] [acc '()])
     (define parent (and k (hash-ref index k #f)))
     (if parent
         (up (node-entry-parent parent)
-            (node-entry-file parent)
             (cons (list (task-title (node-entry-task parent)) k) acc))
-        ;; the top: the file the trail hangs off. An ancestor missing from the
-        ;; index cannot happen (a node is indexed with its parent), but
-        ;; stopping here means a partial trail rather than a crash if it did
-        (cons file acc))))
+        ;; An ancestor missing from the index cannot happen (a node is indexed
+        ;; with its parent), but stopping here means a partial trail rather
+        ;; than a crash if it ever did
+        (cons (node-entry-file entry) acc))))

--- a/olai/index.rkt
+++ b/olai/index.rkt
@@ -1,0 +1,87 @@
+#lang racket/base
+
+;; Node identity, inverted — and what sits above a node.
+;;
+;; A key is minted by the load layer (olai/load, mint-task-keys) and is the
+;; only name anything outside the tree uses: a permalink, an SSE swap target,
+;; a stored collapse state. This module is the inverse of that minting — key
+;; -> the node and where it hangs — plus the one question the "where" is kept
+;; for: the trail of ancestors above a node, which is what a breadcrumb is
+;; drawn from.
+;;
+;; It is not the store. The store decides WHEN the outlines are re-read; this
+;; decides HOW a node is addressed, and the two move on different clocks. A
+;; hash and a walk up it, no I/O, no clocks, no mutation after the build.
+;;
+;; Mirrors are not indexed: a mirror site is the same node as its defining
+;; site, and that site owns the key.
+
+(require racket/contract
+         racket/list
+         (except-in olai/lang/expander #%module-begin)
+         olai/lang/walk
+         ;; one owner for how a file is named in the UI (core, not web)
+         (only-in olai/paths file-label))
+
+(provide (contract-out
+          [struct node-entry ([task task?]
+                              [parent (or/c string? #f)]
+                              [file string?])]
+          [outline-index (-> list? hash?)]
+          [node-ancestors (-> hash? string? list?)]))
+
+;; One node, addressed: the node itself, the KEY of its parent (#f at a file's
+;; top level), and the label of the file it was reached through. Parent as a
+;; key rather than a node is what keeps the trail a walk over this hash
+;; instead of a second tree hanging off it.
+(struct node-entry (task parent file) #:transparent)
+
+;; files-data (see olai/store) -> hash key -> node-entry. Keys come from the
+;; model (task-key), so this is a plain invertible hash: no id formula
+;; restated anywhere, no scan when a lookup misses. First site wins — two
+;; roots sharing an @include fragment are one node, indexed once.
+(define (outline-index files-data)
+  (define idx (make-hash))
+  (for ([e (in-list files-data)])
+    (define label (file-label (car e)))
+    (fold-tasks
+     (cadr e)
+     (λ (tk path acc)
+       (unless (hash-has-key? idx (task-key tk))
+         (hash-set! idx (task-key tk) (node-entry tk (parent-key path) label)))
+       acc)
+     idx))
+  idx)
+
+;; fold-tasks hands each node its ancestors, outermost first. The last of them
+;; is its parent; a top-level node has none.
+(define (parent-key path)
+  (and (pair? path) (task-key (last path))))
+
+;; The trail ABOVE `key`, outermost first, not including the node itself: the
+;; file it was reached through as a bare label, then one (list title key) per
+;; ancestor. That is exactly what render-breadcrumbs draws — a label with
+;; nowhere to go, then crumbs that are nodes.
+;;
+;; '() when the key is not in the index. A node that was deleted (or an
+;; unanchored one that moved and re-keyed) has no trail, and a caller that
+;; already has to draw "no such node" has nothing to ask about it.
+;;
+;; O(depth), asked about the one node someone zoomed to. Keeping the whole
+;; trail for every node in the index would pay for it per LOAD instead — a
+;; file save's worth of work for a question a page asks about one node.
+(define (node-ancestors index key)
+  (define e (hash-ref index key #f))
+  (cond
+    [(not e) '()]
+    [else
+     (let up ([k (node-entry-parent e)] [file (node-entry-file e)] [acc '()])
+       (define pe (and k (hash-ref index k #f)))
+       (if pe
+           (up (node-entry-parent pe)
+               (node-entry-file pe)
+               (cons (list (task-title (node-entry-task pe)) k) acc))
+           ;; the top: the file the trail hangs off. An ancestor missing from
+           ;; the index cannot happen (a node is indexed with its parent), but
+           ;; stopping here means a partial trail rather than a crash if it did
+           (cons file acc)))]))

--- a/olai/index.rkt
+++ b/olai/index.rkt
@@ -28,7 +28,7 @@
                               [parent (or/c string? #f)]
                               [file string?])]
           [outline-index (-> list? hash?)]
-          [node-ancestors (-> hash? string? list?)]))
+          [node-ancestors (-> hash? node-entry? list?)]))
 
 ;; One node, addressed: the node itself, the KEY of its parent (#f at a file's
 ;; top level), and the label of the file it was reached through. Parent as a
@@ -58,30 +58,27 @@
 (define (parent-key path)
   (and (pair? path) (task-key (last path))))
 
-;; The trail ABOVE `key`, outermost first, not including the node itself: the
+;; The trail ABOVE a node, outermost first, not including the node itself: the
 ;; file it was reached through as a bare label, then one (list title key) per
 ;; ancestor. That is exactly what render-breadcrumbs draws — a label with
 ;; nowhere to go, then crumbs that are nodes.
 ;;
-;; '() when the key is not in the index. A node that was deleted (or an
-;; unanchored one that moved and re-keyed) has no trail, and a caller that
-;; already has to draw "no such node" has nothing to ask about it.
+;; It takes an ENTRY, not a key: this is asked about a node you have. A key the
+;; index does not know names no node, and whoever looked it up already has to
+;; say so — answering "no trail" here would be a second, quieter way to find
+;; out, in the module least able to do anything about it.
 ;;
 ;; O(depth), asked about the one node someone zoomed to. Keeping the whole
 ;; trail for every node in the index would pay for it per LOAD instead — a
 ;; file save's worth of work for a question a page asks about one node.
-(define (node-ancestors index key)
-  (define e (hash-ref index key #f))
-  (cond
-    [(not e) '()]
-    [else
-     (let up ([k (node-entry-parent e)] [file (node-entry-file e)] [acc '()])
-       (define pe (and k (hash-ref index k #f)))
-       (if pe
-           (up (node-entry-parent pe)
-               (node-entry-file pe)
-               (cons (list (task-title (node-entry-task pe)) k) acc))
-           ;; the top: the file the trail hangs off. An ancestor missing from
-           ;; the index cannot happen (a node is indexed with its parent), but
-           ;; stopping here means a partial trail rather than a crash if it did
-           (cons file acc)))]))
+(define (node-ancestors index entry)
+  (let up ([k (node-entry-parent entry)] [file (node-entry-file entry)] [acc '()])
+    (define parent (and k (hash-ref index k #f)))
+    (if parent
+        (up (node-entry-parent parent)
+            (node-entry-file parent)
+            (cons (list (task-title (node-entry-task parent)) k) acc))
+        ;; the top: the file the trail hangs off. An ancestor missing from the
+        ;; index cannot happen (a node is indexed with its parent), but
+        ;; stopping here means a partial trail rather than a crash if it did
+        (cons file acc))))

--- a/olai/main.rkt
+++ b/olai/main.rkt
@@ -6,6 +6,7 @@
 (require (except-in olai/lang/expander #%module-begin)
          (only-in olai/lang/walk find-task-by-id find-tasks-by-title)
          olai/agenda
+         olai/index
          olai/web/render)
 
 (provide task
@@ -34,6 +35,13 @@
          collect-dated
          agenda-groups
          agenda-groups-from-files
+         ;; node identity, inverted: key -> node, and the trail above it
+         node-entry?
+         node-entry-task
+         node-entry-parent
+         node-entry-file
+         outline-index
+         node-ancestors
          render-node-fragment
          render-outline
          render-breadcrumbs

--- a/olai/main.rkt
+++ b/olai/main.rkt
@@ -35,11 +35,11 @@
          collect-dated
          agenda-groups
          agenda-groups-from-files
-         ;; node identity, inverted: key -> node, and the trail above it
+         ;; node identity, inverted: key -> node, and the trail above it. The
+         ;; entry's other fields are how the trail is walked, not something to
+         ;; read — ask node-ancestors instead.
          node-entry?
          node-entry-task
-         node-entry-parent
-         node-entry-file
          outline-index
          node-ancestors
          render-node-fragment

--- a/olai/store.rkt
+++ b/olai/store.rkt
@@ -31,8 +31,8 @@
          (except-in olai/lang/expander #%module-begin)
          olai/lang/walk
          olai/load
-         ;; one owner for how a file is named in the UI
-         (only-in olai/paths file-label))
+         ;; how a node is addressed, and what sits above it
+         (only-in olai/index outline-index))
 
 ;; Handlers hold a store for the life of the process and read a snapshot per
 ;; request: the two things that must not be confused with each other, or with
@@ -49,7 +49,6 @@
                             [files-data list?]
                             [index hash?]
                             [watch (listof path?)])]
-          [outline-index (-> list? hash?)]
           [snapshot-day-key (-> snapshot? string? (or/c string? #f))]
           [call-in-outline-namespace (-> (-> any) any)]))
 
@@ -60,7 +59,7 @@
 ;;   files-data : (listof (list path tasks)) — render's input: the same trees
 ;;                with every mirror site already bound to its node
 ;;                (olai/lang/walk, resolve-mirrors)
-;;   index      : hash node-id -> (list task breadcrumb)
+;;   index      : hash key -> node-entry (olai/index) — every node, addressed
 ;;   watch      : (listof path) roots + transitive @include fragments
 (struct snapshot (outlines files-data index watch) #:transparent)
 
@@ -162,29 +161,6 @@
       (for ([q (in-list (module-includes p))]) (visit q))))
   (for ([o (in-list outlines)]) (visit (outline-path o)))
   (reverse acc))
-
-;; key -> (list task crumbs) for every node, where crumbs is the trail from
-;; the file label down to and including the node itself, each crumb a
-;; (list label key) with key #f for the file label. Keys come from the model
-;; (task-key), so this is a plain invertible hash: no id formula restated
-;; anywhere, no scan when a lookup misses. Mirrors are not indexed — a mirror
-;; site is the same node as its defining site, and that site owns the key.
-(define (outline-index files-data)
-  (define idx (make-hash))
-  (for ([e (in-list files-data)])
-    (define file-crumb (list (list (file-label (car e)) #f)))
-    (fold-tasks
-     (cadr e)
-     (λ (tk path _acc)
-       (unless (hash-has-key? idx (task-key tk))
-         (hash-set! idx (task-key tk)
-                    (list tk
-                          (append file-crumb
-                                  (for/list ([n (in-list (task-path path tk))])
-                                    (list (task-title n) (task-key n)))))))
-       idx)
-     idx))
-  idx)
 
 ;; The key of the day node titled `iso-day` (Daily.rkt keeps one per day), or
 ;; #f. First match in file order, so the answer does not depend on hash order.

--- a/olai/tests/contracts.rkt
+++ b/olai/tests/contracts.rkt
@@ -10,6 +10,7 @@
 (require rackunit
          racket/string
          (except-in olai/lang/expander #%module-begin)
+         olai/index
          olai/lang/line
          olai/load
          olai/web/events
@@ -41,9 +42,20 @@
     (check-exn (blames "load.rkt")
                (λ () (mint-outline-keys (list "not an outline")))))
 
+  (test-case "index: files-data in, and a key is a string"
+    (check-exn (blames "index.rkt")
+               (λ () (outline-index "not files-data")))
+    ;; the trail above a node is asked for by key, not by node
+    (check-exn (blames "index.rkt")
+               (λ () (node-ancestors (hash) (make-task #:title "T" #:key "k")))))
+
   (test-case "web/render: the renderer draws tasks, not titles"
     (check-exn (blames "render.rkt")
                (λ () (render-node-fragment "Buy milk" #:today "2026-08-04")))
+    ;; a zoom is a node and the trail above it, both given: this layer draws
+    ;; one, it does not look one up
+    (check-exn (blames "render.rkt")
+               (λ () (render-zoom "ship" '() #:today "2026-08-04" #:home-href "/")))
     ;; `today` is an argument, and it is a string: no clock, no #f
     (check-exn (blames "render.rkt")
                (λ () (render-node-fragment (make-task #:title "T" #:key "k")

--- a/olai/tests/contracts.rkt
+++ b/olai/tests/contracts.rkt
@@ -45,7 +45,10 @@
   (test-case "index: files-data in, and a key is a string"
     (check-exn (blames "index.rkt")
                (λ () (outline-index "not files-data")))
-    ;; the trail above a node is asked for by key, not by node
+    ;; the trail is asked about a node you HAVE — an indexed one, not a key
+    ;; and not a bare task
+    (check-exn (blames "index.rkt")
+               (λ () (node-ancestors (hash) "ship")))
     (check-exn (blames "index.rkt")
                (λ () (node-ancestors (hash) (make-task #:title "T" #:key "k")))))
 

--- a/olai/tests/index.rkt
+++ b/olai/tests/index.rkt
@@ -32,6 +32,10 @@
 
   (define idx (outline-index fd))
 
+  ;; the trail above the node a key names — the two questions the index
+  ;; answers, asked the way a zoom route asks them
+  (define (trail index key) (node-ancestors index (hash-ref index key)))
+
   (test-case "every node is indexed, by its own key, with its parent's"
     (check-equal? (hash-count idx) 5)
     (define e (hash-ref idx (title-key "Buy milk")))
@@ -46,20 +50,19 @@
   (test-case "the trail above a node is the file, then its ancestors"
     ;; outermost first, and the node itself is NOT in it: a breadcrumb says
     ;; where you are, not that you are here
-    (check-equal? (node-ancestors idx (title-key "2% please"))
+    (check-equal? (trail idx (title-key "2% please"))
                   (list "Tasks.rkt"
                         (list "Inbox" (title-key "Inbox"))
                         (list "Buy milk" (title-key "Buy milk"))))
-    (check-equal? (node-ancestors idx (title-key "Buy milk"))
+    (check-equal? (trail idx (title-key "Buy milk"))
                   (list "Tasks.rkt" (list "Inbox" (title-key "Inbox"))))
     ;; a top-level node has only the file above it
-    (check-equal? (node-ancestors idx "ship") (list "Tasks.rkt"))
-    (check-equal? (node-ancestors idx (title-key "2026-08-04")) (list "Daily.rkt")))
+    (check-equal? (trail idx "ship") (list "Tasks.rkt"))
+    (check-equal? (trail idx (title-key "2026-08-04")) (list "Daily.rkt")))
 
-  (test-case "an unknown key has no trail at all"
-    ;; a node deleted (or re-keyed) under a tab that was zoomed on it: the
-    ;; caller draws "no such node", and has nothing to ask about it
-    (check-equal? (node-ancestors idx "pdeadbeef") '())
+  (test-case "an unknown key names no node"
+    ;; a node deleted (or re-keyed) under a tab that was zoomed on it. There
+    ;; is nothing to ask about it — whoever looked it up draws "no such node"
     (check-false (hash-ref idx "pdeadbeef" #f)))
 
   (test-case "renaming an ancestor changes the crumb, not the address"
@@ -72,7 +75,7 @@
                                     #:children
                                     (list (tk "Buy milk" '())))))))
     (define idx2 (outline-index renamed))
-    (check-equal? (node-ancestors idx2 (title-key "Buy milk"))
+    (check-equal? (trail idx2 (title-key "Buy milk"))
                   (list "Tasks.rkt" (list "In" (title-key "Inbox")))))
 
   (test-case "a mirror site is not a second address for the node"
@@ -85,7 +88,7 @@
                           (tk "Later" (list (mirror-ref "ship" #f))))
                     (hash "ship" (tk "Ship it" '() #:id "ship"))))))
     (define midx (outline-index mirrored))
-    (check-equal? (node-ancestors midx "ship")
+    (check-equal? (trail midx "ship")
                   (list "Tasks.rkt" (list "Inbox" (title-key "Inbox"))))
     ;; Inbox, Ship it, Later — the mirror site adds no fourth address
     (check-equal? (hash-count midx) 3)))

--- a/olai/tests/index.rkt
+++ b/olai/tests/index.rkt
@@ -41,29 +41,26 @@
     (define e (hash-ref idx (title-key "Buy milk")))
     (check-equal? (task-title (node-entry-task e)) "Buy milk")
     (check-equal? (node-entry-parent e) (title-key "Inbox"))
-    ;; the file is named the way a human reads it, not by full path
-    (check-equal? (node-entry-file e) "Tasks.rkt")
+    ;; the file is kept as the loaded set named it — what to READ it as is the
+    ;; drawing layer's call, and a basename here would name two files one thing
+    (check-equal? (node-entry-file e) "/tmp/Tasks.rkt")
     ;; a top-level node has no parent, and an anchored one keys by its anchor
     (check-equal? (node-entry-parent (hash-ref idx "ship")) #f)
-    (check-equal? (node-entry-file (hash-ref idx (title-key "2026-08-04"))) "Daily.rkt"))
+    (check-equal? (node-entry-file (hash-ref idx (title-key "2026-08-04")))
+                  "/tmp/Daily.rkt"))
 
   (test-case "the trail above a node is the file, then its ancestors"
     ;; outermost first, and the node itself is NOT in it: a breadcrumb says
     ;; where you are, not that you are here
     (check-equal? (trail idx (title-key "2% please"))
-                  (list "Tasks.rkt"
+                  (list "/tmp/Tasks.rkt"
                         (list "Inbox" (title-key "Inbox"))
                         (list "Buy milk" (title-key "Buy milk"))))
     (check-equal? (trail idx (title-key "Buy milk"))
-                  (list "Tasks.rkt" (list "Inbox" (title-key "Inbox"))))
+                  (list "/tmp/Tasks.rkt" (list "Inbox" (title-key "Inbox"))))
     ;; a top-level node has only the file above it
-    (check-equal? (trail idx "ship") (list "Tasks.rkt"))
-    (check-equal? (trail idx (title-key "2026-08-04")) (list "Daily.rkt")))
-
-  (test-case "an unknown key names no node"
-    ;; a node deleted (or re-keyed) under a tab that was zoomed on it. There
-    ;; is nothing to ask about it — whoever looked it up draws "no such node"
-    (check-false (hash-ref idx "pdeadbeef" #f)))
+    (check-equal? (trail idx "ship") (list "/tmp/Tasks.rkt"))
+    (check-equal? (trail idx (title-key "2026-08-04")) (list "/tmp/Daily.rkt")))
 
   (test-case "renaming an ancestor changes the crumb, not the address"
     ;; the trail is derived when it is asked for, so it reads the titles the
@@ -76,7 +73,7 @@
                                     (list (tk "Buy milk" '())))))))
     (define idx2 (outline-index renamed))
     (check-equal? (trail idx2 (title-key "Buy milk"))
-                  (list "Tasks.rkt" (list "In" (title-key "Inbox")))))
+                  (list "/tmp/Tasks.rkt" (list "In" (title-key "Inbox")))))
 
   (test-case "a mirror site is not a second address for the node"
     ;; a mirror site IS the node it points at; the defining site owns the key,
@@ -89,6 +86,6 @@
                     (hash "ship" (tk "Ship it" '() #:id "ship"))))))
     (define midx (outline-index mirrored))
     (check-equal? (trail midx "ship")
-                  (list "Tasks.rkt" (list "Inbox" (title-key "Inbox"))))
+                  (list "/tmp/Tasks.rkt" (list "Inbox" (title-key "Inbox"))))
     ;; Inbox, Ship it, Later — the mirror site adds no fourth address
     (check-equal? (hash-count midx) 3)))

--- a/olai/tests/index.rkt
+++ b/olai/tests/index.rkt
@@ -1,0 +1,91 @@
+#lang racket/base
+
+;; Node addressing: key -> node, and the trail above it. Hand-built trees, no
+;; files, no store — this is a pure function of one loaded shape.
+;;
+;; Keys here are minted the way tests/render.rkt mints them (off the title), so
+;; a test reads as "the node called X". Real keys come from the load layer; see
+;; tests/store.rkt for those.
+
+(require rackunit
+         file/sha1
+         (except-in olai/lang/expander #%module-begin)
+         (only-in olai/lang/walk resolve-mirrors)
+         olai/index)
+
+(define (title-key title)
+  (string-append
+   "p" (substring (sha1 (open-input-bytes (string->bytes/utf-8 title))) 0 8)))
+
+(define (tk title kids #:id [id #f])
+  (make-task #:title title #:id id #:children kids
+             #:key (or id (title-key title))))
+
+(define (files . entries) entries)
+
+(module+ test
+  (define fd
+    (files (list "/tmp/Tasks.rkt"
+                 (list (tk "Inbox" (list (tk "Buy milk" (list (tk "2% please" '())))))
+                       (tk "Ship it" '() #:id "ship")))
+           (list "/tmp/Daily.rkt" (list (tk "2026-08-04" '())))))
+
+  (define idx (outline-index fd))
+
+  (test-case "every node is indexed, by its own key, with its parent's"
+    (check-equal? (hash-count idx) 5)
+    (define e (hash-ref idx (title-key "Buy milk")))
+    (check-equal? (task-title (node-entry-task e)) "Buy milk")
+    (check-equal? (node-entry-parent e) (title-key "Inbox"))
+    ;; the file is named the way a human reads it, not by full path
+    (check-equal? (node-entry-file e) "Tasks.rkt")
+    ;; a top-level node has no parent, and an anchored one keys by its anchor
+    (check-equal? (node-entry-parent (hash-ref idx "ship")) #f)
+    (check-equal? (node-entry-file (hash-ref idx (title-key "2026-08-04"))) "Daily.rkt"))
+
+  (test-case "the trail above a node is the file, then its ancestors"
+    ;; outermost first, and the node itself is NOT in it: a breadcrumb says
+    ;; where you are, not that you are here
+    (check-equal? (node-ancestors idx (title-key "2% please"))
+                  (list "Tasks.rkt"
+                        (list "Inbox" (title-key "Inbox"))
+                        (list "Buy milk" (title-key "Buy milk"))))
+    (check-equal? (node-ancestors idx (title-key "Buy milk"))
+                  (list "Tasks.rkt" (list "Inbox" (title-key "Inbox"))))
+    ;; a top-level node has only the file above it
+    (check-equal? (node-ancestors idx "ship") (list "Tasks.rkt"))
+    (check-equal? (node-ancestors idx (title-key "2026-08-04")) (list "Daily.rkt")))
+
+  (test-case "an unknown key has no trail at all"
+    ;; a node deleted (or re-keyed) under a tab that was zoomed on it: the
+    ;; caller draws "no such node", and has nothing to ask about it
+    (check-equal? (node-ancestors idx "pdeadbeef") '())
+    (check-false (hash-ref idx "pdeadbeef" #f)))
+
+  (test-case "renaming an ancestor changes the crumb, not the address"
+    ;; the trail is derived when it is asked for, so it reads the titles the
+    ;; snapshot has now — while the keys, which are what the crumbs link to,
+    ;; stay put
+    (define renamed
+      (files (list "/tmp/Tasks.rkt"
+                   (list (make-task #:title "In" #:key (title-key "Inbox")
+                                    #:children
+                                    (list (tk "Buy milk" '())))))))
+    (define idx2 (outline-index renamed))
+    (check-equal? (node-ancestors idx2 (title-key "Buy milk"))
+                  (list "Tasks.rkt" (list "In" (title-key "Inbox")))))
+
+  (test-case "a mirror site is not a second address for the node"
+    ;; a mirror site IS the node it points at; the defining site owns the key,
+    ;; and the trail is the one the node is defined at
+    (define mirrored
+      (files (list "/tmp/Tasks.rkt"
+                   (resolve-mirrors
+                    (list (tk "Inbox" (list (tk "Ship it" '() #:id "ship")))
+                          (tk "Later" (list (mirror-ref "ship" #f))))
+                    (hash "ship" (tk "Ship it" '() #:id "ship"))))))
+    (define midx (outline-index mirrored))
+    (check-equal? (node-ancestors midx "ship")
+                  (list "Tasks.rkt" (list "Inbox" (title-key "Inbox"))))
+    ;; Inbox, Ship it, Later — the mirror site adds no fourth address
+    (check-equal? (hash-count midx) 3)))

--- a/olai/tests/integration/serve.rkt
+++ b/olai/tests/integration/serve.rkt
@@ -144,6 +144,85 @@
        (check-true (string-contains? pane "ol-zoom") pane)
        (check-false (string-contains? pane "Buy milk") pane))))
 
+  ;; ---- zoom ------------------------------------------------------------------
+
+  ;; ^serve is the node's key, so the permalink is one a test can spell.
+  (test-case "GET /n/<key> is that node, zoomed, with the trail above it"
+    (with-server
+     (λ (port f)
+       (define-values (code _h body) (GET port "/n/serve"))
+       (check-equal? code 200 body)
+       (define pane (cadr (string-split body "<main class=\"ol-main\">")))
+       (check-true (string-contains? pane "ol-zoom") pane)
+       (check-true (string-contains? pane "Ship the server") pane)
+       ;; the focused subtree and nothing else
+       (check-false (string-contains? pane "Buy milk") pane)
+       ;; breadcrumbs: home, then the file it is defined in
+       (check-true (string-contains? pane "ol-breadcrumbs") pane)
+       (check-true (string-contains? pane "Tasks.rkt") pane)
+       (check-true (string-contains? pane "href=\"/\"") pane)
+       ;; the tab says which node
+       (check-true (string-contains? body "<title>Ship the server</title>") body))))
+
+  (test-case "a node's permalink is its zoom page, not the home page"
+    (with-server
+     (λ (port f)
+       (define-values (_c _h home) (GET port "/"))
+       ;; every bullet is a link to that node's page — the sidebar's tree too
+       (check-true (string-contains? home "href=\"/n/serve\"") home)
+       (check-false (string-contains? home "href=\"/#n-serve\"") home))))
+
+  (test-case "an ancestor crumb links to the ancestor's own zoom page"
+    (with-server
+     (λ (port f)
+       ;; Buy milk is a child of Inbox, so its trail has a node in it. The
+       ;; keys come from the JSON surface — the same ones the page draws with
+       (define j (read-json (open-input-string
+                             (let-values ([(_c _h b) (GET port "/api/tree")]) b))))
+       (define inbox (car (hash-ref j 'tasks)))
+       (define milk (car (hash-ref inbox 'children)))
+       (check-equal? (hash-ref milk 'title) "Buy milk")
+       (define-values (code _h2 body) (GET port (string-append "/n/" (hash-ref milk 'key))))
+       (check-equal? code 200 body)
+       (define pane (cadr (string-split body "<main class=\"ol-main\">")))
+       (check-true (string-contains? pane "Buy milk") pane)
+       (define crumbs (car (string-split pane "</nav>")))
+       ;; home, the file, then the ancestor — a link to ITS page, not an
+       ;; in-page anchor on the home page
+       (check-true (string-contains? crumbs "Tasks.rkt") crumbs)
+       (check-true (string-contains?
+                    crumbs
+                    (string-append "href=\"/n/" (hash-ref inbox 'key) "\">Inbox"))
+                   crumbs))))
+
+  (test-case "a key the snapshot does not have says so, and stays a page"
+    (with-server
+     (λ (port f)
+       ;; not a 404: a tab zoomed on a node that was deleted re-fetches THIS
+       ;; page to find out, and htmx swaps nothing on an error status
+       (define-values (code headers body) (GET port "/n/nope"))
+       (check-equal? code 200 body)
+       (check-true (string-contains? (or (header-value headers "content-type:") "")
+                                     "text/html")
+                   (format "~a" headers))
+       (check-true (string-contains? body "No such node.") body)
+       ;; still a live page, still pointing at itself
+       (check-true (string-contains? body "id=\"ol-live\" hx-get=\"/n/nope\"") body))))
+
+  (test-case "an edit under a zoomed node lands on the zoom page"
+    (with-server
+     (λ (port f)
+       (define-values (_code _headers in) (open-events port))
+       (display-to-file (string-append outline "  Write the docs\n") f #:exists 'truncate)
+       (check-not-false (next-event in) "no outline event for the edit")
+       ;; the page an open tab re-fetches on that event is this one, and it
+       ;; has the new child in it
+       (define-values (code _h body) (GET port "/n/serve"))
+       (check-equal? code 200 body)
+       (check-true (string-contains? body "Write the docs") body)
+       (check-true (string-contains? body "id=\"ol-live\" hx-get=\"/n/serve\"") body)
+       (close-input-port in))))
+
   (test-case "GET /api/tree matches the tree JSON contract"
     (with-server
      (λ (port f)

--- a/olai/tests/render.rkt
+++ b/olai/tests/render.rkt
@@ -11,7 +11,6 @@
          file/sha1
          (except-in olai/lang/expander #%module-begin)
          (only-in olai/lang/walk resolve-mirrors)
-         olai/index
          olai/web/render
          ;; the list the picker draws: the themes the sheet carries, and the
          ;; one a page that picked nothing reads in
@@ -385,48 +384,39 @@
                                         #:zoom-base "/z/")))
     (check-true (string-contains? z "href=\"/z/p1234abcd\"") z))
 
-  ;; What a zoom PAGE is drawn from: the node, and the trail above it. Which
-  ;; node a key names is olai/index's answer (tests/index.rkt), not this
-  ;; module's — here it is only the input.
-  (define (zoom-of fd key #:zoom-base [zoom-base #f])
-    (define idx (outline-index fd))
-    (define entry (hash-ref idx key))
-    (xstr (render-zoom (node-entry-task entry)
-                       (node-ancestors idx entry)
-                       #:today "2026-08-04"
-                       #:home-href "/"
-                       #:zoom-base zoom-base)))
-
+  ;; A zoom is GIVEN its node and the trail above it (olai/index answers which
+  ;; node a key names; tests/index.rkt asks it). Here both are literals.
   (test-case "zoom shows breadcrumbs plus the focused subtree only"
-    (define fd (files (list "Tasks.rkt"
-                            (list (tk "Inbox" #f #f
-                                      (list (tk "Buy milk" #f #f
-                                                (list (tk "2% please" #f #f '())))))
-                                  (tk "Elsewhere" #f #f '())))))
-    (define fid (task-key (tk "Buy milk" #f #f '())))
-    (define s (zoom-of fd fid))
+    (define milk (tk "Buy milk" #f #f (list (tk "2% please" #f #f '()))))
+    (define inbox-key (task-key (tk "Inbox" #f #f '())))
+    (define (zoom-of #:zoom-base [zoom-base #f])
+      (xstr (render-zoom milk (list "Tasks.rkt" (list "Inbox" inbox-key))
+                         #:today "2026-08-04"
+                         #:home-href "/"
+                         #:zoom-base zoom-base)))
+    (define s (zoom-of))
     (check-true (string-contains? s "ol-breadcrumbs") s)
     (check-true (string-contains? s "Tasks.rkt") s)
     (check-true (string-contains? s "Inbox") s)
-    (check-true (string-contains? s (string-append "id=\"n-" fid "\"")) s)
+    (check-true (string-contains? s (string-append "id=\"n-" (task-key milk) "\"")) s)
     (check-true (string-contains? s "2% please") s)
+    ;; the focused subtree, and only it
     (check-false (string-contains? s "Elsewhere") s)
-    ;; the ancestor crumb is clickable, the file label is not
-    (check-true (string-contains? s (string-append
-                                     "href=\"#n-" (task-key (tk "Inbox" #f #f '())) "\""))
-                s)
+    ;; the ancestor crumb is clickable, the file is not
+    (check-true (string-contains? s (string-append "href=\"#n-" inbox-key "\"")) s)
     ;; and with a zoom base, every ancestor crumb is that ancestor's own page
-    (define z (zoom-of fd fid #:zoom-base "/n/"))
-    (check-true (string-contains?
-                 z (string-append "href=\"/n/" (task-key (tk "Inbox" #f #f '())) "\""))
-                z))
+    (define z (zoom-of #:zoom-base "/n/"))
+    (check-true (string-contains? z (string-append "href=\"/n/" inbox-key "\"")) z))
 
-  (test-case "zoom by anchor"
-    (define fd (files (list "Tasks.rkt"
-                            (list (tk "Root" #f #f (list (tk "Kid" #f #f '() #:id "kid")))))))
-    (define s (zoom-of fd "kid"))
+  (test-case "a file crumb is drawn by its basename, whole path or not"
+    ;; the trail carries the file as the loaded set named it (olai/index); how
+    ;; it READS is this module's call
+    (define s (xstr (render-zoom (tk "Kid" #f #f '() #:id "kid")
+                                 (list (string->path "/tmp/outlines/Tasks.rkt"))
+                                 #:today "2026-08-04" #:home-href "/")))
     (check-true (string-contains? s "id=\"n-kid\"") s)
-    (check-true (string-contains? s "Kid") s))
+    (check-true (string-contains? s "<span class=\"ol-crumb\">Tasks.rkt</span>") s)
+    (check-false (string-contains? s "/tmp/outlines") s))
 
   ;; ---- page shell ---------------------------------------------------------
 

--- a/olai/tests/render.rkt
+++ b/olai/tests/render.rkt
@@ -11,7 +11,7 @@
          file/sha1
          (except-in olai/lang/expander #%module-begin)
          (only-in olai/lang/walk resolve-mirrors)
-         olai/store
+         olai/index
          olai/web/render
          ;; the list the picker draws: the themes the sheet carries, and the
          ;; one a page that picked nothing reads in
@@ -385,6 +385,17 @@
                                         #:zoom-base "/z/")))
     (check-true (string-contains? z "href=\"/z/p1234abcd\"") z))
 
+  ;; What a zoom PAGE is drawn from: the node, and the trail above it. Which
+  ;; node a key names is olai/index's answer (tests/index.rkt), not this
+  ;; module's — here it is only the input.
+  (define (zoom-of fd key #:zoom-base [zoom-base #f])
+    (define idx (outline-index fd))
+    (xstr (render-zoom (node-entry-task (hash-ref idx key))
+                       (node-ancestors idx key)
+                       #:today "2026-08-04"
+                       #:home-href "/"
+                       #:zoom-base zoom-base)))
+
   (test-case "zoom shows breadcrumbs plus the focused subtree only"
     (define fd (files (list "Tasks.rkt"
                             (list (tk "Inbox" #f #f
@@ -392,7 +403,7 @@
                                                 (list (tk "2% please" #f #f '())))))
                                   (tk "Elsewhere" #f #f '())))))
     (define fid (task-key (tk "Buy milk" #f #f '())))
-    (define s (xstr (render-zoom (outline-index fd) fid #:today "2026-08-04" #:home-href "/")))
+    (define s (zoom-of fd fid))
     (check-true (string-contains? s "ol-breadcrumbs") s)
     (check-true (string-contains? s "Tasks.rkt") s)
     (check-true (string-contains? s "Inbox") s)
@@ -402,17 +413,19 @@
     ;; the ancestor crumb is clickable, the file label is not
     (check-true (string-contains? s (string-append
                                      "href=\"#n-" (task-key (tk "Inbox" #f #f '())) "\""))
-                s))
+                s)
+    ;; and with a zoom base, every ancestor crumb is that ancestor's own page
+    (define z (zoom-of fd fid #:zoom-base "/n/"))
+    (check-true (string-contains?
+                 z (string-append "href=\"/n/" (task-key (tk "Inbox" #f #f '())) "\""))
+                z))
 
-  (test-case "zoom by anchor and unknown key"
+  (test-case "zoom by anchor"
     (define fd (files (list "Tasks.rkt"
                             (list (tk "Root" #f #f (list (tk "Kid" #f #f '() #:id "kid")))))))
-    (define s (xstr (render-zoom (outline-index fd) "kid" #:today "2026-08-04" #:home-href "/")))
+    (define s (zoom-of fd "kid"))
     (check-true (string-contains? s "id=\"n-kid\"") s)
-    (check-true (string-contains? s "Kid") s)
-    (define miss (xstr (render-zoom (outline-index fd) "pdeadbeef" #:today "2026-08-04"
-                                #:home-href "/")))
-    (check-true (string-contains? miss "No such node.") miss))
+    (check-true (string-contains? s "Kid") s))
 
   ;; ---- page shell ---------------------------------------------------------
 

--- a/olai/tests/render.rkt
+++ b/olai/tests/render.rkt
@@ -390,8 +390,9 @@
   ;; module's — here it is only the input.
   (define (zoom-of fd key #:zoom-base [zoom-base #f])
     (define idx (outline-index fd))
-    (xstr (render-zoom (node-entry-task (hash-ref idx key))
-                       (node-ancestors idx key)
+    (define entry (hash-ref idx key))
+    (xstr (render-zoom (node-entry-task entry)
+                       (node-ancestors idx entry)
                        #:today "2026-08-04"
                        #:home-href "/"
                        #:zoom-base zoom-base)))

--- a/olai/tests/style.rkt
+++ b/olai/tests/style.rkt
@@ -45,6 +45,7 @@
          olai/web/render
          olai/web/chat-panel
          olai/store
+         olai/index
          (only-in olai/lang/walk resolve-mirrors)
          (except-in olai/lang/expander #%module-begin))
 
@@ -153,8 +154,10 @@
                                           #:zoom-base "/z/")
                 #:banner (render-error-banner "expected ISO date"
                                               #:where "/tmp/Tasks.rkt:3:4"))
-   (render-zoom (snapshot-index example-snapshot) "agent"
-                #:today example-today #:home-href "/" #:zoom-base "/z/")
+   (let ([index (snapshot-index example-snapshot)])
+     (render-zoom (node-entry-task (hash-ref index "agent"))
+                  (node-ancestors index "agent")
+                  #:today example-today #:home-href "/" #:zoom-base "/z/"))
    (render-empty-pane "No such node." #:home-href "/")
    ;; a mirror site whose anchor named nothing: the outline still says
    ;; something belongs here, and the marker is drawn in that state

--- a/olai/tests/style.rkt
+++ b/olai/tests/style.rkt
@@ -154,9 +154,10 @@
                                           #:zoom-base "/z/")
                 #:banner (render-error-banner "expected ISO date"
                                               #:where "/tmp/Tasks.rkt:3:4"))
-   (let ([index (snapshot-index example-snapshot)])
-     (render-zoom (node-entry-task (hash-ref index "agent"))
-                  (node-ancestors index "agent")
+   (let* ([index (snapshot-index example-snapshot)]
+          [entry (hash-ref index "agent")])
+     (render-zoom (node-entry-task entry)
+                  (node-ancestors index entry)
                   #:today example-today #:home-href "/" #:zoom-base "/z/"))
    (render-empty-pane "No such node." #:home-href "/")
    ;; a mirror site whose anchor named nothing: the outline still says

--- a/olai/web/render.rkt
+++ b/olai/web/render.rkt
@@ -95,7 +95,7 @@
                  #:body-extra list?)
                 list?)]
           [render-zoom
-           (->* (hash? string? #:today string? #:home-href string?)
+           (->* (task? list? #:today string? #:home-href string?)
                 (#:zoom-base (or/c string? #f)
                  #:toggle-base (or/c string? #f))
                 list?)]
@@ -661,16 +661,18 @@
 
 (define-style ol-crumb-sep #:color ,line)
 
-;; path: (listof crumb) where crumb is "Label" or (list "Label" href-or-fid)
+;; path: (listof crumb) where crumb is "Label" (a file, nowhere to go) or
+;; (list "Label" key) — a NODE, addressed the one way nodes are addressed
+;; here. A crumb never carries a ready-made href: where a key points is the
+;; route layer's answer, and it hands it down as `zoom-base` like every other
+;; address in this module.
 (define (render-breadcrumbs path #:home-href home-href #:zoom-base [zoom-base #f])
   (define (label->xexprs label)
     (map style-md-xexpr (title->inline-xexprs label)))
   (define (crumb->xexpr c)
     (match c
-      [(list label target)
-       `(a ((class ,ol-crumb) (href ,(if (regexp-match? #px"^[/#]" target)
-                                         target
-                                         (href-for zoom-base target))))
+      [(list label key)
+       `(a ((class ,ol-crumb) (href ,(href-for zoom-base key)))
            ,@(label->xexprs label))]
       [(? string? label) `(span ((class ,ol-crumb)) ,@(label->xexprs label))]
       [_ `(span ((class ,ol-crumb)) ,(format "~a" c))]))
@@ -1001,29 +1003,19 @@
 
 ;; Breadcrumbs + the focused subtree.
 ;;
-;; `index` is the store's node index: key -> (list task crumbs), where crumbs
-;; is the trail from the file label down to and including the node, each crumb
-;; a (list label key) with key #f for the file label itself. Nothing here
-;; recomputes an id or walks a tree — zoom is a hash lookup.
-(define (render-zoom index key
+;; Both are GIVEN: `tk` is the node to draw, `crumbs` the trail above it
+;; (olai/index, node-ancestors). Which node a key names, and what sits above
+;; it, are answered before anything gets here — this draws a zoom, it does not
+;; find one, so there is no such thing as a miss at this layer.
+(define (render-zoom tk crumbs
                      #:today today
                      #:home-href home-href
                      #:zoom-base [zoom-base #f]
                      #:toggle-base [toggle-base #f])
-  (define hit (hash-ref index key #f))
-  (cond
-    [(not hit) (render-empty-pane "No such node." #:home-href home-href)]
-    [else
-     (match-define (list tk crumbs) hit)
-     ;; drop the node's own crumb; the file label has no node to zoom to
-     (define ancestors
-       (for/list ([c (in-list (drop-right crumbs 1))])
-         (match-define (list label k) c)
-         (if k (list label k) label)))
-     `(div ((class ,(classes ol-pane ol-zoom)) (id "ol-outline"))
-           ,(render-breadcrumbs ancestors #:zoom-base zoom-base #:home-href home-href)
-           (ul ((class ,(classes ol-outline ol-zoom-root)))
-               ,(render-node-fragment tk
-                                      #:today today
-                                      #:zoom-base zoom-base
-                                      #:toggle-base toggle-base)))]))
+  `(div ((class ,(classes ol-pane ol-zoom)) (id "ol-outline"))
+        ,(render-breadcrumbs crumbs #:zoom-base zoom-base #:home-href home-href)
+        (ul ((class ,(classes ol-outline ol-zoom-root)))
+            ,(render-node-fragment tk
+                                   #:today today
+                                   #:zoom-base zoom-base
+                                   #:toggle-base toggle-base))))

--- a/olai/web/render.rkt
+++ b/olai/web/render.rkt
@@ -661,21 +661,19 @@
 
 (define-style ol-crumb-sep #:color ,line)
 
-;; path: (listof crumb) where crumb is "Label" (a file, nowhere to go) or
-;; (list "Label" key) — a NODE, addressed the one way nodes are addressed
-;; here. A crumb never carries a ready-made href: where a key points is the
-;; route layer's answer, and it hands it down as `zoom-base` like every other
-;; address in this module.
+;; path: (listof crumb), two shapes and no third. `(list "Title" key)` is a
+;; NODE — a title, which is Markdown, at the one address nodes have; anything
+;; else is the FILE the trail hangs off, drawn the way files are named here
+;; (olai/paths) and nothing to click. A crumb never carries a ready-made href:
+;; where a key points is the route layer's answer, and it hands it down as
+;; `zoom-base` like every other address in this module.
 (define (render-breadcrumbs path #:home-href home-href #:zoom-base [zoom-base #f])
-  (define (label->xexprs label)
-    (map style-md-xexpr (title->inline-xexprs label)))
   (define (crumb->xexpr c)
     (match c
-      [(list label key)
+      [(list title key)
        `(a ((class ,ol-crumb) (href ,(href-for zoom-base key)))
-           ,@(label->xexprs label))]
-      [(? string? label) `(span ((class ,ol-crumb)) ,@(label->xexprs label))]
-      [_ `(span ((class ,ol-crumb)) ,(format "~a" c))]))
+           ,@(map style-md-xexpr (title->inline-xexprs title)))]
+      [file `(span ((class ,ol-crumb)) ,(file-label file))]))
   `(nav ((class ,ol-breadcrumbs) (aria-label "breadcrumbs"))
         ,@(if home-href
               (list `(a ((class ,(classes ol-crumb ol-crumb-home)) (href ,home-href))

--- a/olai/web/serve.rkt
+++ b/olai/web/serve.rkt
@@ -3,6 +3,7 @@
 ;; The read-mostly web view.
 ;;
 ;;   GET  /             the html page: sidebar + outline + chat panel
+;;   GET  /n/<key>      one node, zoomed: breadcrumbs + that subtree
 ;;   GET  /today        today's Daily day node, zoomed
 ;;   GET  /events       SSE stream; `outline` (data: store revision) per reload,
 ;;                      `chat` (data: one JSON frame) per agent frame
@@ -54,6 +55,10 @@
          (only-in web-server/private/mime-types make-path->mime-type)
          olai/agenda
          olai/dates
+         ;; a node's title, for the tab a zoom page opens in
+         (only-in olai/lang/expander task-title)
+         ;; key -> node, and the trail above it (what a breadcrumb is drawn from)
+         (only-in olai/index node-entry-task node-ancestors)
          olai/json/model
          olai/json/reply
          olai/load
@@ -193,9 +198,12 @@
 ;; the renderer, never guessed by it.
 (define events-href "/events")
 
-;; A node's address. There is no zoom route yet, so it is the home page
-;; anchored at the node — every node carries id="n-<key>" there.
-(define node-href-base "/#n-")
+;; A node's address: its own zoom page, keyed by the key the load layer minted
+;; (olai/load). Stable across a rename — that is what makes it a permalink —
+;; and across an ancestor's rename; NOT stable across an unanchored node moving
+;; to a new ordinal, which is what ^anchor is for (docs/cli.md).
+(define node-href-base "/n/")
+(define (node-href key) (string-append node-href-base key))
 
 ;; The chat panel's verbs. All POST, all 204: the reply the panel renders comes
 ;; back over `events-href`. The one GET is the picker's list, which is a thing
@@ -322,41 +330,76 @@
                  #:body-extra (if chat (list chat) '())))
    #:code code))
 
-(define (page-handler st agent)
+;; Every page here is the same shape: one snapshot, the chrome around it, and
+;; a live region that re-fetches THIS url on an `outline` event. `view` is
+;; handed the snapshot and answers (values main title) — the only thing three
+;; pages differ in.
+(define (outline-page st agent live-href view)
   (define chat (chat-panel agent))
-  (with-snapshot st (λ (err) (page-failure err #:live-href home-href #:chat chat))
+  (with-snapshot st (λ (err) (page-failure err #:live-href live-href #:chat chat))
     #:stale-ok? #t
     (λ (snap err)
-      (define files-data (snapshot-files-data snap))
-      (chrome files-data
-              (render-outline files-data #:today (today-iso-string))
-              #:title (page-title (store-files st))
-              #:live-href home-href
+      (define-values (main title) (view snap))
+      (chrome (snapshot-files-data snap) main
+              #:title title
+              #:live-href live-href
               #:chat chat
               #:banner (and err (error-banner err))))))
 
-;; Today's Daily day node, zoomed. No day node yet is the normal state before
-;; the first capture of the day, not an error.
+;; One node, zoomed, with the trail above it — or `missing`, said plainly.
+;;
+;; A key the snapshot does not have is not a 404: a node can be deleted, or an
+;; unanchored one re-keyed, while a tab sits zoomed on it, and that tab
+;; re-fetches this very page to find out. An error status would leave it
+;; showing a node that is gone. The snapshot is the source of truth about what
+;; exists; the route only asks it.
+(define (zoom-pane snap key today #:missing missing)
+  (define index (snapshot-index snap))
+  (define entry (and key (hash-ref index key #f)))
+  (if entry
+      (render-zoom (node-entry-task entry)
+                   (node-ancestors index key)
+                   #:today today
+                   #:home-href home-href
+                   #:zoom-base node-href-base)
+      (render-empty-pane missing #:home-href home-href)))
+
+;; A tab zoomed on one node should say which; an unknown key is just olai.
+(define (zoom-title snap key)
+  (define entry (hash-ref (snapshot-index snap) key #f))
+  (if entry (task-title (node-entry-task entry)) "olai"))
+
+(define (page-handler st agent)
+  (outline-page st agent home-href
+   (λ (snap)
+     (values (render-outline (snapshot-files-data snap)
+                             #:today (today-iso-string)
+                             #:zoom-base node-href-base)
+             (page-title (store-files st))))))
+
+;; A node's permalink.
+(define (node-handler st agent key)
+  (outline-page st agent (node-href key)
+   (λ (snap)
+     (values (zoom-pane snap key (today-iso-string) #:missing "No such node.")
+             (zoom-title snap key)))))
+
+;; Today's Daily day node, zoomed. Finding today's key is a question about the
+;; DAY; the answer goes through the same zoom pane as any permalink, and
+;; nothing under this line knows what day it is.
+;;
+;; It stays a page rather than a redirect to /n/<key>: the key it resolves to
+;; changes at local midnight (the watcher pushes an `outline` event then, which
+;; this page re-fetches on), and before the first capture of the day there is
+;; no key to redirect to. Both are ordinary states of "today", and a page
+;; frozen to the key today HAD would be neither.
 (define (today-handler st agent)
-  (define chat (chat-panel agent))
-  (with-snapshot st (λ (err) (page-failure err #:live-href today-href #:chat chat))
-    #:stale-ok? #t
-    (λ (snap err)
-      (define today (today-iso-string))
-      (define key (snapshot-day-key snap today))
-      (chrome (snapshot-files-data snap)
-              (if key
-                  (render-zoom (snapshot-index snap) key
-                               #:today today
-                               #:home-href home-href
-                               #:zoom-base node-href-base)
-                  (render-empty-pane
-                   (format "No day node for ~a. Run: olai daily" today)
-                   #:home-href home-href))
-              #:title (string-append "today " today)
-              #:live-href today-href
-              #:chat chat
-              #:banner (and err (error-banner err))))))
+  (outline-page st agent today-href
+   (λ (snap)
+     (define today (today-iso-string))
+     (values (zoom-pane snap (snapshot-day-key snap today) today
+                        #:missing (format "No day node for ~a. Run: olai daily" today))
+             (string-append "today " today)))))
 
 (define (tree-handler st)
   (with-snapshot st json-failure
@@ -379,6 +422,8 @@
   (define-values (route _url)
     (dispatch-rules
      [("") (λ (req) (page-handler st agent))]
+     ;; one page per node, addressed by the key the load layer minted
+     [("n" (string-arg)) (λ (req key) (node-handler st agent key))]
      [("today") (λ (req) (today-handler st agent))]
      ;; mounted, not understood: what an event MEANS lives in web/events
      [("events") (λ (req) (hub-response hub))]

--- a/olai/web/serve.rkt
+++ b/olai/web/serve.rkt
@@ -348,17 +348,17 @@
 
 ;; One node, zoomed: the node and the trail above it, both asked of the
 ;; snapshot's index — the only thing that knows either.
-(define (zoom-pane snap entry today)
+(define (zoom-pane index entry today)
   (render-zoom (node-entry-task entry)
-               (node-ancestors (snapshot-index snap) entry)
+               (node-ancestors index entry)
                #:today today
                #:home-href home-href
                #:zoom-base node-href-base))
 
 ;; The key a page was asked for, as a node, or #f. Both zoom routes go through
 ;; here, and each says in its own words what #f means.
-(define (node-at snap key)
-  (and key (hash-ref (snapshot-index snap) key #f)))
+(define (node-at index key)
+  (and key (hash-ref index key #f)))
 
 (define (page-handler st agent)
   (outline-page st agent home-href
@@ -378,10 +378,11 @@
 (define (node-handler st agent key)
   (outline-page st agent (node-href key)
    (λ (snap)
-     (define entry (node-at snap key))
+     (define index (snapshot-index snap))
+     (define entry (node-at index key))
      (if entry
          ;; a tab zoomed on one node should say which
-         (values (zoom-pane snap entry (today-iso-string))
+         (values (zoom-pane index entry (today-iso-string))
                  (task-title (node-entry-task entry)))
          (values (render-empty-pane "No such node." #:home-href home-href)
                  "olai")))))
@@ -399,9 +400,10 @@
   (outline-page st agent today-href
    (λ (snap)
      (define today (today-iso-string))
-     (define entry (node-at snap (snapshot-day-key snap today)))
+     (define index (snapshot-index snap))
+     (define entry (node-at index (snapshot-day-key snap today)))
      (values (if entry
-                 (zoom-pane snap entry today)
+                 (zoom-pane index entry today)
                  ;; no day node yet is the normal state before the first
                  ;; capture of the day, not an error
                  (render-empty-pane

--- a/olai/web/serve.rkt
+++ b/olai/web/serve.rkt
@@ -346,28 +346,19 @@
               #:chat chat
               #:banner (and err (error-banner err))))))
 
-;; One node, zoomed, with the trail above it — or `missing`, said plainly.
-;;
-;; A key the snapshot does not have is not a 404: a node can be deleted, or an
-;; unanchored one re-keyed, while a tab sits zoomed on it, and that tab
-;; re-fetches this very page to find out. An error status would leave it
-;; showing a node that is gone. The snapshot is the source of truth about what
-;; exists; the route only asks it.
-(define (zoom-pane snap key today #:missing missing)
-  (define index (snapshot-index snap))
-  (define entry (and key (hash-ref index key #f)))
-  (if entry
-      (render-zoom (node-entry-task entry)
-                   (node-ancestors index key)
-                   #:today today
-                   #:home-href home-href
-                   #:zoom-base node-href-base)
-      (render-empty-pane missing #:home-href home-href)))
+;; One node, zoomed: the node and the trail above it, both asked of the
+;; snapshot's index — the only thing that knows either.
+(define (zoom-pane snap entry today)
+  (render-zoom (node-entry-task entry)
+               (node-ancestors (snapshot-index snap) entry)
+               #:today today
+               #:home-href home-href
+               #:zoom-base node-href-base))
 
-;; A tab zoomed on one node should say which; an unknown key is just olai.
-(define (zoom-title snap key)
-  (define entry (hash-ref (snapshot-index snap) key #f))
-  (if entry (task-title (node-entry-task entry)) "olai"))
+;; The key a page was asked for, as a node, or #f. Both zoom routes go through
+;; here, and each says in its own words what #f means.
+(define (node-at snap key)
+  (and key (hash-ref (snapshot-index snap) key #f)))
 
 (define (page-handler st agent)
   (outline-page st agent home-href
@@ -378,11 +369,22 @@
              (page-title (store-files st))))))
 
 ;; A node's permalink.
+;;
+;; A key the snapshot has no node for is not a 404: a node can be deleted, or
+;; an unanchored one re-keyed, while a tab sits zoomed on it, and that tab
+;; re-fetches this very page to find out. An error status would leave it
+;; showing a node that is gone. The snapshot is the source of truth about what
+;; exists; this route only asks it, and says what it heard.
 (define (node-handler st agent key)
   (outline-page st agent (node-href key)
    (λ (snap)
-     (values (zoom-pane snap key (today-iso-string) #:missing "No such node.")
-             (zoom-title snap key)))))
+     (define entry (node-at snap key))
+     (if entry
+         ;; a tab zoomed on one node should say which
+         (values (zoom-pane snap entry (today-iso-string))
+                 (task-title (node-entry-task entry)))
+         (values (render-empty-pane "No such node." #:home-href home-href)
+                 "olai")))))
 
 ;; Today's Daily day node, zoomed. Finding today's key is a question about the
 ;; DAY; the answer goes through the same zoom pane as any permalink, and
@@ -397,8 +399,14 @@
   (outline-page st agent today-href
    (λ (snap)
      (define today (today-iso-string))
-     (values (zoom-pane snap (snapshot-day-key snap today) today
-                        #:missing (format "No day node for ~a. Run: olai daily" today))
+     (define entry (node-at snap (snapshot-day-key snap today)))
+     (values (if entry
+                 (zoom-pane snap entry today)
+                 ;; no day node yet is the normal state before the first
+                 ;; capture of the day, not an error
+                 (render-empty-pane
+                  (format "No day node for ~a. Run: olai daily" today)
+                  #:home-href home-href))
              (string-append "today " today)))))
 
 (define (tree-handler st)


### PR DESCRIPTION
Roadmap 0.5, WP7: a zoom route for any node, breadcrumbs from the ancestor
path, and permalinks that point at it.

    GET /n/<key>   breadcrumbs (home › file › each ancestor) + that subtree

Every bullet in the outline and every entry in the sidebar tree now links to
that node's own page. `key` is the one the load layer mints (`tree` JSON's
`key`), so a permalink survives a rename — of the node or of any ancestor.

## What moved

**`olai/index.rkt` (new).** Node addressing, inverted: `key -> node-entry`
(the node, its parent's KEY, the file it was reached through) plus
`node-ancestors`, which walks that up. `olai/store` builds one per load and
asks it nothing; `olai/main` re-exports the queries.

**`render-zoom` is handed a node and its trail.** It draws a zoom now; it does
not find one. There is no such thing as a miss at that layer.

**`/today` is a thin wrapper, not a redirect.** Which key today's day node has
is a question about the day; the answer goes through the same `zoom-pane` as
any permalink.

**One `outline-page`.** Home, `/n/<key>` and `/today` differ only in a `view`
that answers `(values main title)` from the snapshot.

## SSE

The zoom page's live region re-fetches its own url (`hx-get="/n/<key>"`), so a
save under a zoomed node lands on it. A key the snapshot has no node for
answers **200** with "No such node.", not a 404 — a tab zoomed on a node that
was just deleted re-fetches that page to find out, and htmx swaps nothing on
an error status. `/today` is unchanged in behaviour, including the midnight
event, which is exactly why it did not become a redirect.

## The two lenses

**Hickey (spatial) — what it made me change:**

- `outline-index` braided *which node is key K* with *what sits above K* (it
  stored a full crumb list per node). Split: the index answers identity and
  where a node hangs; `node-ancestors` derives the trail.
- `render-zoom` braided lookup with drawing — a hash-ref, a miss branch, and a
  `drop-right` on a crumb convention shared across three modules. It now takes
  the node and the crumbs.
- A breadcrumb's target was *a key OR a ready-made href*, told apart by
  `regexp-match?` on the value. A crumb target is a node key, full stop; where
  keys point is `zoom-base`, handed down like every other address.
- `page-handler` and `today-handler` each restated the whole page assembly.
  Now `outline-page` is that once.

**Löwy (temporal) — what it made me change:**

- The crumb trail for *every* node was computed per LOAD (file-save cadence)
  for a question asked per ZOOM about ONE node. `node-ancestors` is O(depth),
  on demand.
- The index shape changes when addressing changes; the store changes when the
  reloading machinery does. Different clocks, so different modules — and core
  still builds without `web/` (the existing test covers the new module by
  globbing core).
- It also decided `/today`: the key it resolves to moves on a CLOCK, the page's
  content on file saves. A redirect would freeze a clock-derived answer into
  the url of a file-derived page.

## Tests

`olai/tests/index.rkt` (new): the trail's shape, an unknown key, a renamed
ancestor (crumb text moves, addresses do not), a mirror site adding no second
address. Contract/blame tests for the new boundary and for `render-zoom`'s.
Serve tests for `/n/<key>`, the crumb links, the missing key, the permalink on
the home page, and an edit under a zoomed node. `just test-all`: 295 passed.
`nix build` clean.

## Also

- docs/cli.md: the route, and the permalink stability rule (unanchored nodes
  key off position — `^anchor` a link that has to outlive a move).
- CLAUDE.md: one line for the new layer.
- Roadmap.rkt untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Refactor pass (post-implementation, both lenses at once)

- **`node-ancestors` takes the node, not a key.** "That key names nothing" is
  answered once, by the route that has to draw something about it, instead of
  a second and quieter time by the query. Each zoom route looks its key up
  once, branches once, and asks the snapshot for its index once.
- **The index keeps the file as a file.** It stored a basename — a display
  decision made at load depth, and an address nothing can write back to (two
  `Daily.rkt` under different roots are one label). `render-breadcrumbs` names
  it now, where the one owner of file naming already lives.
- **The crumb grammar is two shapes and no third.** `(title key)` is a node;
  anything else is the file. The unreachable catch-all is gone, and a filename
  no longer goes through the Markdown inline reader.
- **The renderer's tests hand `render-zoom` literals.** The point of the new
  signature is that it is given both the node and the trail — those tests no
  longer build an index to make arguments, so `tests/render.rkt` needs neither
  `olai/store` nor `olai/index`.
- Skipped: making `#:zoom-base` required everywhere (a wider API decision than
  this change), moving `snapshot-day-key` out of the store (it reads
  files-data in file order, which is a snapshot-shaped fact), and keeping the
  ancestor list from `fold-tasks` in the entry (that is the O(nodes × depth)
  retention this change exists to remove).

Merged latest master (CLI shrink + `just ci` DAG); no conflicts in the code.
