### PR TITLE
roadmap: park the flaky chat boot-frame race, with the diagnosis

### DIFF
--- a/Roadmap.rkt
+++ b/Roadmap.rkt
@@ -183,6 +183,28 @@ olai roadmap #project
       : collapse #bug becomes its regression test); chat panel open
       : keeps .ol-main readable (the #14 wrap bug); theme flip
       : persists across reload.
+    chat boot frames race the assertions #bug
+      : integration/chat.rkt fails intermittently, on either runner, with an
+      : extra LEADING frame: ("commands" "session" "user" "chunk") for
+      : ("user" "chunk") at chat.rkt:886, and ("commands" "reset" ...) for
+      : ("reset" ...) at chat.rkt:949.
+      : Not a commit: it failed on master at 46cf193a — a Roadmap.rkt-only
+      : commit — with f6d1b71c before it and c609691d after it both green,
+      : and once on PR #17's macOS lane, green on re-run with no chat or acp
+      : change. Two different assertions, two different runners, always the
+      : same shape.
+      : Cause: with-server gates on wait-booted (chat.rkt:167), which waits
+      : for chat-session-id — set from the session/new RESULT. The fake
+      : agent emits commands! and session-info! one round trip LATER, on
+      : session/set_mode (fake-acp-agent.rkt:349). chat-boot! runs in its
+      : own thread (serve.rkt), so those two frames can land after the test
+      : opens /events and inside its assertion window. The fake agent pins
+      : the order AMONG boot frames; nothing pins boot against the test's
+      : own subscription, which is the ordering that breaks.
+      : Fix: gate on the LAST boot signal, not the first — wait-booted
+      : answers (and (chat-session-id ag) (pair? (chat-commands ag))), since
+      : chat-commands is populated by the very frame that races and the fake
+      : agent ships a non-empty list at boot. One line, no product change.
     refactor pass ^pre-squash
       : Structural cleanups batched together, done just prior to squashing
       : master into one root commit.


### PR DESCRIPTION
Parks the intermittent `integration/chat.rkt` failure under `codebase`, with
the evidence and the root cause, so it is not re-derived from a red run.

**It is a flake, not a regression.** It failed on master at `46cf193a` — a
`Roadmap.rkt`-only commit — with `f6d1b71c` before it and `c609691d` after it
both green, and once on PR #17's macOS lane, green on re-run with no chat or
acp change. Two different assertions, two different runners, always the same
shape: an extra **leading** frame.

```
chat.rkt:886  actual ("commands" "session" "user" "chunk")  expected ("user" "chunk")
chat.rkt:949  actual ("commands" "reset" "user" ...)        expected ("reset" "user" ...)
```

**Cause.** `with-server` gates on `wait-booted` (`chat.rkt:167`), which waits
for `chat-session-id` — set from the `session/new` *result*. The fake agent
emits `commands!` and `session-info!` one round trip later, on
`session/set_mode` (`fake-acp-agent.rkt:349`). `chat-boot!` runs in its own
thread, so those two frames can land after the test opens `/events` and inside
its assertion window. The fake agent pins the order *among* boot frames;
nothing pins boot against the test's own subscription, which is the ordering
that breaks.

**Fix (recorded, not applied):** gate on the last boot signal rather than the
first — `(and (chat-session-id ag) (pair? (chat-commands ag)))` — since
`chat-commands` is populated by the very frame that races. One line in the
test helper, no product change.

Roadmap only; `olai check Roadmap.rkt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
