### PR TITLE
serve: fall back to a free port when the default is taken

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -257,7 +257,11 @@ $ olai serve examples/Example.rkt
 olai serve http://127.0.0.1:8080 files: /.../examples/Example.rkt
 ```
 
-- `--port N` — default `8080`. `0` binds a free port and logs which one.
+- `--port N` — default `8080`. `0` binds a free port and logs which one. The
+  default is a preference: with `8080` taken, `serve` binds a free port
+  instead, says so on stderr (`olai: port 8080 is taken; serving on 41235`),
+  and the URL it prints is the port it actually bound. A port you typed is a
+  request — taken, `serve` refuses to start (exit 1).
 - `--bind ADDR` — default `127.0.0.1`. `--bind ""` listens on all interfaces.
 - **No auth.** The network is the auth: put it behind Tailscale or Caddy.
 

--- a/olai/cli.rkt
+++ b/olai/cli.rkt
@@ -342,7 +342,11 @@
 ;;
 ;; `dir` is the directory the agent works in when there was one to name (see
 ;; serve-roots); #f leaves it to the outlines' own common base.
-(define (cmd-serve paths dir port bind)
+;;
+;; `fallback?` is "nobody asked for this port" — the default. Taken, we bind a
+;; free one and say which. A port typed on the command line is a request, and
+;; a taken one is an error.
+(define (cmd-serve paths dir port fallback? bind)
   (define acp-command (acp-command-or-die))
   (define cust (make-custodian))
   (define stop
@@ -352,12 +356,17 @@
             (λ (e) (die exit-usage (exn-message e) #:json? #f))])
         (start-server
          #:port port
+         #:port-fallback? fallback?
          #:bind bind
          #:files paths
          #:acp-command acp-command
          #:agent-cwd dir
          #:on-listen
          (λ (bound)
+           ;; The URL below is always the port actually bound; this line is
+           ;; why it is not the one you expected.
+           (when (and fallback? (not (= bound port)))
+             (eprintf "olai: port ~a is taken; serving on ~a\n" port bound))
            (printf "olai serve http://~a:~a ~afiles: ~a\n"
                    (or bind "0.0.0.0") bound
                    (if dir (format "dir: ~a " dir) "")
@@ -443,22 +452,24 @@
 
 (define (cli-serve)
   (define port 8080)
+  (define asked? #f)
   (define bind "127.0.0.1")
   (define file-args '())
   (command-line
    #:program "olai serve"
    #:once-each
-   [("--port") p "TCP port (default: 8080; 0 picks a free one)"
+   [("--port") p "TCP port (default: 8080, or a free one if taken; 0 picks a free one)"
                (define n (string->number p))
                (unless (and (exact-nonnegative-integer? n) (< n 65536))
                  (die exit-usage (format "invalid --port ~s" p) #:json? #f))
-               (set! port n)]
+               (set! port n)
+               (set! asked? #t)]
    [("--bind") a "Listen address (default: 127.0.0.1; \"\" for all)"
                (set! bind a)]
    #:args paths
    (set! file-args paths))
   (define-values (roots dir) (serve-roots file-args))
-  (cmd-serve roots dir port (if (string=? bind "") #f bind)))
+  (cmd-serve roots dir port (not asked?) (if (string=? bind "") #f bind)))
 
 (define (cli-add)
   (define file-arg #f)

--- a/olai/tests/integration/serve.rkt
+++ b/olai/tests/integration/serve.rkt
@@ -10,6 +10,7 @@
          racket/path
          racket/port
          racket/string
+         racket/tcp
          olai/web/serve)
 
 ;; Sizes differ on every write below: the store's staleness probe is mtime +
@@ -24,23 +25,30 @@
    "Ship the server ^serve\n"))
 
 ;; Run body with the server up: (proc port outline-path). The path is handed
-;; back so a test can edit the outline underneath a running server.
-(define (with-server proc)
+;; back so a test can edit the outline underneath a running server. The temp
+;; dir goes whether or not the server came up, which is a case here.
+(define (with-server proc #:port [port 0] #:port-fallback? [fallback? #f])
   (define dir (make-temporary-file "sfserve~a" 'directory))
   (define f (build-path dir "Tasks.rkt"))
   (display-to-file outline f #:exists 'truncate)
-  (define bound #f)
-  (define stop
-    (start-server #:port 0
-                  #:bind "127.0.0.1"
-                  #:files (list f)
-                  #:on-listen (λ (p) (set! bound p))))
   (dynamic-wind
    void
-   (λ () (proc bound f))
    (λ ()
-     (stop)
-     (delete-directory/files dir))))
+     (define bound #f)
+     (define stop
+       (start-server #:port port
+                     #:port-fallback? fallback?
+                     #:bind "127.0.0.1"
+                     #:files (list f)
+                     #:on-listen (λ (p) (set! bound p))))
+     (dynamic-wind void (λ () (proc bound f)) stop))
+   (λ () (delete-directory/files dir))))
+
+;; A port that is already bound, for the two "taken" cases: (proc port).
+(define (with-taken-port proc)
+  (define l (tcp-listen 0 4 #t "127.0.0.1"))
+  (define-values (_h port _rh _rp) (tcp-addresses l #t))
+  (dynamic-wind void (λ () (proc port)) (λ () (tcp-close l))))
 
 ;; -> (values status-code headers body-string)
 (define (GET port path)
@@ -87,6 +95,25 @@
       [else (loop name data)])))
 
 (module+ test
+  ;; The port the CLI did not have to be told (its default): taken means take
+  ;; another one, and on-listen hears which.
+  (test-case "a taken port falls back to a free one when it was only a default"
+    (with-taken-port
+     (λ (taken)
+       (with-server
+        #:port taken #:port-fallback? #t
+        (λ (bound f)
+          (check-not-equal? bound taken)
+          (define-values (code _h body) (GET bound "/"))
+          (check-equal? code 200 body))))))
+
+  ;; A port asked for by name is a request, not a preference.
+  (test-case "a taken port without the fallback is an error"
+    (with-taken-port
+     (λ (taken)
+       (check-exn exn:fail:network?
+                  (λ () (with-server #:port taken (λ (bound f) (void))))))))
+
   (test-case "GET / is an html page with the outline in it"
     (with-server
      (λ (port f)

--- a/olai/web/serve.rkt
+++ b/olai/web/serve.rkt
@@ -38,6 +38,7 @@
          racket/port
          racket/promise
          racket/string
+         racket/tcp
          (for-syntax racket/base)
          json
          net/url
@@ -423,8 +424,38 @@
 
 ;; ---- server ---------------------------------------------------------------
 
+;; Bind the dispatcher. -> (values stop bound-port). #:port 0 means "pick
+;; one"; fallback? means the port asked for is a preference, not a request —
+;; taken, we take a free one instead. Without it a taken port is an error,
+;; which is what a port asked for by name deserves.
+;;
+;; The probe is what keeps the fallback quiet: the web server's listener
+;; thread re-raises a failed bind after reporting it, so walking into one
+;; dumps a stack trace on the way to an ordinary "that port was taken". The
+;; handler is still there, for the race between probing and binding.
+(define (listen dispatch port bind fallback?)
+  (define (free? port)
+    (with-handlers ([exn:fail:network? (λ (_e) #f)])
+      (tcp-close (tcp-listen port 4 #t bind))
+      #t))
+  (define (go port)
+    (define confirm (make-async-channel 1))
+    (define stop
+      (serve #:dispatch dispatch
+             #:port port
+             #:listen-ip bind
+             #:confirmation-channel confirm))
+    (define bound (async-channel-get confirm))
+    (when (exn? bound)
+      (stop)
+      (raise bound))
+    (values stop bound))
+  (with-handlers ([(λ (e) (and fallback? (exn:fail:network? e)))
+                   (λ (_e) (go 0))])
+    (go (if (and fallback? (not (free? port))) 0 port))))
+
 ;; Returns a stop procedure. #:on-listen gets the port actually bound (useful
-;; when #:port is 0, i.e. "pick one").
+;; when #:port is 0, i.e. "pick one", or when #:port-fallback? took over).
 ;;
 ;; #:acp-command is the agent `serve` chats with — #f means there is none, and
 ;; the CLI never passes #f (it refuses to start without one; see docs/cli.md).
@@ -432,6 +463,7 @@
 ;; #:on-agent is handed the conversation once it exists: the seam for tests,
 ;; and for anything that wants to prompt the agent without an HTTP request.
 (define (start-server #:port [port 8080]
+                      #:port-fallback? [port-fallback? #f]
                       #:bind [bind "127.0.0.1"]
                       #:files files
                       #:acp-command [acp-command #f]
@@ -451,16 +483,8 @@
          (make-chat #:command acp-command
                     #:cwd (or agent-cwd (roots-base files))
                     #:broadcast (λ (name data) (hub-broadcast! hub name data)))))
-  (define confirm (make-async-channel 1))
-  (define stop
-    (serve #:dispatch (make-dispatcher st hub agent)
-           #:port port
-           #:listen-ip bind
-           #:confirmation-channel confirm))
-  (define bound (async-channel-get confirm))
-  (when (exn? bound)
-    (stop)
-    (raise bound))
+  (define-values (stop bound)
+    (listen (make-dispatcher st hub agent) port bind port-fallback?))
   ;; Only once there is a listener: a watcher with nobody to tell is a
   ;; thread that reloads outlines for its own amusement.
   ;;


### PR DESCRIPTION
`olai serve` (so `just serve` / `just run` / `just watch`) refused to start
when 8080 was already bound — the one port nobody types. Now it behaves like
vite: the default is a preference.

- default taken -> bind a free port, `olai: port 8080 is taken; serving on
  41235` on stderr, and the URL on stdout is the port actually bound (that
  line keeps its shape).
- `--port N` taken -> still a loud failure, exit 1. A port you asked for by
  name is a request.

The choice sits at the CLI boundary where the default is applied
(`cli-serve` knows whether `--port` was typed); the mechanism is
`start-server`'s new `#:port-fallback?`. It probes the port before binding,
because the web server's listener thread re-raises a failed bind and would
dump a stack trace on the way to an ordinary "that one was taken"; the
handler stays for the probe/bind race.

Tests (olai/tests/integration/serve.rkt): a taken port with the fallback
serves elsewhere and answers GET /; a taken port without it raises.
`just test` and `just test-integration` green locally.

docs/cli.md `--port` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)