### PR TITLE
e2e: browser journeys (cucumber + playwright), own lane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ compiled/
 # leaves behind is nix's business, not the repo's.
 /acp/node_modules/
 
+# The e2e harness's deps are a derivation (e2e/default.nix); `just e2e`
+# symlinks them here so ESM resolution can find them.
+/e2e/node_modules
+
 /.direnv
 
 # Agent scratch worktrees

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ just serve                       # $OLAI_HOME on http://127.0.0.1:8080
 just test                        # unit tests (in-process; builds first)
 just test-integration            # subprocess CLI + servers
 just test-all                    # both
+just e2e                         # browser journeys (cucumber + playwright)
 just ci                          # full CI DAG (nix + smoke + tests; odu root)
 just clean                       # drop olai/**/compiled
 just css-classes                 # regenerate olai/tests/classes.golden

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -22,7 +22,7 @@ nix_shell := if env('IN_NIX_SHELL', '') != '' { '' } else { 'nix develop --accep
 [macos]
 [parallel]
 [metadata("ci")]
-default: smoke test test-integration
+default: smoke test test-integration e2e
 
 # One install + raco setup per lane — funnel every racket test through this.
 build:
@@ -34,7 +34,7 @@ nix:
 
 # Packaged binary can load and check committed outlines.
 smoke: nix
-    ./result/bin/olai check examples/Example.rkt Roadmap.rkt
+    ./result/bin/olai check examples/Example.rkt Roadmap.rkt e2e/fixtures/Tasks.rkt
 
 # Unit tests: in-process (olai/tests/*.rkt).
 test: build
@@ -43,3 +43,25 @@ test: build
 # Integration tests: subprocess CLI + real servers (olai/tests/integration/).
 test-integration: build
     {{ nix_shell }} raco test -j {{ num_cpus() }} olai/tests/integration/
+
+# Its own devShell (node + the browser), so the prefix here is not nix_shell —
+# and its own node in the DAG, never part of `test`. It calls the RUNNER, not
+# `just e2e`: that recipe builds first, and a lane body that rebuilt would take
+# the pkg lock while the other lanes are reading .zo (see the header).
+#
+# CUCUMBER_RETRY is the CI-only budget for a browser that lost a frame on a
+# loaded runner; a developer sees the first failure instead. CUCUMBER_PARALLEL
+# is small on purpose: two racket test lanes are already running beside this
+# one, each with -j num_cpus().
+
+# Browser journeys: cucumber + playwright, one `olai serve` per scenario.
+[linux]
+e2e: build
+    CUCUMBER_RETRY=1 CUCUMBER_PARALLEL=4 nix develop .#e2e --accept-flake-config -c just e2e-run
+
+# The browser bundle is nixpkgs' (playwright-driver), and only its Linux one
+# is exercised here: a second browser to keep trusting buys no coverage the
+# racket lanes do not already have on macOS.
+[macos]
+e2e:
+    @echo "e2e: linux only (see ci/mod.just)"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -258,6 +258,9 @@ olai serve http://127.0.0.1:8080 files: /.../examples/Example.rkt
 ```
 
 - `--port N` — default `8080`. `0` binds a free port and logs which one.
+  That startup line is a contract: the e2e harness reads the port back
+  out of it (`e2e/support/server.js`), which is how a scenario gets a
+  server nobody else can collide with.
 - `--bind ADDR` — default `127.0.0.1`. `--bind ""` listens on all interfaces.
 - **No auth.** The network is the auth: put it behind Tailscale or Caddy.
 

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -91,6 +91,46 @@ Class-name renames: run `just css-classes` to regenerate
 * `just test` — unit, in-process, `olai/tests/*.rkt`
 * `just test-integration` — spawns `olai`, boots servers
 * `just test-all` — both, one `-j` pool
+* `just e2e` — browser journeys (see below); never in `just test`
 * Parse JSON with `read-json`. Never string-match JSON.
 * Personal outline data is `$OLAI_HOME` (outside the repo). CI and
   tests use `examples/` only.
+
+## e2e (browser)
+
+`e2e/` is cucumber-js + Playwright over a real headless Chromium: the
+journeys the racket tests cannot see, because they stop at HTTP and no
+JS runs there — folding, the theme picker, the live re-swap, the chat
+panel's geometry.
+
+* `just e2e` runs the suite; arguments go straight to cucumber, so
+  `just e2e features/chat.feature` and `just e2e features/chat.feature:12`
+  both work. `--tags` on the command line is ANDed with the profile's
+  `not @skip`, so it can only ever narrow: to run a skipped scenario,
+  replace the filter — `CUCUMBER_TAGS='@skip' just e2e`.
+* It is **not** in `just test` (that stays the fast racket set) and it
+  is its own CI node (`ci/mod.just`, Linux only).
+* Node, the browser and the harness's `node_modules` come from a
+  SEPARATE devShell (`nix develop .#e2e`); the recipe enters it itself.
+  Nothing racket-only pays for a 500 MB browser.
+* `e2e/package.json` pins `playwright` to the same version as nixpkgs'
+  `playwright-driver` (the browser bundle `PLAYWRIGHT_BROWSERS_PATH`
+  points at). Bump them together or scenario one says "Executable
+  doesn't exist".
+* Deps are a derivation (`e2e/default.nix`, one fixed-output
+  `fetchNpmDeps`, like `acp/`); the regenerate-the-hash recipe is in
+  that file's header, next to the hash it is about.
+* The fixture outline is a real file, `e2e/fixtures/Tasks.rkt`, checked
+  by the `smoke` lane like any other committed outline.
+* Each scenario gets its own temp outline, its own `olai serve` on an
+  ephemeral port (`--port 0`; the server prints the port it took), and
+  a fresh browser context — so localStorage, folds and prefs start
+  empty every time.
+* The agent is ALWAYS `olai/tests/integration/fake-acp-agent.rkt`
+  (`e2e/support/server.js` sets `OLAI_ACP_AGENT`). No real Claude Code
+  is ever spawned by a test.
+* `@skip` is the regression harness for known-broken behaviour: the
+  scenario is written and excluded. `CUCUMBER_TAGS=@skip just e2e` runs
+  exactly those. `CUCUMBER_RETRY` (CI sets 1) and `CUCUMBER_PARALLEL`
+  are the other two knobs.
+* Assert behaviour and geometry, never pixel snapshots.

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -128,7 +128,13 @@ panel's geometry.
   empty every time.
 * The agent is ALWAYS `olai/tests/integration/fake-acp-agent.rkt`
   (`e2e/support/server.js` sets `OLAI_ACP_AGENT`). No real Claude Code
-  is ever spawned by a test.
+  is ever spawned by a test. What it woke up with is a scenario TAG —
+  `@stored-sessions`, `@foreign-sessions` — because stored
+  conversations are a fact about the machine, not something a step can
+  arrange later (`e2e/support/hooks.js`).
+* `serve` answers requests while the agent is still booting, so a
+  scenario about what the panel comes up KNOWING says `Given the agent
+  has woken up` first (`world.waitForAgent`).
 * `@skip` is the regression harness for known-broken behaviour: the
   scenario is written and excluded. `CUCUMBER_TAGS=@skip just e2e` runs
   exactly those. `CUCUMBER_RETRY` (CI sets 1) and `CUCUMBER_PARALLEL`

--- a/e2e/cucumber.js
+++ b/e2e/cucumber.js
@@ -1,0 +1,28 @@
+// cucumber-js configuration. `just e2e` runs it; nothing else does.
+//
+// No `paths`: cucumber already defaults to features/**/*.feature, and the key
+// is ADDITIVE in the merge — spelling the same glob here would concatenate
+// with a feature named on the command line rather than be replaced by it.
+
+export default {
+  import: ["steps/**/*.js", "support/**/*.js"],
+
+  // @skip is the regression harness for behaviour that is known-broken: the
+  // scenario is written, and it is not run. CUCUMBER_TAGS replaces this
+  // outright (a --tags on the command line is ANDed with it, so that one can
+  // only narrow): `CUCUMBER_TAGS=@skip just e2e` runs exactly those.
+  tags: process.env.CUCUMBER_TAGS || "not @skip",
+
+  // Off by default: a flake that only shows up on the second attempt is a bug
+  // report, and a developer should see it. CI sets a budget (ci/mod.just).
+  retry: parseInt(process.env.CUCUMBER_RETRY || "0", 10),
+
+  // Every scenario boots its own server on its own port against its own temp
+  // dir, so workers share nothing. 0 is cucumber's "no workers"; CI picks a
+  // small number rather than the box's, because the racket lanes run beside it.
+  parallel: parseInt(process.env.CUCUMBER_PARALLEL || "0", 10),
+
+  // A progress bar redraws itself, which a CI log cannot do.
+  format: [process.stdout.isTTY ? "progress-bar" : "progress", "summary"],
+  formatOptions: { snippetInterface: "async-await" },
+};

--- a/e2e/default.nix
+++ b/e2e/default.nix
@@ -1,0 +1,56 @@
+# The e2e harness's node_modules, as a derivation.
+#
+# npm is the only channel cucumber and playwright ship through, so they get
+# the acp/ treatment: a committed lockfile, ONE fixed-output derivation
+# (fetchNpmDeps) for the tarballs, nothing fetched when the tree is built.
+# Regenerate after any edit to e2e/package.json:
+#   cd e2e && npm install --package-lock-only --ignore-scripts
+#   set npmDeps.hash below to lib.fakeHash, build, paste what nix prints.
+#
+# It is node_modules and nothing else — not an installed package. ESM
+# resolution walks UP from the importing file and ignores NODE_PATH, so the
+# harness needs this tree at e2e/node_modules; `just e2e` symlinks it there.
+#
+# --ignore-scripts is load-bearing twice over: playwright's postinstall
+# downloads a browser, and the browser is nixpkgs' (playwright-driver, pinned
+# to the same version in flake.nix).
+{ lib, stdenvNoCC, nodejs, npmHooks, fetchNpmDeps }:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "olai-e2e-node-modules";
+  version = "0.1.0";
+
+  # ./. would pull in the features and steps, and every edit to a scenario
+  # would rebuild the deps. Keep src to what npm actually reads.
+  src = lib.cleanSourceWith {
+    name = "olai-e2e-manifest";
+    src = ./.;
+    filter = path: _type:
+      builtins.elem (baseNameOf path) [ "package.json" "package-lock.json" ];
+  };
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src;
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    hash = "sha256-W7xMppL4qlYhjg19rZB0eDoJkOhgpNKzV9IjzKIGFus=";
+  };
+
+  nativeBuildInputs = [ nodejs npmHooks.npmConfigHook ];
+  npmFlags = [ "--ignore-scripts" ];
+
+  dontBuild = true;
+
+  # -a, not -r: .bin/cucumber-js is a relative symlink into the tree, and a
+  # copy that followed it would leave a file no `npm` ever wrote.
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -a node_modules $out/node_modules
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "cucumber + playwright, pinned, for olai's browser journeys";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/e2e/features/chat.feature
+++ b/e2e/features/chat.feature
@@ -1,0 +1,66 @@
+Feature: the agent panel
+
+  The chat panel docks to the right edge: closed until asked for, remembered
+  across loads, and beside the outline rather than over it. A turn is drawn
+  from frames that arrive on the page's one SSE connection — the same
+  connection the live outline rides — so the panel and the outline have to
+  stay out of each other's way.
+
+  The agent is the fake one (olai/tests/integration/fake-acp-agent.rkt): it
+  answers any ordinary prompt with "hello world" and one tool call.
+
+  Scenario: the panel is closed until I ask for it, and the × puts it back
+    When I open the home page
+    Then the chat panel is closed
+    When I press the agent toggle
+    Then the chat panel is open
+    When I close the chat panel
+    Then the chat panel is closed
+
+  Scenario: the panel is still open after a reload
+    When I open the home page
+    And I press the agent toggle
+    And I reload the page
+    Then the chat panel is open
+
+  # Issue #14: the gutter the panel needs was PADDING on .ol-main, and .ol-main
+  # is border-box under `max-width: 56rem` — so --chat-w came out of the reading
+  # column's own cap instead of out of the free space beside it. The outline
+  # kept its full border box (right edge under the panel), and the text wrapped
+  # into whatever the padding left, three words to a line, with the gutter
+  # sitting empty. Both numbers below say it: the column stayed wide enough to
+  # read, and it ends before the panel starts.
+  Scenario: an open panel leaves the outline a column you can still read
+    When I open the home page
+    And I press the agent toggle
+    Then the outline column is at least 20 rem wide
+    And the outline column stops before the chat panel
+
+  Scenario: a turn shows what I said, what it said, and what it ran
+    When I open the home page
+    And I press the agent toggle
+    And I send "what is in the outline" to the agent
+    Then the last turn quotes me "what is in the outline"
+    And the last turn reads "hello world"
+    And the last turn ran the tool "read Tasks.rkt"
+    And the chat panel is idle
+
+  Scenario: the panel says the agent is working, and stops saying it
+    When I open the home page
+    And I press the agent toggle
+    And I send a slow prompt to the agent
+    Then the chat panel is busy
+    And the chat panel is idle
+    And the last turn reads "hello world"
+
+  Scenario: an outline edit does not swap the conversation away
+    When I open the home page
+    And I press the agent toggle
+    And I send "what is in the outline" to the agent
+    Then the last turn reads "hello world"
+    And I mark this page load
+    When I add the title "Renew the passport" to the outline
+    Then I see the title "Renew the passport"
+    And the page has not reloaded
+    And the chat panel is open
+    And the last turn reads "hello world"

--- a/e2e/features/collapse.feature
+++ b/e2e/features/collapse.feature
@@ -1,0 +1,54 @@
+Feature: folding a node
+
+  A parent folds and unfolds from the disclosure toggle in its own row. The
+  fold is the browser's, not the file's: collapse.js keeps it in localStorage
+  per collapse key, so it outlives a reload — and the sidebar tree keys its
+  own state separately, so the same node folds in one pane at a time.
+
+  Scenario: folding a node hides what is under it
+    When I open the home page
+    Then I see the title "Buy milk"
+    When I fold "Inbox"
+    Then "Inbox" is folded
+    And "Buy milk" is out of sight
+
+  Scenario: a fold outlives a reload
+    When I open the home page
+    And I fold "Inbox"
+    And I reload the page
+    Then "Inbox" is folded
+    And "Buy milk" is out of sight
+
+  Scenario: unfolding brings the children back, and that sticks too
+    When I open the home page
+    And I fold "Inbox"
+    And I unfold "Inbox"
+    Then "Inbox" is unfolded
+    And I see the title "Buy milk"
+    When I reload the page
+    Then "Inbox" is unfolded
+
+  Scenario: the sidebar tree folds on its own
+    When I open the home page
+    And I fold "Inbox"
+    Then "Inbox" is folded
+    And the sidebar's "Inbox" is unfolded
+    When I fold the sidebar's "Ship the server"
+    Then the sidebar's "Ship the server" is folded
+    And "Ship the server" is unfolded
+
+  # KNOWN BROKEN: the live view unfolds everything you folded.
+  # collapse.js re-applies the fold on htmx:afterSwap, and at that moment it is
+  # right — but the nodes carry ids, so htmx's settle phase then restores the
+  # class attribute the SERVER sent, which has no is-collapsed. The fold is
+  # correct for ~20ms and then gone. htmx:afterSettle is where that pass
+  # belongs. Parked until collapse.js listens there.
+  @skip
+  Scenario: a fold outlives the live view's re-swap
+    When I open the home page
+    And I fold "Inbox"
+    And I mark this page load
+    And I add the title "Feed the cat" to the outline
+    Then I see the title "Feed the cat"
+    And the page has not reloaded
+    And "Inbox" is folded

--- a/e2e/features/error.feature
+++ b/e2e/features/error.feature
@@ -1,0 +1,23 @@
+Feature: a broken file, under a running server
+
+  A file is broken for a moment during every edit. The page keeps the last
+  good content and says where the trouble is, and it takes itself back down
+  when the file loads again — all of it without a reload.
+
+  Scenario: breaking the file banners the error and keeps the last good page
+    When I open the home page
+    And I mark this page load
+    And I break the outline
+    Then the error banner names the file, with a line and a column
+    And I see the title "Buy milk"
+    And the page has not reloaded
+
+  Scenario: fixing the file takes the banner back down
+    When I open the home page
+    And I break the outline
+    Then the error banner names the file, with a line and a column
+    And I mark this page load
+    And I fix the outline
+    Then the error banner clears
+    And I see the title "Buy milk"
+    And the page has not reloaded

--- a/e2e/features/live.feature
+++ b/e2e/features/live.feature
@@ -1,0 +1,21 @@
+Feature: the outline, live
+
+  The page watches the file it was drawn from. Whoever saves it — an editor,
+  an agent, `olai add` — every open page follows within a couple of seconds,
+  and nobody reloads anything.
+
+  Scenario: a title saved to the file shows up on a page nobody touched
+    When I open the home page
+    And I mark this page load
+    And I add the title "Water the plants" to the outline
+    Then I see the title "Water the plants"
+    And the page has not reloaded
+
+  Scenario: a title deleted from the file leaves the page the same way
+    When I open the home page
+    Then I see the title "Write the tests"
+    And I mark this page load
+    And I remove the title "Write the tests" from the outline
+    Then "Write the tests" leaves the page
+    And I see the title "Ship the server"
+    And the page has not reloaded

--- a/e2e/features/outline.feature
+++ b/e2e/features/outline.feature
@@ -1,0 +1,25 @@
+Feature: the outline, drawn
+
+  The home page draws the outline the server was pointed at: what each node
+  says, what it is tagged, when it is due, whether it is done, and where a
+  mirror stands in for a node defined elsewhere.
+
+  Scenario: every part of a node reaches the page
+    When I open the home page
+    Then I see the title "Buy milk"
+    And the note under "Inbox" reads "Quick capture landing zone"
+    And "Inbox" carries the tag "#capture"
+    And "Buy milk" carries the date "2026-01-15"
+    And "Ship the pitch" is done
+    And "Buy milk" is not done
+
+  Scenario: a mirror site draws the node it mirrors
+    When I open the home page
+    Then "This week" holds a mirror of "serve"
+    And the mirror under "This week" draws "Ship the server"
+
+  Scenario: the sidebar tree lists the outline's top level
+    When I open the home page
+    Then the sidebar lists "Inbox"
+    And the sidebar lists "Ship the server"
+    And the sidebar lists "This week"

--- a/e2e/features/sessions.feature
+++ b/e2e/features/sessions.feature
@@ -1,0 +1,76 @@
+Feature: past conversations, and whose they are
+
+  The agent stores its conversations by the directory it worked in, and it is
+  asked about a directory by PREFIX — so a checkout with a worktree under it
+  is told about the worktree's chats too. Only the ones worked in exactly this
+  directory are this panel's: the picker lists those, and boot comes up in the
+  newest of those.
+
+  What the machine had stored when the agent woke up is the scenario's tag —
+  the fake agent reads it (support/hooks.js).
+
+  @stored-sessions
+  Scenario: the panel comes up in the last conversation from this directory
+    Given the agent has woken up
+    When I open the home page
+    And I press the agent toggle
+    Then the chat is titled "the last conversation"
+
+  @stored-sessions
+  Scenario: the picker lists this directory's chats and nobody else's
+    Given the agent has woken up
+    When I open the home page
+    And I press the agent toggle
+    And I press the sessions button
+    Then the picker offers "the last conversation"
+    And the picker offers "an older conversation"
+    And the picker does not offer "another checkout's conversation"
+
+  @stored-sessions
+  Scenario: picking an older conversation replays it into the panel
+    Given the agent has woken up
+    When I open the home page
+    And I press the agent toggle
+    And I press the sessions button
+    And I pick the conversation "an older conversation"
+    Then the chat is titled "an older conversation"
+    And the last turn quotes me "what did we do"
+    And the last turn reads "we shipped it"
+    And the last turn ran the tool "read Roadmap.rkt"
+
+  # Another checkout's conversation is newer than anything here, and adopting
+  # it is how a task agent's coding session used to become the web chat. With
+  # nothing of this directory's stored, the panel starts a conversation of its
+  # own instead.
+  @foreign-sessions
+  Scenario: another checkout's conversation is not adopted, and not offered
+    Given the agent has woken up
+    When I open the home page
+    And I press the agent toggle
+    Then the chat is not titled "another checkout's conversation"
+    And the transcript is empty
+    When I press the sessions button
+    Then the picker says there are no past chats here
+    And the picker does not offer "another checkout's conversation"
+
+  @foreign-sessions
+  Scenario: a fresh conversation still starts here
+    When I open the home page
+    And I press the agent toggle
+    And I send "what is in the outline" to the agent
+    Then the last turn reads "hello world"
+
+  # KNOWN BROKEN: the panel a page opens with is only as current as the agent.
+  # `serve` prints its URL and answers requests while the agent is still waking
+  # up in its own thread, and its boot frames (model, session, commands) are
+  # BROADCAST — a page opened in that window is not listening yet, and the
+  # server-rendered panel it did get was drawn before any of them landed. The
+  # conversation is there; the panel does not say which one until something
+  # else makes it redraw. Every other scenario here waits the boot out
+  # (`the agent has woken up`), which is the harness admitting it.
+  # Same shape as the racket suite's parked boot-frame race (Roadmap.rkt).
+  @skip @stored-sessions
+  Scenario: a page opened while the agent is still waking up says which chat it is in
+    When I open the home page
+    And I press the agent toggle
+    Then the chat is titled "the last conversation"

--- a/e2e/features/theme.feature
+++ b/e2e/features/theme.feature
@@ -1,0 +1,46 @@
+Feature: the theme picker
+
+  The picker in the sidebar is CLIENT state: a chip writes data-theme on
+  <html>, this browser keeps it, the sheet repaints, and the browser chrome
+  (meta theme-color) follows the paper. Nothing about it reaches the server —
+  every scenario here is one fresh browser against the same page.
+
+  Scenario: a fresh browser reads in the default theme
+    When I open the home page
+    Then the page names no theme
+    And the lit theme chip is the default
+    And every theme chip agrees with what it announces
+
+  Scenario: picking a dark theme repaints the page
+    When I open the home page
+    And I note the paper colour
+    And I pick the theme "pitch"
+    Then the page is in the theme "pitch"
+    And the lit theme chip is "pitch"
+    And the paper colour has changed
+
+  Scenario: the browser chrome follows the paper
+    When I open the home page
+    Then the theme-color meta matches the paper
+    When I pick the theme "pitch"
+    Then the theme-color meta matches the paper
+
+  Scenario: the theme I picked is there before the page has finished parsing
+    When I open the home page
+    And I pick the theme "pitch"
+    And I watch for the theme landing
+    And I reload the page
+    Then the theme "pitch" landed while the page was still parsing
+    And the lit theme chip is "pitch"
+    And the theme-color meta matches the paper
+
+  Scenario: picking the default theme is a pick like any other
+    When I open the home page
+    And I pick the theme "pitch"
+    And I pick the default theme
+    Then the page is in the default theme
+    And the lit theme chip is the default
+    When I reload the page
+    Then the page is in the default theme
+    And the lit theme chip is the default
+    And the theme-color meta matches the paper

--- a/e2e/features/today.feature
+++ b/e2e/features/today.feature
@@ -1,0 +1,19 @@
+Feature: Today, zoomed
+
+  The sidebar's Today link goes to today's day node. Before the first capture
+  of the day there is no such node, which is the normal state and not an
+  error; once the file has one, the page is that subtree and nothing else.
+
+  Scenario: the sidebar's Today link lands on a day that has not started yet
+    When I open the home page
+    Then the sidebar links to "/today"
+    When I follow the sidebar's Today link
+    Then the main pane says there is no day node for today
+    And I do not see the title "Buy milk"
+
+  Scenario: a day node in the file is what Today zooms to
+    When I add a day node for today holding "Water the plants"
+    And I open the Today page
+    Then the main pane is zoomed
+    And I see the title "Water the plants"
+    And I do not see the title "Buy milk"

--- a/e2e/features/zoom.feature
+++ b/e2e/features/zoom.feature
@@ -1,0 +1,57 @@
+Feature: one node, zoomed
+
+  Every node has a page of its own at the key the load layer minted for it —
+  a permalink you can paste at someone. It draws that subtree and the trail
+  above it, and it is as live as the home page: the same file, the same SSE
+  swap, its own address.
+
+  Scenario: a bullet is a link to the node's own page
+    When I open the home page
+    And I zoom into "Inbox"
+    Then I am on a node's own page
+    And the main pane is zoomed
+    And the tab is named for "Inbox"
+    And I see the title "Buy milk"
+    And I do not see the title "Ship the server"
+
+  Scenario: the breadcrumbs are the trail above the node
+    When I open the home page
+    And I zoom into "Buy milk"
+    Then the breadcrumbs read "home > Tasks.rkt > Inbox #capture"
+    When I follow the breadcrumb "Inbox #capture"
+    Then the main pane is zoomed
+    And the tab is named for "Inbox"
+    And I see the title "Buy milk"
+    When I follow the breadcrumb "home"
+    Then I am back on the home page
+    And I see the title "Ship the server"
+
+  Scenario: the sidebar tree zooms to the same page
+    When I open the home page
+    And I zoom into the sidebar's "Ship the server"
+    Then I am on a node's own page
+    And the tab is named for "Ship the server"
+    And I see the title "Write the tests"
+
+  # The parent is named as the FILE spells it: a tag and an anchor are part of
+  # the line, and this step edits the file rather than the page.
+  Scenario: a zoomed page follows the file like any other
+    When I open the home page
+    And I zoom into "Inbox"
+    And I mark this page load
+    And I add the title "Call the dentist" under "Inbox #capture" in the outline
+    Then I see the title "Call the dentist"
+    And the page has not reloaded
+    And the main pane is zoomed
+
+  # A node can be deleted, or an unanchored one re-keyed, while a tab sits
+  # zoomed on it — and that tab re-fetches this very page to find out. So it is
+  # a page saying the node is gone, not a 404 that would leave the tab showing
+  # a node that no longer exists.
+  Scenario: a node that has gone away says so, on the page
+    When I open the home page
+    And I zoom into "Write the tests"
+    And I mark this page load
+    And I remove the title "Write the tests" from the outline
+    Then the page says there is no such node
+    And the page has not reloaded

--- a/e2e/fixtures/Tasks.rkt
+++ b/e2e/fixtures/Tasks.rkt
@@ -1,0 +1,11 @@
+#lang olai
+
+Inbox #capture
+  : Quick capture landing zone
+  Buy milk
+    @date 2026-01-15
+  [x] Ship the pitch
+Ship the server ^serve
+  Write the tests
+This week
+  *serve

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,1098 @@
+{
+  "name": "olai-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "olai-e2e",
+      "devDependencies": {
+        "@cucumber/cucumber": "13.2.1",
+        "playwright": "1.61.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cucumber/ci-environment": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/ci-environment/-/ci-environment-14.0.0.tgz",
+      "integrity": "sha512-CJbjPPGuk1fArPRVKB6FU2q9FHxOQOeq7IEJcB2NLNhOhV97uazLxvwD5ucAJb/flky+czOLhvaYaRAF6l5QYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cucumber/cucumber": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-13.2.1.tgz",
+      "integrity": "sha512-Km3mLbZKOE/TlR9ExGWcG7PwOG1ArMt/R6BexrMhGA8pLGaLCWYISTHStpftLuuhVKvVd3RO5M/pfARKyvcyWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/ci-environment": "14.0.0",
+        "@cucumber/cucumber-expressions": "20.0.0",
+        "@cucumber/gherkin": "42.0.0",
+        "@cucumber/gherkin-streams": "7.0.1",
+        "@cucumber/gherkin-utils": "12.0.1",
+        "@cucumber/html-formatter": "24.1.0",
+        "@cucumber/junit-xml-formatter": "0.14.0",
+        "@cucumber/message-streams": "5.0.1",
+        "@cucumber/messages": "34.2.0",
+        "@cucumber/pretty-formatter": "4.0.0",
+        "@cucumber/tag-expressions": "11.0.0",
+        "assertion-error-formatter": "^3.0.0",
+        "cli-table3": "0.6.5",
+        "commander": "^15.0.0",
+        "debug": "^4.3.4",
+        "error-stack-parser": "^2.1.4",
+        "figures": "^6.0.0",
+        "has-ansi": "^6.0.0",
+        "indent-string": "^5.0.0",
+        "is-installed-globally": "^1.0.0",
+        "knuth-shuffle-seeded": "^1.0.6",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "luxon": "3.7.2",
+        "read-package-up": "^12.0.0",
+        "semver": "7.8.5",
+        "string-argv": "0.3.2",
+        "supports-color": "^11.0.0",
+        "type-fest": "^5.0.0",
+        "util-arity": "^1.1.0",
+        "yaml": "^2.2.2",
+        "yup": "1.7.1"
+      },
+      "bin": {
+        "cucumber-js": "bin/cucumber.js"
+      },
+      "engines": {
+        "node": "22 || 24 || >=26"
+      },
+      "funding": {
+        "url": "https://opencollective.com/cucumber"
+      }
+    },
+    "node_modules/@cucumber/cucumber-expressions": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-20.0.0.tgz",
+      "integrity": "sha512-t2FBLKuU0U1nP5FM8pHiVonYcXVm07fvXr/H9osdvrjcLXSWc5OCbOOqV/k5S56w/YndPv1Sv2/m/x1KBYvIlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-match-indices": "1.0.2"
+      }
+    },
+    "node_modules/@cucumber/gherkin": {
+      "version": "42.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-42.0.0.tgz",
+      "integrity": "sha512-kBcv+NV4FGQYX6NIsSCjsjaX8MsRdEH559BQ9xEFPgkLQX/Z//JZrY94fpjxW6quo4V5kxlzFiiVC5xouF9Akg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/messages": ">=34.0.0 <35"
+      }
+    },
+    "node_modules/@cucumber/gherkin-streams": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-streams/-/gherkin-streams-7.0.1.tgz",
+      "integrity": "sha512-8W1lmof0hbQ1HgOEpPCkz1KCFaM6MfA7n7rr6vX/7ffgUQ0saOAwapKSVj7P68Aht0K9XqHaw8BDLtqaK/jRIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "15.0.0",
+        "source-map-support": "0.5.21"
+      },
+      "bin": {
+        "gherkin-javascript": "bin/gherkin"
+      },
+      "peerDependencies": {
+        "@cucumber/gherkin": ">=22.0.0",
+        "@cucumber/message-streams": ">=4.0.0",
+        "@cucumber/messages": ">=17.1.1"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-12.0.1.tgz",
+      "integrity": "sha512-vImHbmTzvGcZP4SFSbx7P6janHZN+BqGWXc3EIQ7UeYMeDzwV9ybSlRfpECV340pxKYZyMTtuSCP3CDXfuWCQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/gherkin": "^41.0.0",
+        "@cucumber/messages": "^33.0.0",
+        "@teppeis/multimaps": "3.0.0",
+        "commander": "15.0.0",
+        "source-map-support": "^0.5.21"
+      },
+      "bin": {
+        "gherkin-utils": "bin/gherkin-utils"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin": {
+      "version": "41.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-41.0.0.tgz",
+      "integrity": "sha512-pKGx1EzNjtWbpw74kEevKDMj71dF3ZSaFJpLYuWVvRZKe+Cwoq5iEkuMaELIg1jxIu8jH/A2HPMpMR8UBvdG0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/messages": ">=31.0.0 <34"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/messages": {
+      "version": "33.0.4",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-33.0.4.tgz",
+      "integrity": "sha512-i6P1a0bnmhecOHfvIW0rhMxv/gMKfBKwDMxmD9/Uo1HSqpQ17ocHms1JwWW6uTMLAopqqWlcz7l6Pax+qUOTzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cucumber/html-formatter": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-24.1.0.tgz",
+      "integrity": "sha512-5TBLnBT+tIvtamw/jtblBVgzQ2/ckd+md8I0rwkEk29vFMCF68jNwhyONGq6leUYMq4kVF+KdFhE8xGrSc3kJw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@cucumber/messages": ">=18"
+      }
+    },
+    "node_modules/@cucumber/junit-xml-formatter": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/junit-xml-formatter/-/junit-xml-formatter-0.14.0.tgz",
+      "integrity": "sha512-uDuJySsUr1b1VEAERC+YywvVhygBgYIAMyfSMzLZ3LrourudaWZIhfTND4uLNkRZZQcPr6IYv+qj5TP8RTJJ+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/query": "^16.0.0",
+        "@teppeis/multimaps": "^3.0.0",
+        "luxon": "^3.5.0",
+        "xmlbuilder": "^15.1.1"
+      },
+      "peerDependencies": {
+        "@cucumber/messages": "*"
+      }
+    },
+    "node_modules/@cucumber/message-streams": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-5.0.1.tgz",
+      "integrity": "sha512-MXsD7ZAWWAiWMrn3Lzq2nwu9DJpPbbvdqXj2ot1BSM2gXnoSvg8d0pc6PzS9pI02swMSn/KN11mTdF5ScE7X0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@cucumber/messages": ">=17.1.1"
+      }
+    },
+    "node_modules/@cucumber/messages": {
+      "version": "34.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-34.2.0.tgz",
+      "integrity": "sha512-6X6T1TApmbQNqxC0Oh3GcnLU+gfE5fp+cEXE/ml6+Ldx76Q6BDmkgM5vagSSDXP+vetPV2Fb0kWVeP7QIR6+Aw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cucumber/pretty-formatter": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/pretty-formatter/-/pretty-formatter-4.0.0.tgz",
+      "integrity": "sha512-vWKHUfjMphtbeHHlQBZ1gQzPL3/HE/O2dNnpBqEOIDwvhp7tKvqSe8kscp2H7pArbxN6euEpR5JbstJdzo3iyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/query": "16.0.0",
+        "luxon": "^3.7.2"
+      },
+      "peerDependencies": {
+        "@cucumber/messages": "*"
+      }
+    },
+    "node_modules/@cucumber/pretty-formatter/node_modules/@cucumber/query": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-16.0.0.tgz",
+      "integrity": "sha512-CtGBHLc92y1RNogXGOFVF7so+XdLR5rVuJGsS6nH7yLeayyYhdV8lYW/LG8R05cm4irG/RO6Wn5I2CAgxMhmwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@teppeis/multimaps": "3.0.0",
+        "lodash.sortby": "^4.7.0"
+      },
+      "peerDependencies": {
+        "@cucumber/messages": "*"
+      }
+    },
+    "node_modules/@cucumber/query": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-16.1.1.tgz",
+      "integrity": "sha512-SBaP4Lc7xv55jY78Q8raoxvbBIPGhQKrui/Tq+l6jYBl1alV0TG1sW8TRtk9W7RQl27nVJo9DyyvASp374L9Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@teppeis/multimaps": "3.0.0",
+        "lodash.sortby": "^4.7.0"
+      },
+      "peerDependencies": {
+        "@cucumber/messages": "*"
+      }
+    },
+    "node_modules/@cucumber/tag-expressions": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-11.0.0.tgz",
+      "integrity": "sha512-7Uo6dYST8xZbHwwemXCt7Kv80Yh/SE85DyOed1/FTwxRXs3NYVOCm6e/h8DxlhTGIpD6rYXfpY3nHnIXAFMBlw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@teppeis/multimaps": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-3.0.0.tgz",
+      "integrity": "sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error-formatter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error-formatter/-/assertion-error-formatter-3.0.0.tgz",
+      "integrity": "sha512-6YyAVLrEze0kQ7CmJfUgrLHb+Y7XghmL2Ie7ijVa2Y9ynP3LV+VDiwFk62Dn0qtqbmY0BT0ss6p1xxpiF2PYbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff": "^4.0.1",
+        "pad-right": "^0.2.2",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-6.0.2.tgz",
+      "integrity": "sha512-vAyM+6+jAYwSwz0/M0jYKfU9AvAMCz0kH791RsUhvMKGUHXled/3FjcQB3YiQ4Astj5srHdb6B2FHGIfZkOQNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/has-ansi?sponsor=1"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/knuth-shuffle-seeded": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/knuth-shuffle-seeded/-/knuth-shuffle-seeded-1.0.6.tgz",
+      "integrity": "sha512-9pFH0SplrfyKyojCLxZfMcvkhf5hH0d+UwR9nTVJ/DDQJGuzcXjTwB7TP7sDfehSudlGGaOLblmEWqv04ERVWg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "seed-random": "~2.2.0"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mime": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "license": "MIT",
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-package-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+      "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^9.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/pad-right": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+      "integrity": "sha512-4cy8M95ioIGolCoMmm2cMntGR1lPLEbOMzOKu8bzjuJP6JpzEMQcDHmh7hHLYGgob+nKe1YHFMaG4V59HQa89g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "repeat-string": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-json/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/read-package-up": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-12.0.0.tgz",
+      "integrity": "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.1",
+        "read-pkg": "^10.0.0",
+        "type-fest": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.1.0.tgz",
+      "integrity": "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.4",
+        "normalize-package-data": "^8.0.0",
+        "parse-json": "^8.3.0",
+        "type-fest": "^5.4.4",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/regexp-match-indices": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regexp-match-indices/-/regexp-match-indices-1.0.2.tgz",
+      "integrity": "sha512-DwZuAkt8NF5mKwGGER1EGh2PRqyvhRhhLviH+R8y8dIuaQROlUfXjt4s9ZTXstIsSkptf06BSvwcEmmfheJJWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "regexp-tree": "^0.1.11"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/seed-random": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
+      "integrity": "sha512-34EQV6AAHQGhoc0tn/96a9Fsi6v2xdqe/dMUwljGRaFOzR3EgRmECvD0O8vi8X+/uQ50LGHfkNu/Eue5TPKZkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-11.0.0.tgz",
+      "integrity": "sha512-/zyImLdxhdygBIaVX0xTlQhKaCDLCrm665aqHk8xqK/Pa6k61fL6gwQGQq1k31yNyz6x55PppQgF2DMyPQa5xw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/util-arity": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/util-arity/-/util-arity-1.1.0.tgz",
+      "integrity": "sha512-kkyIsXKwemfSy8ZEoaIz06ApApnWsk5hQO0vLjZS6UkBiGiW++Jsyb8vSBoc0WKlffGoGs5yYy/j5pp8zckrFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
+      "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/yup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "olai-e2e",
+  "private": true,
+  "type": "module",
+  "description": "browser journeys for the olai web view (cucumber + playwright)",
+  "devDependencies": {
+    "@cucumber/cucumber": "13.2.1",
+    "playwright": "1.61.1"
+  }
+}

--- a/e2e/steps/chat_steps.js
+++ b/e2e/steps/chat_steps.js
@@ -5,9 +5,16 @@
 // pretending to test something slower than it is.
 
 import assert from "node:assert/strict";
-import { Then, When } from "@cucumber/cucumber";
+import { Given, Then, When } from "@cucumber/cucumber";
 
 import { SLOW_PROMPT } from "../support/server.js";
+
+// Before the page is opened, not after: what the panel comes up KNOWING is
+// server-rendered, and a page opened mid-boot misses the frames that would
+// have told it (world.waitForAgent).
+Given("the agent has woken up", async function () {
+  await this.waitForAgent();
+});
 
 // The panel's own state, as a selector: matched means open, no match means
 // closed. `detached` is how playwright spells "nothing matches this", which is
@@ -62,6 +69,74 @@ Then("the chat panel is busy", async function () {
 
 Then("the chat panel is idle", async function () {
   await this.page.locator(BUSY).waitFor({ state: "detached" });
+});
+
+// ---- past conversations ---------------------------------------------------
+//
+// The picker is drawn by chat.js from what the server asks the agent, every
+// time it is opened — a cached list would be wrong the moment another client
+// wrote a session. Rows are .ol-chat-cmd, the same shape the slash-command
+// popover uses; the title is the name a conversation goes by.
+
+const PICKER = "#ol-chat-spop";
+const PICKER_ROW = `${PICKER} .ol-chat-cmd`;
+
+When("I press the sessions button", async function () {
+  await this.page.locator("#ol-chat [data-chat-sessions]").click();
+  await this.page.locator(PICKER).waitFor({ state: "visible" });
+});
+
+When("I pick the conversation {string}", async function (title) {
+  await this.page
+    .locator(PICKER_ROW, { hasText: title })
+    .first()
+    .click();
+});
+
+Then("the picker offers {string}", async function (title) {
+  await this.page
+    .locator(PICKER_ROW, { hasText: title })
+    .first()
+    .waitFor({ state: "visible" });
+});
+
+// The picker is open and drawn by the time this runs (pressing the button
+// waits for it), so a row that is not there now is not coming.
+Then("the picker does not offer {string}", async function (title) {
+  assert.equal(
+    await this.page.locator(PICKER_ROW, { hasText: title }).count(),
+    0,
+    `${title} is in the picker`,
+  );
+});
+
+Then("the picker says there are no past chats here", async function () {
+  await this.page
+    .locator(PICKER)
+    .getByText("no past chats here")
+    .waitFor({ state: "visible" });
+});
+
+// Which conversation the panel is in. The agent is what knows its name, so it
+// arrives as a frame — and an unnamed conversation is an empty line, which the
+// sheet takes away entirely (so it is read, not waited for as a visible thing).
+Then("the chat is titled {string}", async function (title) {
+  await this.page
+    .locator("#ol-chat-session")
+    .filter({ hasText: title })
+    .waitFor();
+});
+
+Then("the chat is not titled {string}", async function (title) {
+  const line = this.page.locator("#ol-chat-session");
+  await line.waitFor({ state: "attached" });
+  assert.notEqual((await line.textContent()).trim(), title);
+});
+
+// Nothing was replayed into it: this conversation is new, not one adopted from
+// somewhere else.
+Then("the transcript is empty", async function () {
+  assert.equal(await this.page.locator("#ol-chat-body .ol-chat-turn").count(), 0);
 });
 
 // ---- geometry -------------------------------------------------------------

--- a/e2e/steps/chat_steps.js
+++ b/e2e/steps/chat_steps.js
@@ -1,0 +1,141 @@
+// The agent panel: its open bit, the room it makes, and what a turn draws.
+//
+// Every wait here is a wait on the DOM. Frames arrive over SSE and a turn is
+// drawn as they land, so a step that slept would either be racing the agent or
+// pretending to test something slower than it is.
+
+import assert from "node:assert/strict";
+import { Then, When } from "@cucumber/cucumber";
+
+import { SLOW_PROMPT } from "../support/server.js";
+
+// The panel's own state, as a selector: matched means open, no match means
+// closed. `detached` is how playwright spells "nothing matches this", which is
+// what makes the closed assertions auto-wait like the open ones.
+const OPEN = "#ol-chat.is-open";
+const BUSY = "#ol-chat.is-busy";
+
+// Two buttons toggle the panel and only one of them is ever reachable: the
+// floating one is taken away while the panel is open (it sits under it), and
+// the header's × is inside the panel it closes.
+const TOGGLE = ".ol-chat-open[data-chat-toggle]";
+const CLOSE = "#ol-chat [data-chat-toggle]";
+
+When("I press the agent toggle", async function () {
+  await this.page.locator(TOGGLE).click();
+});
+
+When("I close the chat panel", async function () {
+  await this.page.locator(CLOSE).click();
+});
+
+When("I send {string} to the agent", async function (text) {
+  await send(this.page, text);
+});
+
+// A turn that dawdles, so "working" is a state to look at rather than a frame
+// to catch. The prompt that asks for one is support/server.js's to spell.
+When("I send a slow prompt to the agent", async function () {
+  await send(this.page, SLOW_PROMPT);
+});
+
+async function send(page, text) {
+  await page.locator("#ol-chat-form .ol-chat-input").fill(text);
+  await page.locator("#ol-chat-form .ol-chat-send").click();
+}
+
+Then("the chat panel is open", async function () {
+  await this.page.locator(OPEN).waitFor({ state: "visible" });
+});
+
+// The panel carries no is-open on the way out of the renderer, so a page where
+// chat.js never ran would pass this for the wrong reason. The popover the
+// script builds at init is the proof it ran.
+Then("the chat panel is closed", async function () {
+  await this.page.locator("#ol-chat-pop").waitFor({ state: "attached" });
+  await this.page.locator(OPEN).waitFor({ state: "detached" });
+});
+
+Then("the chat panel is busy", async function () {
+  await this.page.locator(BUSY).waitFor({ state: "visible" });
+});
+
+Then("the chat panel is idle", async function () {
+  await this.page.locator(BUSY).waitFor({ state: "detached" });
+});
+
+// ---- geometry -------------------------------------------------------------
+//
+// Measured in the page, off the boxes the browser actually laid out: a
+// stylesheet assertion would only say what the CSS claims, and the bug this
+// guards was the cascade doing exactly what it was told.
+
+/** .ol-main's content width, its right edge, the panel's left edge, and what a
+ *  rem is worth here (the floor is written in rem, and the root font size is
+ *  the reader's). */
+async function measure(page) {
+  await page.locator(OPEN).waitFor({ state: "visible" });
+  return await page.evaluate(() => {
+    const main = document.querySelector(".ol-main");
+    const style = getComputedStyle(main);
+    const box = main.getBoundingClientRect();
+    return {
+      rem: parseFloat(getComputedStyle(document.documentElement).fontSize),
+      // border box minus its own gutters: what a line of text has to sit in
+      content:
+        box.width -
+        parseFloat(style.paddingLeft) -
+        parseFloat(style.paddingRight),
+      right: box.right,
+      chatLeft: document.querySelector("#ol-chat").getBoundingClientRect().left,
+    };
+  });
+}
+
+Then("the outline column is at least {int} rem wide", async function (rems) {
+  const m = await measure(this.page);
+  const floor = rems * m.rem;
+  assert.ok(
+    m.content >= floor,
+    `the outline column is ${m.content}px, under the ${floor}px floor`,
+  );
+});
+
+Then("the outline column stops before the chat panel", async function () {
+  const m = await measure(this.page);
+  assert.ok(
+    m.right <= m.chatLeft,
+    `the outline runs to ${m.right}px, under the panel's edge at ${m.chatLeft}px`,
+  );
+});
+
+// ---- the conversation -----------------------------------------------------
+
+/** The turn being drawn. A turn owns its user bubble, the agent's text and its
+ *  tool lines, so everything asserted about one is looked up inside it. */
+function lastTurn(page) {
+  return page.locator("#ol-chat-body .ol-chat-turn").last();
+}
+
+Then("the last turn quotes me {string}", async function (text) {
+  const el = lastTurn(this.page).locator(".ol-chat-msg.is-user");
+  await el.waitFor({ state: "visible" });
+  assert.equal((await el.innerText()).trim(), text);
+});
+
+// The agent's text arrives in chunks and is replaced wholesale by the server's
+// Markdown when the turn ends, so this waits for the finished sentence rather
+// than reading whatever is there when it looks.
+Then("the last turn reads {string}", async function (text) {
+  await lastTurn(this.page)
+    .locator(".ol-chat-msg.is-agent")
+    .filter({ hasText: text })
+    .waitFor({ state: "visible" });
+});
+
+Then("the last turn ran the tool {string}", async function (title) {
+  await lastTurn(this.page)
+    .locator(".ol-chat-tool .ol-chat-tool-title", { hasText: title })
+    .first()
+    .waitFor({ state: "visible" });
+});

--- a/e2e/steps/collapse_steps.js
+++ b/e2e/steps/collapse_steps.js
@@ -1,0 +1,70 @@
+// Folding: the toggle, and what a fold means in each pane.
+//
+// "Folded" is asserted three ways at once because the app spells it three
+// ways — the class the CSS hangs off, the ARIA state a screen reader gets,
+// and the children actually being gone. Any one of them drifting is a bug.
+
+import assert from "node:assert/strict";
+import { Then, When } from "@cucumber/cucumber";
+
+import { assertClass, hasClass } from "../support/dom.js";
+
+// The node's OWN toggle. A descendant's would fold the wrong node.
+const TOGGLE = ":scope > .ol-row > .ol-toggle";
+
+When("I fold {string}", async function (title) {
+  await setFold(this.node(title).first(), true);
+});
+
+When("I unfold {string}", async function (title) {
+  await setFold(this.node(title).first(), false);
+});
+
+When("I fold the sidebar's {string}", async function (title) {
+  await setFold(this.treeNode(title).first(), true);
+});
+
+Then("{string} is folded", async function (title) {
+  await assertFolded(this.node(title).first(), true, title);
+});
+
+Then("{string} is unfolded", async function (title) {
+  await assertFolded(this.node(title).first(), false, title);
+});
+
+Then("the sidebar's {string} is folded", async function (title) {
+  await assertFolded(this.treeNode(title).first(), true, `sidebar ${title}`);
+});
+
+Then("the sidebar's {string} is unfolded", async function (title) {
+  await assertFolded(this.treeNode(title).first(), false, `sidebar ${title}`);
+});
+
+// Hidden, not absent: a folded child is still in the document, so the
+// "I do not see the title" step would be asserting the wrong thing.
+Then("{string} is out of sight", async function (title) {
+  await this.node(title).first().waitFor({ state: "hidden" });
+});
+
+// ---- helpers --------------------------------------------------------------
+
+/** Click the toggle only when it is pointing the wrong way. It is a toggle, so
+ *  a step that always clicked would mean "fold" or "unfold" by luck. */
+async function setFold(node, want) {
+  if ((await hasClass(node, "is-collapsed")) === want) return;
+  await node.locator(TOGGLE).click();
+}
+
+async function assertFolded(node, want, what) {
+  // Wait on the children first: it is the one part that settles late (an htmx
+  // swap re-applies the fold after the new markup lands), and once it holds
+  // the class and the ARIA state are already whatever they are going to be.
+  const kids = node.locator(":scope > .ol-children");
+  await kids.waitFor({ state: want ? "hidden" : "visible" });
+  await assertClass(node, "is-collapsed", want, what);
+  assert.equal(
+    await node.locator(TOGGLE).getAttribute("aria-expanded"),
+    want ? "false" : "true",
+    `${what}: aria-expanded disagrees with the fold`,
+  );
+}

--- a/e2e/steps/file_steps.js
+++ b/e2e/steps/file_steps.js
@@ -1,0 +1,43 @@
+// Every write to the outline file, and nothing else.
+//
+// This is the only file in the suite that edits Tasks.rkt. The scenarios that
+// lean on it are about three different things — the live swap, the error
+// banner, the /today zoom, a fold surviving a re-render — and they all mean
+// the same act, so they say it the same way.
+//
+// Nothing here waits for the page: the watcher turns a save into an `outline`
+// event on its own schedule (0.15s debounce, 2s poll fallback), and the
+// assertions that follow are what wait.
+
+import assert from "node:assert/strict";
+import { When } from "@cucumber/cucumber";
+
+import { BREAKAGE, FIXTURE } from "../support/outline.js";
+
+When("I add the title {string} to the outline", async function (title) {
+  await this.append(`${title}\n`);
+});
+
+// By its own line, at whatever depth it sits: a title is unique in the
+// fixture, so "the line that says this" means one line.
+When("I remove the title {string} from the outline", async function (title) {
+  const lines = this.outline.split("\n");
+  const kept = lines.filter((l) => l.trim() !== title);
+  assert.notEqual(kept.length, lines.length, `${title} is not in the outline`);
+  await this.rewrite(kept.join("\n"));
+});
+
+// A day node is a top-level node whose title IS the ISO day (what `olai daily`
+// writes). The day comes from the server, because the server is the one that
+// decides which day /today is looking for.
+When("I add a day node for today holding {string}", async function (child) {
+  await this.append(`${await this.today()}\n  ${child}\n`);
+});
+
+When("I break the outline", async function () {
+  await this.append(BREAKAGE);
+});
+
+When("I fix the outline", async function () {
+  await this.rewrite(FIXTURE);
+});

--- a/e2e/steps/file_steps.js
+++ b/e2e/steps/file_steps.js
@@ -18,6 +18,20 @@ When("I add the title {string} to the outline", async function (title) {
   await this.append(`${title}\n`);
 });
 
+// Nesting is two spaces (docs/syntax.md), so a child is the parent's line
+// again with two more of them, on the line after it.
+When(
+  "I add the title {string} under {string} in the outline",
+  async function (title, parent) {
+    const lines = this.outline.split("\n");
+    const at = lines.findIndex((l) => l.trim() === parent);
+    assert.notEqual(at, -1, `${parent} is not in the outline`);
+    const indent = " ".repeat(lines[at].search(/\S/) + 2);
+    lines.splice(at + 1, 0, `${indent}${title}`);
+    await this.rewrite(lines.join("\n"));
+  },
+);
+
 // By its own line, at whatever depth it sits: a title is unique in the
 // fixture, so "the line that says this" means one line.
 When("I remove the title {string} from the outline", async function (title) {

--- a/e2e/steps/outline_steps.js
+++ b/e2e/steps/outline_steps.js
@@ -1,0 +1,100 @@
+// What the outline pane draws: the parts of a node, the mirror sites, the
+// zoom, and the empty state that stands in for all of it.
+//
+// A node is addressed by (part of) its own title — world.node — so these read
+// like the outline does rather than like the DOM does.
+
+import assert from "node:assert/strict";
+import { Then } from "@cucumber/cucumber";
+
+import { assertClass, literal } from "../support/dom.js";
+
+// ---- a title is there, or it is not ----------------------------------------
+
+Then("I see the title {string}", async function (title) {
+  await this.node(title).first().waitFor({ state: "visible" });
+});
+
+// A count NOW, so this is sound about a page that has finished loading and
+// says nothing about one mid-swap. "leaves the page" is the waiting one.
+Then("I do not see the title {string}", async function (title) {
+  assert.equal(await this.node(title).count(), 0, `${title} is on the page`);
+});
+
+Then("{string} leaves the page", async function (title) {
+  await this.node(title).first().waitFor({ state: "detached" });
+});
+
+// ---- the rest of a node ----------------------------------------------------
+
+/** A part of a node's OWN row: a descendant's row is another node's. */
+function part(world, title, cls) {
+  return world.node(title).first().locator(`:scope > .ol-row ${cls}`).first();
+}
+
+Then("the note under {string} reads {string}", async function (title, note) {
+  const el = part(this, title, ".ol-note");
+  await el.waitFor({ state: "visible" });
+  assert.match((await el.innerText()).trim(), literal(note));
+});
+
+Then("{string} carries the tag {string}", async function (title, tag) {
+  const el = part(this, title, ".ol-tag");
+  await el.waitFor({ state: "visible" });
+  assert.equal((await el.innerText()).trim(), tag);
+});
+
+Then("{string} carries the date {string}", async function (title, date) {
+  const pill = part(this, title, ".ol-date");
+  await pill.waitFor({ state: "visible" });
+  // the pill reads friendly ("Thu 15 Jan"); the ISO it stands for is its title
+  assert.equal(await pill.getAttribute("title"), date);
+});
+
+// Done is a state of the NODE (web/render), so that is where it is asserted —
+// not on the strikethrough, which is one of several ways it draws.
+Then("{string} is done", async function (title) {
+  await assertClass(this.node(title).first(), "is-done", true, title);
+});
+
+Then("{string} is not done", async function (title) {
+  await assertClass(this.node(title).first(), "is-done", false, title);
+});
+
+// ---- mirrors ---------------------------------------------------------------
+//
+// A mirror is the same node drawn at a second SITE, so it is addressed by
+// where it hangs (the parent) rather than by its title — which is the title of
+// the node it mirrors, and belongs to that node's defining site too.
+
+Then("{string} holds a mirror of {string}", async function (parent, anchor) {
+  const link = this.node(parent).first().locator(".ol-mirror").first();
+  await link.waitFor({ state: "visible" });
+  assert.equal(await link.getAttribute("href"), `#${anchor}`);
+});
+
+Then("the mirror under {string} draws {string}", async function (parent, title) {
+  const site = this.node(parent)
+    .first()
+    .locator(".ol-node")
+    .filter({ has: this.page.locator(".ol-mirror") })
+    .first();
+  await site.waitFor({ state: "visible" });
+  assert.match(await site.innerText(), literal(title));
+});
+
+// ---- zoom, and nothing to zoom to ------------------------------------------
+
+Then("the main pane is zoomed", async function () {
+  await this.page.locator("#ol-outline.ol-zoom").waitFor({ state: "visible" });
+});
+
+// The empty state names the day it went looking for, so the assertion asks the
+// server which day that was rather than deciding for itself.
+Then("the main pane says there is no day node for today", async function () {
+  const day = await this.today();
+  await this.page
+    .getByText(`No day node for ${day}`)
+    .first()
+    .waitFor({ state: "visible" });
+});

--- a/e2e/steps/page_steps.js
+++ b/e2e/steps/page_steps.js
@@ -1,0 +1,74 @@
+// Getting to a page, and the chrome that is on every one of them: the
+// sidebar, the error banner, and whether this is still the same page load.
+
+import assert from "node:assert/strict";
+import * as path from "node:path";
+import { Given, Then, When } from "@cucumber/cucumber";
+
+// ---- navigation -------------------------------------------------------------
+
+When("I open the home page", async function () {
+  await this.open("/");
+});
+
+When("I open the Today page", async function () {
+  await this.open("/today");
+});
+
+When("I reload the page", async function () {
+  await this.page.reload();
+});
+
+When("I follow the sidebar's Today link", async function () {
+  await sidebarLink(this, "/today").click();
+  await this.page.waitForURL(this.url("/today"));
+});
+
+// ---- one page load ----------------------------------------------------------
+//
+// The live view swaps a region of the page; a reload replaces the page. They
+// look the same from the outside, and only one of them is the feature.
+
+Given("I mark this page load", async function () {
+  await this.mark();
+});
+
+Then("the page has not reloaded", async function () {
+  assert.equal(await this.marked(), true, "the mark is gone: the page reloaded");
+});
+
+// ---- the sidebar ------------------------------------------------------------
+
+Then("the sidebar lists {string}", async function (title) {
+  await this.treeNode(title).first().waitFor({ state: "visible" });
+});
+
+Then("the sidebar links to {string}", async function (href) {
+  await sidebarLink(this, href).waitFor({ state: "visible" });
+});
+
+function sidebarLink(world, href) {
+  return world.page.locator(`#ol-sidebar a[href="${href}"]`).first();
+}
+
+// ---- the error banner -------------------------------------------------------
+//
+// The store saying "this file does not load, here is the last good page
+// anyway". role=alert is the part a screen reader gets, so that is what gets
+// addressed.
+
+Then(
+  "the error banner names the file, with a line and a column",
+  async function () {
+    const banner = this.page.locator('.ol-error[role="alert"]');
+    await banner.waitFor({ state: "visible" });
+    const where = banner.locator(".ol-error-where");
+    // which file it is, is the world's to say — it named the temp outline
+    const file = path.basename(this.outlinePath).replace(/\./g, "\\.");
+    assert.match((await where.innerText()).trim(), new RegExp(`${file}:\\d+:\\d+$`));
+  },
+);
+
+Then("the error banner clears", async function () {
+  await this.page.locator(".ol-error").waitFor({ state: "detached" });
+});

--- a/e2e/steps/page_steps.js
+++ b/e2e/steps/page_steps.js
@@ -5,6 +5,8 @@ import assert from "node:assert/strict";
 import * as path from "node:path";
 import { Given, Then, When } from "@cucumber/cucumber";
 
+import { escapeRx } from "../support/dom.js";
+
 // ---- navigation -------------------------------------------------------------
 
 When("I open the home page", async function () {
@@ -64,7 +66,7 @@ Then(
     await banner.waitFor({ state: "visible" });
     const where = banner.locator(".ol-error-where");
     // which file it is, is the world's to say — it named the temp outline
-    const file = path.basename(this.outlinePath).replace(/\./g, "\\.");
+    const file = escapeRx(path.basename(this.outlinePath));
     assert.match((await where.innerText()).trim(), new RegExp(`${file}:\\d+:\\d+$`));
   },
 );

--- a/e2e/steps/prefs_steps.js
+++ b/e2e/steps/prefs_steps.js
@@ -1,0 +1,206 @@
+// Client prefs: the theme picker, what it writes on <html>, and what the page
+// repaints to. The theme names are read off the CHIPS — web/theme owns the
+// table, and a suite with its own copy of it would only ever be out of date.
+
+import assert from "node:assert/strict";
+import { Then, When } from "@cucumber/cucumber";
+
+// The theme row of the picker. `data-pref` is the pref's name, which is also
+// the tail of the attribute (data-theme) and of the storage key (olai.theme) —
+// so one selector reaches all three (web/prefs).
+const ROW = '.ol-prefs .ol-pref[data-pref="theme"]';
+const CHIP = `${ROW} .ol-pref-opt`;
+
+// What the parse probe leaves on the window. Named here because two steps and
+// one init script have to agree on it.
+const PROBE = "__olai_theme_landed";
+
+// ---- picking ---------------------------------------------------------------
+
+When("I pick the theme {string}", async function (theme) {
+  await pick(this.page, theme);
+});
+
+When("I pick the default theme", async function () {
+  await pick(this.page, await defaultTheme(this.page));
+});
+
+/** Click a chip and wait for the page to say it is in that theme. prefs.js
+ *  writes the attribute in the click handler, so this settles in a tick — but
+ *  waiting on the page rather than on the click is what keeps the assertions
+ *  after it about the theme and not about timing. */
+async function pick(page, theme) {
+  const chip = page.locator(`${CHIP}[data-value="${theme}"]`);
+  await chip.waitFor({ state: "visible" });
+  await chip.click();
+  await page.waitForFunction(
+    (t) => document.documentElement.getAttribute("data-theme") === t,
+    theme,
+  );
+}
+
+// ---- what the page is in ---------------------------------------------------
+
+// No attribute is not "no theme": it is the DEFAULT, which the sheet draws on
+// the bare :root. The distinction is the point — this is the page nobody has
+// picked on yet.
+Then("the page names no theme", async function () {
+  const named = await namedTheme(this.page);
+  assert.equal(named, null, `the page already names a theme: ${named}`);
+});
+
+Then("the page is in the theme {string}", async function (theme) {
+  assert.equal(await namedTheme(this.page), theme);
+});
+
+Then("the page is in the default theme", async function () {
+  assert.equal(await namedTheme(this.page), await defaultTheme(this.page));
+});
+
+/** The theme <html> names, or null for the one nobody has picked. */
+function namedTheme(page) {
+  return page.locator("html").getAttribute("data-theme");
+}
+
+Then("the lit theme chip is {string}", async function (theme) {
+  assert.equal(await litTheme(this.page), theme);
+});
+
+Then("the lit theme chip is the default", async function () {
+  assert.equal(await litTheme(this.page), await defaultTheme(this.page));
+});
+
+// The invariant behind the chips, as its own step: a screen reader reads
+// aria-pressed and not the class, and a scenario about PICKING a theme should
+// not be the thing that fails when those two drift.
+Then("every theme chip agrees with what it announces", async function () {
+  for (const c of await chips(this.page)) {
+    assert.equal(c.pressed, c.on ? "true" : "false", `${c.value}: aria-pressed`);
+  }
+});
+
+/** The theme the row falls back to, asked of the row. */
+async function defaultTheme(page) {
+  const row = page.locator(ROW);
+  await row.waitFor({ state: "visible" });
+  return await row.getAttribute("data-default");
+}
+
+/** Every chip: which theme it offers, whether it is lit, what it announces. */
+function chips(page) {
+  return page.locator(CHIP).evaluateAll((els) =>
+    els.map((el) => ({
+      value: el.dataset.value,
+      on: el.classList.contains("is-on"),
+      pressed: el.getAttribute("aria-pressed"),
+    })),
+  );
+}
+
+/** Which theme the picker says is in force. */
+async function litTheme(page) {
+  // prefs.js is deferred and re-marks after every htmx swap, so the lit chip
+  // is a thing that ARRIVES rather than a thing the server drew — and exactly
+  // one of them is lit once it has.
+  await page.waitForFunction(
+    (sel) => document.querySelectorAll(`${sel}.is-on`).length === 1,
+    CHIP,
+  );
+  return (await chips(page)).find((c) => c.on).value;
+}
+
+// ---- the paint -------------------------------------------------------------
+
+When("I note the paper colour", async function () {
+  this.paperBefore = await paper(this.page);
+  assert.ok(this.paperBefore, "the sheet paints no --paper");
+});
+
+Then("the paper colour has changed", async function () {
+  const now = await paper(this.page);
+  assert.ok(this.paperBefore, "nothing noted the paper colour first");
+  assert.notEqual(
+    now,
+    this.paperBefore,
+    "the attribute flipped but the sheet painted the same paper",
+  );
+});
+
+// The one colour a step may talk about is the one the server computed and the
+// browser resolved: we compare --paper against itself, never against a hex
+// written here.
+async function paper(page) {
+  return await page.evaluate(() =>
+    getComputedStyle(document.documentElement)
+      .getPropertyValue("--paper")
+      .trim(),
+  );
+}
+
+// The pair, spelled once for both the wait and the diagnosis. A page-side
+// expression rather than a function, because waitForFunction and evaluate can
+// both take a string and neither can call back into this module.
+const META_AND_PAPER = `({
+  meta: document.querySelector('meta[name="theme-color"]')?.getAttribute('content'),
+  paper: getComputedStyle(document.documentElement).getPropertyValue('--paper').trim(),
+})`;
+
+Then("the theme-color meta matches the paper", async function () {
+  try {
+    // pwa.js repaints the meta two animation frames after a chip is clicked,
+    // so this is a wait, not a read. Short: a mismatch is a fact within a
+    // frame or two, and the rest of the budget would only buy a worse message.
+    await this.page.waitForFunction(
+      `(r => !!r.meta && r.meta === r.paper)(${META_AND_PAPER})`,
+      null,
+      { timeout: 5_000 },
+    );
+  } catch (e) {
+    // the timeout says "it never matched"; say WHAT it said instead
+    const { meta, paper } = await this.page.evaluate(META_AND_PAPER);
+    assert.equal(meta, paper, "meta theme-color is not the paper");
+    throw e;
+  }
+});
+
+// ---- before the first paint ------------------------------------------------
+
+// The stored theme has to be on <html> while the document is still parsing:
+// the inline boot script in <head> is what puts it there, and everything else
+// on the page is deferred — a theme that landed later is a flash of the wrong
+// colours on every load. The observer is installed before any page script runs
+// and reads document.readyState at the moment the attribute appears:
+// "loading" is the parser still going, and no deferred script has run yet.
+When("I watch for the theme landing", async function () {
+  await this.page.addInitScript((key) => {
+    window[key] = null;
+    // `document` with subtree: at this point <html> does not exist yet, so
+    // there is nothing narrower to observe.
+    new MutationObserver((records) => {
+      if (window[key]) return;
+      if (!records.some((r) => r.attributeName === "data-theme")) return;
+      window[key] = {
+        theme: document.documentElement.getAttribute("data-theme"),
+        parsing: document.readyState === "loading",
+      };
+    }).observe(document, {
+      attributes: true,
+      subtree: true,
+      attributeFilter: ["data-theme"],
+    });
+  }, PROBE);
+});
+
+Then(
+  "the theme {string} landed while the page was still parsing",
+  async function (theme) {
+    const landed = await this.page.evaluate((k) => window[k], PROBE);
+    assert.ok(landed, "no theme was ever written on <html>");
+    assert.equal(landed.theme, theme);
+    assert.equal(
+      landed.parsing,
+      true,
+      "the theme landed after the parse: the page flashed the wrong one",
+    );
+  },
+);

--- a/e2e/steps/zoom_steps.js
+++ b/e2e/steps/zoom_steps.js
@@ -1,0 +1,56 @@
+// Zooming: a node's own page (/n/<key>), and the trail back out of it.
+//
+// A key never appears in a scenario. It is minted by the load layer and is
+// nobody's to type — what a person does is click a bullet, and what they get
+// back is an address that is one node's. So the steps click, and assert the
+// SHAPE of where they landed.
+
+import assert from "node:assert/strict";
+import { Then, When } from "@cucumber/cucumber";
+
+// Every node's address, whoever links to it: /n/ + the key.
+const NODE_URL = /\/n\/[^/]+$/;
+
+const CRUMBS = "nav.ol-breadcrumbs";
+
+When("I zoom into {string}", async function (title) {
+  await this.node(title).first().locator(":scope > .ol-row .ol-bullet-link").click();
+  await this.page.waitForURL(NODE_URL);
+});
+
+When("I zoom into the sidebar's {string}", async function (title) {
+  await this.treeNode(title).first().locator(".ol-tree-link").first().click();
+  await this.page.waitForURL(NODE_URL);
+});
+
+When("I follow the breadcrumb {string}", async function (label) {
+  await this.page.locator(`${CRUMBS} a.ol-crumb`, { hasText: label }).first().click();
+});
+
+Then("I am on a node's own page", async function () {
+  assert.match(new URL(this.page.url()).pathname, NODE_URL);
+});
+
+Then("I am back on the home page", async function () {
+  await this.page.waitForURL(this.url("/"));
+});
+
+// The tab is what a permalink is pasted into, so the node's title has to be on
+// it — a page called "olai" says nothing about which node you sent someone.
+Then("the tab is named for {string}", async function (title) {
+  assert.match(await this.page.title(), new RegExp(title));
+});
+
+// The trail above the node, in order, as it reads: "home" first (it is always
+// drawn), then the file, then each ancestor. The node itself is NOT a crumb —
+// it is the thing you are looking at.
+Then("the breadcrumbs read {string}", async function (trail) {
+  const crumbs = this.page.locator(`${CRUMBS} .ol-crumb`);
+  await crumbs.first().waitFor({ state: "visible" });
+  const read = (await crumbs.allInnerTexts()).map((s) => s.trim());
+  assert.deepEqual(read, trail.split(" > "));
+});
+
+Then("the page says there is no such node", async function () {
+  await this.page.getByText("No such node.").first().waitFor({ state: "visible" });
+});

--- a/e2e/support/dom.js
+++ b/e2e/support/dom.js
@@ -1,0 +1,29 @@
+// Assertions about an element that playwright has no spelling for. Here
+// rather than in whichever step file needed one first: a step file is about a
+// surface of the app, and reaching into another one for a helper couples two
+// surfaces that have nothing to say to each other.
+
+import assert from "node:assert/strict";
+
+/** Whether an element wears a class the app puts on it to mean a STATE
+ *  (is-done, is-collapsed). Read directly rather than through what it paints:
+ *  the paint is one of several ways the state draws, and the cheapest one to
+ *  change. */
+export async function hasClass(locator, cls) {
+  await locator.waitFor();
+  return await locator.evaluate((el, c) => el.classList.contains(c), cls);
+}
+
+export async function assertClass(locator, cls, want, what) {
+  assert.equal(
+    await hasClass(locator, cls),
+    want,
+    `${what}: expected .${cls} to be ${want}`,
+  );
+}
+
+/** A literal, as a regexp. innerText carries whatever the markup put around
+ *  it, so a step that means "this text is in there" says so with a match. */
+export function literal(s) {
+  return new RegExp(s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+}

--- a/e2e/support/dom.js
+++ b/e2e/support/dom.js
@@ -22,8 +22,15 @@ export async function assertClass(locator, cls, want, what) {
   );
 }
 
+/** A string, as regexp source: every metacharacter escaped, backslash first
+ *  among them. For building a pattern that has a literal PART — a filename, a
+ *  title — and a real pattern around it. */
+export function escapeRx(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /** A literal, as a regexp. innerText carries whatever the markup put around
  *  it, so a step that means "this text is in there" says so with a match. */
 export function literal(s) {
-  return new RegExp(s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  return new RegExp(escapeRx(s));
 }

--- a/e2e/support/hooks.js
+++ b/e2e/support/hooks.js
@@ -1,0 +1,50 @@
+// Browser lifecycle, scenario lifecycle.
+//
+// One chromium per worker (launching one is the expensive part), one context
+// and one server per scenario (isolation is the point). The browser is
+// nixpkgs' — playwright-driver pins it, PLAYWRIGHT_BROWSERS_PATH points at it,
+// and the npm `playwright` beside it is the same version (flake.nix).
+
+import {
+  After,
+  AfterAll,
+  Before,
+  BeforeAll,
+  Status,
+  setDefaultTimeout,
+  setWorldConstructor,
+} from "@cucumber/cucumber";
+import { chromium } from "playwright";
+
+import { OlaiWorld } from "./world.js";
+
+// A step here can be waiting on a racket start-up, a filesystem watcher's
+// 2-second poll fallback, and an agent subprocess. Cucumber's 5s default is a
+// budget for none of those.
+setDefaultTimeout(30_000);
+
+setWorldConstructor(OlaiWorld);
+
+let browser;
+
+BeforeAll(async () => {
+  browser = await chromium.launch({ headless: true });
+});
+
+AfterAll(async () => {
+  if (browser) await browser.close();
+});
+
+Before(async function () {
+  await this.boot(browser);
+});
+
+// The server's own output is the first thing worth reading when a scenario
+// fails — a load error, an agent that would not start — and it dies with the
+// scenario, so it is attached here or nowhere.
+After(async function ({ result }) {
+  if (result?.status === Status.FAILED && this.server) {
+    this.attach(this.server.log(), "text/plain");
+  }
+  await this.shutdown();
+});

--- a/e2e/support/hooks.js
+++ b/e2e/support/hooks.js
@@ -35,8 +35,22 @@ AfterAll(async () => {
   if (browser) await browser.close();
 });
 
-Before(async function () {
-  await this.boot(browser);
+// What the fake agent had stored when it woke up. A property of the machine,
+// not of anything a client says (fake-acp-agent.rkt), so it is a property of
+// the server a scenario boots — and a tag is how a scenario asks for one.
+// "foreign" is only other directories' conversations; anything else is two of
+// this directory's own plus a newer foreign one.
+const STORED_SESSIONS = {
+  "@stored-sessions": "1",
+  "@foreign-sessions": "foreign",
+};
+
+Before(async function ({ pickle }) {
+  const env = {};
+  for (const { name } of pickle.tags) {
+    if (name in STORED_SESSIONS) env.OLAI_FAKE_ACP_STORED = STORED_SESSIONS[name];
+  }
+  await this.boot(browser, env);
 });
 
 // The server's own output is the first thing worth reading when a scenario

--- a/e2e/support/outline.js
+++ b/e2e/support/outline.js
@@ -1,0 +1,32 @@
+// The outline a scenario boots against, and the breakage one scenario feeds
+// it.
+//
+// The fixture is a REAL `#lang olai` file (e2e/fixtures/Tasks.rkt), read once
+// per run and written into each scenario's temp dir: the language is the only
+// validator, so a typo in it is a srcloc out of `olai check` — which the CI
+// smoke lane runs over this file — and not a browser-level mystery three
+// layers away. The quoteless outline has no comment syntax, which is why what
+// the fixture is FOR is written here rather than in it.
+//
+// Fiction, like examples/: no personal data reaches this suite. Every title in
+// it is distinct enough that a step can name a node by a SUBSTRING of its
+// title and mean one node.
+//
+// EVERY edit a step makes to it changes the file's SIZE. The store's staleness
+// probe is mtime (whole seconds) + size, so a same-second same-size rewrite is
+// invisible to a running server — the same discipline
+// olai/tests/integration/serve.rkt keeps.
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+export const FIXTURE = await fs.readFile(
+  path.join(import.meta.dirname, "..", "fixtures", "Tasks.rkt"),
+  "utf8",
+);
+
+// A form the expander rejects — `@date` wants an ISO date — with a srcloc the
+// banner can name. A string, not a file: it must not parse, so it cannot be
+// one of the repo's checked outlines. The same broken form stands in for "a
+// file mid-edit" in olai/tests/integration/serve.rkt and nix/smoke.nix.
+export const BREAKAGE = "Broken\n  @date not-a-date\n";

--- a/e2e/support/server.js
+++ b/e2e/support/server.js
@@ -1,0 +1,132 @@
+// One `olai serve` per scenario: ephemeral port, temp outline, fake agent.
+//
+// The port is the server's to pick (`--port 0`) and the server's to report —
+// the line it prints on stdout is where the harness learns it. Nothing here
+// picks a port, so parallel workers and a developer's own `just serve` never
+// collide.
+//
+// THE AGENT IS ALWAYS THE FAKE ONE (olai/tests/integration/fake-acp-agent.rkt,
+// a racket script with a shebang, committed executable). `serve` refuses to
+// start without an ACP agent, and an e2e suite that spawned a real Claude Code
+// would be a suite that costs money and answers differently every run.
+
+import { spawn } from "node:child_process";
+import * as path from "node:path";
+
+const REPO = path.resolve(import.meta.dirname, "..", "..");
+
+const FAKE_AGENT = path.join(
+  REPO,
+  "olai",
+  "tests",
+  "integration",
+  "fake-acp-agent.rkt",
+);
+
+// The binary under test: whatever `just build` put on PATH, unless something
+// names another one (the packaged ./result/bin/olai, say).
+const OLAI_BIN = process.env.OLAI_BIN || "olai";
+
+// The fake agent's script is keyed on the prompt TEXT (its keyword table is at
+// the top of fake-acp-agent.rkt). Which words those are is this module's
+// business, like the agent's path: a feature file saying SLOW would be a
+// scenario spelling a protocol it does not otherwise know exists.
+export const SLOW_PROMPT = "SLOW down and read it all";
+
+// Racket start-up, the agent's own boot, and a slow CI box — generous, since
+// this is a "the server never came up" timeout and not a latency budget. It
+// has to stay UNDER the Before hook's step timeout (support/hooks.js) or
+// cucumber gives up first and the message below, which carries the server's
+// own output, never gets to be the failure.
+const BOOT_TIMEOUT_MS = 20_000;
+
+const URL_RX = /(http:\/\/[\d.]+:\d+)/;
+
+/** Boot a server on `dir`. Resolves once it says which port it took. */
+export async function startServer(dir) {
+  const child = spawn(OLAI_BIN, ["serve", "--port", "0", dir], {
+    cwd: dir,
+    env: serverEnv(),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  // Both pipes are drained for the whole life of the process: a server whose
+  // stderr filled up would block mid-scenario, and the log is what a failing
+  // step attaches.
+  let out = "";
+  let log = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (d) => {
+    out += d;
+  });
+  child.stderr.on("data", (d) => {
+    log += d;
+  });
+
+  const url = await new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`olai serve did not come up in ${BOOT_TIMEOUT_MS}ms\n${out}${log}`)),
+      BOOT_TIMEOUT_MS,
+    );
+    const settle = () => {
+      clearTimeout(timer);
+      child.stdout.off("data", onData);
+      child.off("exit", onExit);
+      child.off("error", onError);
+    };
+    const onData = () => {
+      const m = URL_RX.exec(out);
+      if (m) {
+        settle();
+        resolve(m[1]);
+      }
+    };
+    const onExit = (code) => {
+      settle();
+      reject(new Error(`olai serve exited with ${code}\n${out}${log}`));
+    };
+    const onError = (e) => {
+      settle();
+      reject(e);
+    };
+    child.stdout.on("data", onData);
+    child.on("exit", onExit);
+    child.on("error", onError);
+    onData();
+  });
+
+  return {
+    url,
+    // What the server said while the scenario ran. Read at teardown, so it
+    // holds everything up to the failure.
+    log: () => out + log,
+    stop: () => stop(child),
+  };
+}
+
+/** The child's environment, minus everything personal.
+ *
+ *  OLAI_HOME especially: a developer running the suite has one, `serve` would
+ *  never read it (it is given a directory), but a step that shelled out could,
+ *  and personal data has no business in a test process. */
+function serverEnv() {
+  const env = { ...process.env, OLAI_ACP_AGENT: FAKE_AGENT };
+  delete env.OLAI_HOME;
+  // The fake agent reads this to decide whether the machine has stored
+  // conversations; scenarios that want them set it themselves.
+  delete env.OLAI_FAKE_ACP_STORED;
+  return env;
+}
+
+/** SIGINT first: `olai serve` blocks on a break, and its handler is what stops
+ *  the watcher and kills the agent it spawned. SIGKILL is the backstop for a
+ *  server that ignored it — and would orphan the agent. */
+async function stop(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise((resolve) => child.once("exit", resolve));
+  child.kill("SIGINT");
+  const killer = setTimeout(() => child.kill("SIGKILL"), 5_000);
+  await exited;
+  clearTimeout(killer);
+}

--- a/e2e/support/server.js
+++ b/e2e/support/server.js
@@ -42,11 +42,16 @@ const BOOT_TIMEOUT_MS = 20_000;
 
 const URL_RX = /(http:\/\/[\d.]+:\d+)/;
 
-/** Boot a server on `dir`. Resolves once it says which port it took. */
-export async function startServer(dir) {
+/** Boot a server on `dir`. Resolves once it says which port it took.
+ *
+ *  `env` is what this scenario wants the agent to have woken up to — what the
+ *  machine had stored, and nothing else. It is a boot-time fact for the same
+ *  reason it is one for a real agent: no step can put a conversation in the
+ *  past after the panel has already asked what is there. */
+export async function startServer(dir, env = {}) {
   const child = spawn(OLAI_BIN, ["serve", "--port", "0", dir], {
     cwd: dir,
-    env: serverEnv(),
+    env: { ...serverEnv(), ...env },
     stdio: ["ignore", "pipe", "pipe"],
   });
 

--- a/e2e/support/world.js
+++ b/e2e/support/world.js
@@ -1,0 +1,120 @@
+// The scenario's world: one temp outline, one server, one browser context.
+//
+// Everything a step needs is reached through here, and nothing here knows what
+// any scenario is about. The page is the only thing steps assert against —
+// this suite is the one place in the repo that runs the JS.
+
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { World } from "@cucumber/cucumber";
+
+import { FIXTURE } from "./outline.js";
+import { startServer } from "./server.js";
+
+// A desktop, because the layout the scenarios assert is the desktop one: the
+// sidebar is a column, and the chat panel sits BESIDE the outline rather than
+// over it (the phone rules are a @media away and would make the geometry
+// assertions say nothing).
+const VIEWPORT = { width: 1280, height: 900 };
+
+// The sentinel a mark leaves on the page. A reload wipes it; an htmx swap does
+// not — which is the whole difference "without a reload" is about.
+const MARK = "__olai_e2e_mark";
+
+export class OlaiWorld extends World {
+  /** Temp outline + server + a fresh browser context. `browser` is the run's
+   *  (hooks.js owns it): a context per scenario is what makes localStorage —
+   *  the fold state, the theme, the chat panel's open bit — start empty. */
+  async boot(browser) {
+    this.dir = await fs.mkdtemp(path.join(os.tmpdir(), "olai-e2e-"));
+    this.outlinePath = path.join(this.dir, "Tasks.rkt");
+    await this.rewrite(FIXTURE);
+
+    // The context does not depend on the URL, and the racket boot is the
+    // second the scenario actually waits for; it may as well cover both.
+    const [server, context] = await Promise.all([
+      startServer(this.dir),
+      browser.newContext({ viewport: VIEWPORT }),
+    ]);
+    this.server = server;
+    this.context = context;
+    this.page = await context.newPage();
+  }
+
+  async shutdown() {
+    // The browser and the server have nothing to say to each other on the way
+    // out; only the temp dir has to outlive the server that is reading it.
+    await Promise.all([
+      this.context?.close(),
+      this.server?.stop(),
+    ]);
+    if (this.dir) await fs.rm(this.dir, { recursive: true, force: true });
+  }
+
+  url(pathname = "/") {
+    return this.server.url + pathname;
+  }
+
+  async open(pathname = "/") {
+    await this.page.goto(this.url(pathname));
+  }
+
+  // ---- the outline file ---------------------------------------------------
+
+  /** Rewrite the outline under the running server. */
+  async rewrite(text) {
+    this.outline = text;
+    await fs.writeFile(this.outlinePath, text, "utf8");
+  }
+
+  /** Add to the outline under the running server (see outline.js on sizes). */
+  async append(text) {
+    await this.rewrite(this.outline + text);
+  }
+
+  /** The server's idea of today, asked of the server: an ISO day the outline
+   *  can be given a node for. A harness that computed one itself would be a
+   *  second clock, and the two disagree for an hour twice a year. */
+  async today() {
+    const res = await fetch(this.url("/api/agenda"));
+    return (await res.json()).today;
+  }
+
+  // ---- addressing a node --------------------------------------------------
+  //
+  // The two panes draw the SAME shell (.ol-node / .ol-row / .ol-children,
+  // web/render's node-shell) and differ in what sits in the row: a title in
+  // the outline, a link in the sidebar tree. So do these.
+
+  /** A main-pane node by (part of) its own title. `:scope >` is what keeps an
+   *  ancestor — whose subtree also contains that title — from matching. */
+  node(title) {
+    return this.paneNode("#ol-outline", ".ol-title", title);
+  }
+
+  /** A sidebar-tree node by (part of) its own link text. */
+  treeNode(title) {
+    return this.paneNode("#ol-sidebar", ".ol-tree-link", title);
+  }
+
+  paneNode(pane, row, text) {
+    return this.page.locator(`${pane} .ol-node`).filter({
+      has: this.page.locator(`:scope > .ol-row ${row}`, { hasText: text }),
+    });
+  }
+
+  // ---- this page load -----------------------------------------------------
+
+  /** Leave a mark on this page load. It survives every SSE swap and nothing
+   *  else, so a step can tell a live update from a reload. */
+  async mark() {
+    await this.page.evaluate((k) => {
+      window[k] = true;
+    }, MARK);
+  }
+
+  async marked() {
+    return await this.page.evaluate((k) => window[k] === true, MARK);
+  }
+}

--- a/e2e/support/world.js
+++ b/e2e/support/world.js
@@ -26,7 +26,7 @@ export class OlaiWorld extends World {
   /** Temp outline + server + a fresh browser context. `browser` is the run's
    *  (hooks.js owns it): a context per scenario is what makes localStorage —
    *  the fold state, the theme, the chat panel's open bit — start empty. */
-  async boot(browser) {
+  async boot(browser, env = {}) {
     this.dir = await fs.mkdtemp(path.join(os.tmpdir(), "olai-e2e-"));
     this.outlinePath = path.join(this.dir, "Tasks.rkt");
     await this.rewrite(FIXTURE);
@@ -34,7 +34,7 @@ export class OlaiWorld extends World {
     // The context does not depend on the URL, and the racket boot is the
     // second the scenario actually waits for; it may as well cover both.
     const [server, context] = await Promise.all([
-      startServer(this.dir),
+      startServer(this.dir, env),
       browser.newContext({ viewport: VIEWPORT }),
     ]);
     this.server = server;
@@ -79,6 +79,32 @@ export class OlaiWorld extends World {
   async today() {
     const res = await fetch(this.url("/api/agenda"));
     return (await res.json()).today;
+  }
+
+  // ---- the agent's boot ---------------------------------------------------
+
+  /** Wait until the agent's boot frames have landed ON THE SERVER.
+   *
+   *  `serve` prints its URL and starts answering while the agent is still
+   *  waking up in its own thread, so the first second of a server's life is a
+   *  panel that does not know its model, its conversation or its commands yet.
+   *  A page opened in that window never learns: the frames are broadcast to
+   *  whoever is listening, and it was not born yet (see the @skip scenario in
+   *  features/sessions.feature).
+   *
+   *  The command list is the LAST boot frame — the same signal Roadmap.rkt
+   *  names for the racket suite's version of this race — so the page carrying
+   *  a non-empty one is the agent being all the way up. */
+  async waitForAgent(timeout = 20_000) {
+    const deadline = Date.now() + timeout;
+    for (;;) {
+      const html = await (await fetch(this.url("/"))).text();
+      if (/data-commands="\[\{/.test(html)) return;
+      if (Date.now() > deadline) {
+        throw new Error(`the agent was still waking up after ${timeout}ms`);
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
 
   // ---- addressing a node --------------------------------------------------

--- a/flake.nix
+++ b/flake.nix
@@ -21,29 +21,53 @@
       }) systems);
     in
     {
-      devShells = forAllSystems ({ pkgs, system }: {
-        default = pkgs.mkShell {
-          packages = [
-            pkgs.racket
-            pkgs.just
-            pkgs.watchexec
-            pkgs.tzdata
-            pkgs.npins
-            self.packages.${system}.acp-agent
-          ];
-          shellHook = ''
-            export PLTUSERHOME="''${PLTUSERHOME:-$PWD/.plt-user}"
-            mkdir -p "$PLTUSERHOME"
-            if [ -d "${pkgs.tzdata}/share/zoneinfo" ]; then
-              export TZDIR="${pkgs.tzdata}/share/zoneinfo"
-            fi
-            # `serve` refuses to start without an ACP agent; hand it the
-            # bundled one so `just serve` works out of the box. Set the var
-            # yourself to point at a different agent.
-            export OLAI_ACP_AGENT="''${OLAI_ACP_AGENT:-${pkgs.lib.getExe self.packages.${system}.acp-agent}}"
-          '';
-        };
-      });
+      devShells = forAllSystems ({ pkgs, system }:
+        let
+          racketShell = {
+            packages = [
+              pkgs.racket
+              pkgs.just
+              pkgs.watchexec
+              pkgs.tzdata
+              pkgs.npins
+              self.packages.${system}.acp-agent
+            ];
+            shellHook = ''
+              export PLTUSERHOME="''${PLTUSERHOME:-$PWD/.plt-user}"
+              mkdir -p "$PLTUSERHOME"
+              if [ -d "${pkgs.tzdata}/share/zoneinfo" ]; then
+                export TZDIR="${pkgs.tzdata}/share/zoneinfo"
+              fi
+              # `serve` refuses to start without an ACP agent; hand it the
+              # bundled one so `just serve` works out of the box. Set the var
+              # yourself to point at a different agent.
+              export OLAI_ACP_AGENT="''${OLAI_ACP_AGENT:-${pkgs.lib.getExe self.packages.${system}.acp-agent}}"
+            '';
+          };
+        in
+        {
+          default = pkgs.mkShell racketShell;
+
+          # The browser lane, and only it: node, a pinned chromium, and the
+          # harness's node_modules. Kept OUT of the default shell because
+          # nothing else here has any use for a 500M browser — `just e2e`
+          # enters this one itself (OLAI_E2E_SHELL says it is already in).
+          # The racket side comes along whole: e2e boots the `olai` the dev
+          # shell builds, against the repo's own fake ACP agent (racket).
+          e2e = pkgs.mkShell {
+            packages = racketShell.packages ++ [ pkgs.nodejs ];
+            shellHook = racketShell.shellHook + ''
+              export OLAI_E2E_SHELL=1
+              export OLAI_E2E_NODE_MODULES="${self.packages.${system}.e2e-node-modules}/node_modules"
+              # playwright the npm package and playwright-driver the browser
+              # bundle are ONE version (e2e/package.json pins the same
+              # ${pkgs.playwright-driver.version}); a drift is "Executable
+              # doesn't exist" at scenario one.
+              export PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright-driver.browsers}"
+              export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
+            '';
+          };
+        });
 
       packages = forAllSystems ({ pkgs, system }:
         let
@@ -67,6 +91,10 @@
           inherit olai;
           racket-deps = racketDepsPkg.racketDeps;
           acp-agent = acpAgent;
+          # cucumber + playwright for the browser journeys (e2e/default.nix).
+          # Nothing in the olai package or its checks depends on it: `nix
+          # build` stays what it was.
+          e2e-node-modules = pkgs.callPackage ./e2e { };
         });
 
       # `nix run` starts the web view; `nix run .#cli -- check ...` is the CLI.

--- a/justfile
+++ b/justfile
@@ -75,3 +75,30 @@ test-integration: build
 # Everything, in one -j pool so the slow files start first
 test-all: build
     raco test -j {{ num_cpus() }} olai/tests/integration/ olai/tests/*.rkt
+
+# Browser journeys: what the wire tests cannot see, because no JS runs there
+# (folding, prefs, the live swap, the chat panel). NEVER part of `just test` —
+# that stays the fast racket set. Its own nix shell (node + a pinned chromium),
+# entered here rather than by the caller; OLAI_E2E_SHELL says we are in it.
+e2e_shell := if env('OLAI_E2E_SHELL', '') != '' { '' } else { 'nix develop .#e2e --accept-flake-config -c' }
+
+# `build` runs INSIDE that shell rather than as a dependency of this recipe:
+# a dependency runs in whatever shell the caller had, and the racket-less one
+# is exactly the shell a developer types `just e2e` from. One entry, not two —
+# a flake eval is a couple of seconds, and this is an edit-loop recipe.
+
+# Browser journeys (args are cucumber's: FILE, FILE:LINE, --tags '@skip')
+e2e *args:
+    {{ e2e_shell }} bash -euc 'just build && just e2e-run "$@"' -- {{ args }}
+
+# The runner, inside the e2e shell: link the nix-built node_modules into place
+# (ESM resolution walks up from the importing file and ignores NODE_PATH) and
+# hand the rest to cucumber. CI calls this one directly — its `build` is a
+# separate DAG node, and a lane body that rebuilt would race the others
+# (ci/mod.just).
+e2e-run *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ln -sfn "$OLAI_E2E_NODE_MODULES" e2e/node_modules
+    cd e2e
+    exec node_modules/.bin/cucumber-js {{ args }}


### PR DESCRIPTION
Browser-level journeys the wire tests cannot see: `integration/` stops at HTTP
(HTML strings, SSE frames, JSON) and no JS runs there, so folding, the theme
picker, the live re-swap, the chat panel's geometry and zoom were untested.

cucumber-js features + step definitions driving headless Chromium. Each
scenario boots its own `olai serve --port 0` against its own temp outline and
gets a fresh browser context, so localStorage (folds, theme, the panel's open
bit) starts empty every time and parallel workers share nothing. The agent is
always the repo's fake one (`olai/tests/integration/fake-acp-agent.rkt`) — no
real Claude Code is ever spawned, and no scenario reads `$OLAI_HOME`.

`just e2e` (args go to cucumber: `just e2e features/chat.feature:12`) and its
own CI node in `ci/mod.just` — Linux only, `CUCUMBER_RETRY=1`,
`CUCUMBER_PARALLEL=4`. Never part of `just test`.

## Flow inventory

**Covered** — 34 scenarios, 276 steps, ~18s on 4 workers:

| feature | what it holds down |
|---|---|
| `outline` | titles, notes, tags, date pills, done state, mirror sites, the sidebar tree |
| `collapse` | fold hides children (class + `aria-expanded` + children gone), survives a reload, unfold sticks too, the sidebar tree folds on its own key |
| `live` | a title saved to the file appears — and a deleted one leaves — with no reload (a page-load mark proves it was a swap) |
| `error` | a broken file banners `file:line:col` and keeps the last good page; fixing it clears the banner, no reload |
| `today` | the sidebar's Today link, the empty state before the first capture, the zoom once a day node exists |
| `zoom` (#17) | a bullet is a link to `/n/<key>`, breadcrumbs are the trail above the node, crumbs and the sidebar tree zoom, a zoomed page follows the file, a node that went away says so instead of 404ing |
| `theme` | default theme in force, picking one repaints (`--paper` moves), `theme-color` meta follows the paper, the pick survives a reload and lands *while the page is still parsing* (the inline boot script, i.e. no flash), the default is a pick like any other |
| `chat` | open/close/remembered, a turn (my message, the streamed reply, the tool line), busy then idle, an outline edit does not swap the conversation away |
| `chat` (#14 harness) | with the panel open, `.ol-main`'s content width stays over a 20 rem floor **and** its right edge stops before the panel's left edge — geometry off `getBoundingClientRect`, no pixels |
| `sessions` (#20) | the picker lists only this directory's chats, boot comes up in the newest of *those*, picking an older one replays it; another checkout's newer conversation is neither adopted nor offered, and a fresh chat still starts |

**Skipped (`@skip`, written and parked)** — the regression-ledger convention;
`CUCUMBER_TAGS='@skip' just e2e` runs them, and both fail today for the reason
stated:

1. `collapse.feature` — *a fold outlives the live view's re-swap*. The parked
   bug. Diagnosed while writing it: collapse.js re-applies on `htmx:afterSwap`
   and at that moment it is right, but the nodes carry ids, so htmx's **settle**
   phase then restores the class attribute the server sent, which has no
   `is-collapsed`. The fold is correct for ~20 ms and then gone; `htmx:afterSettle`
   is where that pass belongs. Same defect hits the sidebar tree.
2. `sessions.feature` — *a page opened while the agent is still waking up says
   which chat it is in*. Found by this suite. `serve` prints its URL and answers
   requests while the agent boots in its own thread, and the boot frames (model,
   session, commands) are **broadcast** — a page opened in that window is not
   listening yet, and the panel it was served was rendered before any of them
   landed. It never learns until something else makes it redraw. Same shape as
   the racket suite's parked boot-frame race. Every other sessions scenario says
   `Given the agent has woken up` first, which is the harness admitting it.

**Deferred**: nothing. The chat-conversation flows the brief allowed deferring
are in — pointing `serve` at the fake agent is one env var, so streamed replies,
tool lines and the session picker are all covered.

## Wiring

- `e2e/default.nix` — node_modules as one fixed-output derivation
  (`fetchNpmDeps`), the `acp/` pattern; `src` filtered to the manifest so
  editing a scenario does not rebuild deps.
- `flake.nix` — `devShells.e2e` (node + `playwright-driver`'s browsers) beside
  the default shell, which is untouched; `packages.e2e-node-modules`. The npm
  `playwright` is pinned to the same version as nixpkgs' `playwright-driver`.
  `nix build` of olai, and its checks, are unchanged.
- `e2e/fixtures/Tasks.rkt` is a real `#lang olai` file, added to the `smoke`
  lane — the language is the only validator, here too, so a typo in the fixture
  is a srcloc and not a browser-level mystery.
- Docs: an `e2e` section in `docs/hacking.md`; `docs/cli.md` notes that the
  startup line is a contract (the harness reads the port back out of it).

## The Hickey + Lowy pass, and /simplify

Written flow-by-flow first, then refactored as one judgement:

- **One subject per step file.** The first cut had `outline_steps.js` writing
  the file *and* reading the page. Now: `file_steps.js` is the only writer to
  the outline; `outline_steps.js` is what the outline pane draws;
  `page_steps.js` is navigation and chrome (sidebar, banner, page-load mark);
  `collapse` / `prefs` / `chat` / `zoom` are one interactive surface each. Each
  file now changes for one reason — the language and the store's probe, or
  `render.rkt`, or the routes, or that component's JS.
- **One act, one name.** Appending a title to the outline had grown three
  spellings across three features ("I add…", "…is appended…", "the outline
  gains…"). One step now, used by all of them.
- **Vocabulary in `support/`, assertions in `steps/`.** `world.node` /
  `world.treeNode` share one `paneNode` (the two panes draw the same node shell
  and differ only in what sits in the row); `assertClass`/`hasClass` moved to
  `support/dom.js` so no step file reaches into another for a helper.
- **Facts asked of their owner.** The banner's filename comes from
  `world.outlinePath`; the day `/today` wants comes from `/api/agenda`; theme
  names are read off the chips, never listed here; the fake agent's prompt
  keywords live next to the fake agent's path in `support/server.js`, not in a
  feature file.
- **Boot-time state is boot-time.** What the agent woke up with is a scenario
  *tag* → server env (`@stored-sessions`, `@foreign-sessions`), because no step
  can put a conversation in the past after the panel has asked.

`/simplify` then ran four review agents (reuse, simplification, efficiency,
altitude) over the diff. Applied: dropped the `paths` + argv-sniffing in
`cucumber.js` (cucumber's own default is that glob, and the key is additive);
one shell entry for `just e2e` instead of two (~2 s per run); server boot and
browser context started together, torn down together; the `litTheme` audit
split out into its own step so an aria regression names itself; one page-side
expression for the meta/paper pair; `CUCUMBER_PARALLEL=4` in CI (47 s → 18 s).
Skipped, with reasons: sharing the npm-manifest filter with `acp/` (churn there
for three lines), a central `selectors.js` (a class belongs where it is
asserted, mirroring how the app defines a class where it is drawn), reusing
`examples/Example.rkt` as the fixture (it changes for demo reasons; this suite
needs one it controls), and having the CI lane call `just e2e` (it would rebuild
inside a lane body, which `ci/mod.just` explicitly forbids).

Local `just ci` is green: 196 unit, 100 integration, 34 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
