### PR TITLE
tests: gate with-server on the LAST boot frame, not the first

### DIFF
--- a/olai/tests/integration/chat.rkt
+++ b/olai/tests/integration/chat.rkt
@@ -163,12 +163,23 @@
      (stop)
      (delete-directory/files dir))))
 
-;; -> #t once the bridge has a session.
+;; -> #t once the bridge has said everything a boot says (see `boot-frames`).
+;;
+;; The session id is the FIRST of those, not the last: it comes off the
+;; session/new RESULT, while the commands and the conversation's name are still
+;; a round trip away, on session/set_mode. Waiting for the id alone let those
+;; two land after the body opened /events and inside its assertions. So wait
+;; for all three — whichever way the session was got, the last frame of the
+;; boot is one of them (a new session names itself last, an adopted one already
+;; had its name and finishes on the commands).
 (define (wait-booted ag [seconds 30])
   (define deadline (+ (current-inexact-milliseconds) (* 1000.0 seconds)))
   (let loop ()
     (cond
-      [(chat-session-id ag) #t]
+      [(and (chat-session-id ag)
+            (pair? (chat-commands ag))
+            (chat-session-title ag))
+       #t]
       [(>= (current-inexact-milliseconds) deadline) #f]
       [else (sleep 0.02) (loop)])))
 


### PR DESCRIPTION
Fixes the flake parked in `Roadmap.rkt` under "chat boot frames race the
assertions" — `integration/chat.rkt` failing on either runner with an extra
**leading** `("commands" "session" …)` in an assertion that expected only the
turn's own frames.

## What raced

`with-server` gates on `wait-booted`, which waited for `chat-session-id`. That
is the **first** boot signal, not the last: it comes off the `session/new`
*result*. The commands and the conversation's name are a round trip later, on
`session/set_mode` (`fake-acp-agent.rkt`) — and `chat-boot!` runs in its own
thread (`serve.rkt:503`), so `wait-booted` could return while those two
notifications were still in flight, and they landed after the body opened
`/events`.

The diagnosis in the roadmap holds. Its proposed one-liner does not:

```racket
(and (chat-session-id ag) (pair? (chat-commands ag)))   ;; not enough
```

`session-info!` is emitted *after* `commands!`, so the trailing `session`
(title) frame still races — same bug, narrower window. This waits for all
three. Whichever way the session was got, the last frame of the boot is one of
them: a new session names itself last, an adopted one already had its name and
finishes on the commands.

Test helper only — no product change.

## Proof

The race does not reproduce naturally here (25/25 green before the change, and
25/25 after). So the window was widened with a temporary `(sleep 0.3)` in the
fake agent — reverted before commit, it appears in no diff — at each of the two
points where a boot frame can slip through:

| widening | gate | result |
| --- | --- | --- |
| after the `set_mode` response, before `commands!` | id only (before) | **3/3 fail** — `("user" "commands" "session" "chunk")` for `("user" "chunk")` |
| same | id + commands + title | 3/3 pass |
| after `commands!`, before `session-info!` | id + commands (the parked one-liner) | **2/2 fail** — `("user" "session" "chunk")` for `("user" "chunk")` |
| same | id + commands + title | 3/3 pass |

The first row is the shape reported from CI, reproduced exactly.

`just test` (191 tests) and `just test-integration` (94 tests) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)