### PR TITLE
chat: only this directory's stored sessions are listed and adopted

### DIFF
--- a/olai/acp.rkt
+++ b/olai/acp.rkt
@@ -367,16 +367,55 @@
 (define (session-stamp s)
   (or (string-or-false (hash-ref s 'updatedAt #f)) ""))
 
+;; A directory, canonically: complete, links resolved, and one spelling for "/x"
+;; and "/x/". Two of these are the same place when they are `equal?`. Not
+;; `simple-form-path`, which leaves a link spelled the way it was written: the
+;; agent reports the directory its own process is in, which the kernel already
+;; resolved, and a server started through a symlink would match nothing.
+;; Raises for a directory that is not there — a place that does not exist is
+;; not one to compare against.
+(define (as-directory p)
+  (path->directory-path (normalize-path p)))
+
+;; -> #t when `c`, a cwd off the wire, names `dir`. Compared as directories and
+;; not as strings: an agent stores the spelling it was handed.
+(define (same-directory? c dir)
+  (and (string? c)
+       (with-handlers ([exn:fail? (λ (_e) #f)])
+         (equal? (as-directory (string->path c)) dir))))
+
 ;; The agent's stored sessions for THIS cwd, newest first. Raw entries —
 ;; {sessionId, cwd, title, updatedAt} — the picker's shape is minted below.
+;;
+;; The `cwd` sent is a REQUEST, not a filter: the Claude Code adapter scopes its
+;; answer by PREFIX, so a server started in a checkout is told about every agent
+;; working under it — a worktree, an orchestrator in the root. Boot adopts the
+;; newest of what comes back, so trusting the list is how a task agent's coding
+;; session becomes the web chat's conversation. The entries say where they were
+;; worked in; only that exact directory is ours, and an entry that names none
+;; cannot be shown to be.
+;;
+;; Filtered HERE because everything downstream — the picker, the title a load
+;; shows, and boot's adopt-the-newest — draws from this one list.
 (define (list-sessions cl)
   (define r (request! cl "session/list"
                       (hash 'cwd (path->string (acp-client-cwd cl)))))
   (define raw (let ([ss (hash-ref r 'sessions '())]) (if (list? ss) ss '())))
-  (sort (for/list ([s (in-list raw)]
-                   #:when (and (hash? s) (string? (hash-ref s 'sessionId #f))))
-          s)
-        string>? #:key session-stamp))
+  (define here (as-directory (acp-client-cwd cl)))
+  (define mine
+    (for/list ([s (in-list raw)]
+               #:when (and (hash? s)
+                           (string? (hash-ref s 'sessionId #f))
+                           (same-directory? (hash-ref s 'cwd #f) here)))
+      s))
+  ;; A list that was emptied by the filter looks exactly like a machine with
+  ;; nothing stored — a fresh panel every boot, and no way to tell which it was.
+  ;; Said once: the picker asks again every time it is drawn.
+  (when (and (pair? raw) (null? mine))
+    (acp-log-once! cl "sessions-elsewhere"
+                   (format "~a stored session(s), none of them in ~a"
+                           (length raw) (path->string here))))
+  (sort mine string>? #:key session-stamp))
 
 ;; The name the picker showed for a session, off the same list it drew. Worth
 ;; a round trip on a button press: the agent pushes a title only when it

--- a/olai/tests/integration/acp.rkt
+++ b/olai/tests/integration/acp.rkt
@@ -78,13 +78,13 @@
 (define (event-of evs name)
   (for/or ([ev (in-list evs)]) (and (eq? (event-name ev) name) ev)))
 
-;; The fake agent keeps stored sessions only when it is told to (see its
-;; header): the environment is what the subprocess inherits, so this is set
-;; around the whole of a test, agent and all.
-(define (with-stored-sessions thunk)
+;; The fake agent keeps stored sessions only when it is told to, and `mode`
+;; says whose (see its header): the environment is what the subprocess
+;; inherits, so this is set around the whole of a test, agent and all.
+(define (with-stored-sessions thunk [mode #"1"])
   (define env (current-environment-variables))
   (dynamic-wind
-   (λ () (environment-variables-set! env #"OLAI_FAKE_ACP_STORED" #"1"))
+   (λ () (environment-variables-set! env #"OLAI_FAKE_ACP_STORED" mode))
    thunk
    (λ () (environment-variables-set! env #"OLAI_FAKE_ACP_STORED" #f))))
 
@@ -136,12 +136,19 @@
                           user-said said said tool tool-moved
                           replay-ended session config-model commands session-titled))
           (check-equal? (acp-user-said-text (event-of evs 'user-said)) "what did we do")
-          ;; the newer of the two stored sessions, not the first one listed,
-          ;; and it comes with the name it was listed under
+          ;; The newer of this client's two, and it comes with the name it was
+          ;; listed under. Not the first one listed, and not the newest thing
+          ;; the agent knows about: session/list is scoped by PREFIX, so the
+          ;; fake answers with a session from a directory UNDERNEATH this one
+          ;; (another checkout's agent) that is newer than either. Adopting
+          ;; that is the bug. `fake-stored-new` also spells its cwd with a
+          ;; trailing slash — the same directory, said differently.
           (define s (event-of evs 'session))
           (check-equal? (acp-session-id s) "fake-stored-new")
           (check-equal? (acp-session-title s) "the last conversation"))))))
 
+  ;; The picker draws this list, so the foreign session must not be in it
+  ;; either: these are the ids, whole, and there are two of them.
   (test-case "the stored sessions are listed, newest first, with the current one marked"
     (with-stored-sessions
      (λ ()
@@ -156,6 +163,24 @@
                         '(#t #f))
           (check-equal? (hash-ref (car ss) 'title) "the last conversation")
           (check-true (string? (hash-ref (car ss) 'updatedAt))))))))
+
+  ;; With NOTHING but somebody else's stored, there is nothing to adopt: a
+  ;; fresh session, exactly as on a machine that has none at all.
+  (test-case "a boot that finds only other directories' sessions starts a new one"
+    (with-stored-sessions
+     (λ ()
+       (with-client
+        (λ (cl events log)
+          (acp-boot! cl)
+          (define evs (events-through events 'session-titled))
+          (check-equal? (event-names evs) boot-events)
+          (check-equal? (acp-session-id (event-of evs 'session)) "fake-session-1")
+          (check-equal? (acp-sessions cl) '())
+          ;; and the log says which of the two this was: a list emptied by the
+          ;; filter looks exactly like a machine with nothing stored
+          (check-true (string-contains? (get-output-string log) "none of them in")
+                      (get-output-string log)))))
+     #"foreign"))
 
   ;; An agent that is not running is not a list that is empty.
   (test-case "asking a dead agent for its sessions is a validation failure"

--- a/olai/tests/integration/fake-acp-agent.rkt
+++ b/olai/tests/integration/fake-acp-agent.rkt
@@ -13,11 +13,13 @@
 ;; a property of the machine the agent woke up on, not of anything a client
 ;; says:
 ;;
-;;   OLAI_FAKE_ACP_STORED   non-empty -> session/list answers with two
-;;                               conversations and session/load replays the
-;;                               one that is asked for; unset (the default) ->
-;;                               nothing is stored, so a client boots the way
-;;                               it always did, with session/new
+;;   OLAI_FAKE_ACP_STORED   unset (the default) -> nothing is stored, so a
+;;                               client boots the way it always did, with
+;;                               session/new. Set -> session/list answers and
+;;                               session/load replays what it is asked for:
+;;                               "foreign" is only other directories'
+;;                               conversations, anything else is two of the
+;;                               client's own plus a newer foreign one
 ;;
 ;; Behaviour is keyed on the prompt text, so a test asks for what it needs:
 ;;
@@ -74,22 +76,47 @@
 ;; sends carry the loaded id, the way a real one's do.
 (define session-id (box "fake-session-1"))
 
-;; What this machine has stored, newest LAST on purpose — a client that takes
-;; the first entry instead of the most recently updated one gets the wrong
-;; conversation, and a test says so.
-(define stored-sessions
-  (list (hash 'sessionId "fake-stored-old"
-              'cwd "/tmp"
-              'title "an older conversation"
-              'updatedAt "2026-07-01T09:00:00.000Z")
-        (hash 'sessionId "fake-stored-new"
-              'cwd "/tmp"
-              'title "the last conversation"
-              'updatedAt "2026-08-01T17:30:00.000Z")))
+;; The name each stored conversation goes by, wherever it was worked in.
+(define stored-titles
+  (hash "fake-stored-old" "an older conversation"
+        "fake-stored-new" "the last conversation"
+        "fake-foreign" "another checkout's conversation"))
+
+;; The same directory, spelled with a trailing slash; and one beneath it.
+(define (as-dir cwd) (path->string (path->directory-path (string->path cwd))))
+(define (beneath cwd . parts) (path->string (apply build-path (string->path cwd) parts)))
+
+;; What this machine has stored, given the directory a client asked about.
+;; Three things here are deliberate:
+;;
+;;   * the client's own two are newest LAST, so a client that takes the first
+;;     entry instead of the most recently updated one gets the wrong one;
+;;   * one of them spells that directory with a trailing slash — an agent
+;;     stores the spelling it was handed, and it is the same place;
+;;   * the FOREIGN one is newer than either and sits UNDERNEATH the directory
+;;     asked about. A real adapter scopes session/list by PREFIX, which is how
+;;     another checkout's agent (a worktree, an orchestrator) turns up in the
+;;     answer; a client that trusts the list adopts THAT.
+(define (stored-sessions cwd)
+  (define (entry id dir stamp)
+    (hash 'sessionId id 'cwd dir 'title (hash-ref stored-titles id) 'updatedAt stamp))
+  (define foreign
+    (list (entry "fake-foreign" (beneath cwd ".worktrees" "other")
+                 "2026-08-04T11:00:00.000Z")))
+  (if (foreign-only?)
+      foreign
+      (append (list (entry "fake-stored-old" cwd "2026-07-01T09:00:00.000Z")
+                    (entry "fake-stored-new" (as-dir cwd) "2026-08-01T17:30:00.000Z"))
+              foreign)))
+
+(define (stored-mode)
+  (or (getenv "OLAI_FAKE_ACP_STORED") ""))
 
 (define (stored?)
-  (define v (getenv "OLAI_FAKE_ACP_STORED"))
-  (and v (not (string=? v ""))))
+  (not (string=? (stored-mode) "")))
+
+(define (foreign-only?)
+  (string=? (stored-mode) "foreign"))
 
 ;; Set by a session/cancel notification, cleared when a prompt is accepted —
 ;; both in the reading loop, so the two stay in the order they arrived.
@@ -189,12 +216,8 @@
 ;; pushes it when it moved; this one says it once, as soon as there is a
 ;; session to say it about, so the frame it becomes is where a test can find it.
 (define (session-info!)
-  (define stored
-    (for/or ([s (in-list stored-sessions)])
-      (and (equal? (hash-ref s 'sessionId) (unbox session-id))
-           (hash-ref s 'title))))
   (update! (hash 'sessionUpdate "session_info_update"
-                 'title (or stored "a fake conversation")
+                 'title (hash-ref stored-titles (unbox session-id) "a fake conversation")
                  'updatedAt "2026-08-05T12:00:00.000Z")))
 
 ;; ---- replaying a stored session ---------------------------------------------
@@ -323,8 +346,12 @@
                         'agentCapabilities (hash 'loadSession #t
                                                  'sessionCapabilities (hash 'list (hash)))
                         'agentInfo (hash 'name "fake-acp-agent" 'version "1")))]
+    ;; Answered for the directory the client asked about, and NOT filtered to
+    ;; it: see `stored-sessions`.
     [(equal? method "session/list")
-     (respond! id (hash 'sessions (if (stored?) stored-sessions '())))]
+     (respond! id (hash 'sessions (if (stored?)
+                                      (stored-sessions (hash-ref params 'cwd))
+                                      '())))]
     [(equal? method "session/new")
      (remember-raw-filter! params)
      (respond! id (hash 'sessionId (unbox session-id) 'configOptions (config-options)))]
@@ -335,8 +362,7 @@
     [(equal? method "session/load")
      (define sid (hash-ref params 'sessionId #f))
      (cond
-       [(and (stored?) (for/or ([s (in-list stored-sessions)])
-                         (equal? (hash-ref s 'sessionId) sid)))
+       [(and (stored?) (hash-ref stored-titles sid #f))
         (remember-raw-filter! params)
         (set-box! session-id sid)
         (replay!)


### PR DESCRIPTION
Fixes the roadmap `#bug`: **session picker adopts foreign sessions**.

An ACP agent's `session/list` is scoped by PREFIX, so `olai serve` from one
checkout was told about every agent working underneath it — `.worktrees/*`,
an orchestrator in the root — and boot ADOPTED the newest of them. A task
agent's coding session became the web chat's conversation.

## The fix

`list-sessions` (olai/acp.rkt) keeps only the entries whose `cwd` names the
client's own directory. Compared as DIRECTORIES, not strings: `normalize-path`
so a link resolves the way the agent's own `process.cwd()` already has, and
`path->directory-path` so `/x` and `/x/` are the same place. An entry that
names no directory cannot be shown to be ours, and is dropped.

One place, because everything downstream draws from that one list — the
picker (`acp-sessions`), the title a load shows (`stored-title`), and boot's
adopt-the-newest (`adopt-or-create!`). The chat layer grows no filtering of
its own and `acp.rkt` learns nothing about `web/`.

A list emptied by the filter is logged once: it is otherwise indistinguishable
from a machine with nothing stored (a fresh panel every boot, and no way to
tell which it was).

## Tests

The fake agent now answers `session/list` for the directory it was asked
about, unfiltered — two of the client's own (one spelling that directory with
a trailing slash) plus a FOREIGN one, newer than either, in a directory
underneath it. That is the shape that made the bug, so the existing adopt and
list cases now fail without the fix. `OLAI_FAKE_ACP_STORED=foreign` is the
none-of-them-match case: nothing to adopt, so a fresh session, and the log
says why.

Without the filter: 4/15 fail. With it: `just test` (191) and
`just test-integration` (93) green.

## Not in scope

`acp-load-session!` still takes any session id, so a hand-rolled
`POST /chat/load` with a foreign id would load it. Unreachable from the
picker now that the list is filtered, and the guard needs its own policy call
(an agent that loads but will not list) — flagged, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
