### PR TITLE
web: a fold survives the live re-swap (htmx:afterSettle)

### DIFF
--- a/e2e/features/collapse.feature
+++ b/e2e/features/collapse.feature
@@ -37,13 +37,6 @@ Feature: folding a node
     Then the sidebar's "Ship the server" is folded
     And "Ship the server" is unfolded
 
-  # KNOWN BROKEN: the live view unfolds everything you folded.
-  # collapse.js re-applies the fold on htmx:afterSwap, and at that moment it is
-  # right — but the nodes carry ids, so htmx's settle phase then restores the
-  # class attribute the SERVER sent, which has no is-collapsed. The fold is
-  # correct for ~20ms and then gone. htmx:afterSettle is where that pass
-  # belongs. Parked until collapse.js listens there.
-  @skip
   Scenario: a fold outlives the live view's re-swap
     When I open the home page
     And I fold "Inbox"

--- a/olai/web/static/collapse.js
+++ b/olai/web/static/collapse.js
@@ -9,8 +9,8 @@
     var t=n.querySelector(':scope > .ol-row > .ol-toggle');
     if(t)t.setAttribute('aria-expanded',c?'false':'true');
   }
-  function apply(root){
-    (root||document).querySelectorAll('[data-collapse-key]').forEach(function(n){
+  function apply(){
+    document.querySelectorAll('[data-collapse-key]').forEach(function(n){
       var v=state[n.dataset.collapseKey];
       set(n,v===undefined?n.classList.contains('is-collapsed'):v);
     });
@@ -26,9 +26,11 @@
     // fold that threw would leave the click half-done
     try{localStorage.setItem(KEY,JSON.stringify(state))}catch(e){}
   });
-  // An outerHTML swap replaces the element the event would name, so re-apply
-  // over the whole document rather than over e.target: a live re-render must
-  // not silently unfold what you folded.
-  document.addEventListener('htmx:afterSwap',function(){apply()});
+  // afterSETTLE, not afterSwap: the nodes carry ids, so htmx's settle phase
+  // restores the class attribute the SERVER sent, undoing any pass that ran
+  // earlier. It is also the first moment that attribute IS the server's, which
+  // is what the unvisited-key branch above reads. Whole document, not
+  // e.target: an outerHTML swap replaces the element the event would name.
+  document.addEventListener('htmx:afterSettle',apply);
   apply();
 })();


### PR DESCRIPTION
Fixes the roadmap bug "collapse state lost on live re-swap". One line in
`olai/web/static/collapse.js`: the re-apply pass moves from
`htmx:afterSwap` to `htmx:afterSettle`.

## The mechanism (the parked note had it wrong)

Roadmap's note guessed `sse.js` swaps via `api.swap` directly, so
`htmx:afterSwap` never fires. Not what happens: the live region is
`hx-get` + `hx-trigger="sse:outline"` (`olai/web/render.rkt:899`), i.e.
the ordinary htmx AJAX pipeline, and afterSwap fires normally.

What actually kills the fold is settle. The nodes carry ids, so htmx
copies the old element's attributes onto the new one at swap time (which
is why the fold looks right for a moment) and a settle task then restores
the attributes the SERVER sent — a class with no `is-collapsed`. Any pass
that ran before that is undone. afterSettle is also the first moment the
class attribute IS the server's, which is what collapse.js's
unvisited-key branch reads to let render-time defaults survive; on
afterSwap that branch was reading htmx's copy of the *old* class.

No MutationObserver needed.

## Both panes

One fix covers both: `apply()` runs over the whole document. The sidebar
tree is additionally out of the line of fire — it is rendered outside
`#ol-live` and the swap is `hx-select`/`hx-target` `#ol-live`, so a live
re-render never replaces those rows.

`prefs.js:37` has a structurally identical listener still on afterSwap.
Not the same defect today (the pref chips carry no id, and the sidebar is
never swapped), so it is left alone — noting it here rather than widening
this change.

## Tests

- `@skip` comes off *a fold outlives the live view's re-swap* in
  `e2e/features/collapse.feature`, along with the postmortem comment. It
  fails without the one-liner (times out waiting for the fold) and passes
  with it — checked both ways.
- `just e2e`: 35 scenarios, all pass. `just test`: 196 pass, untouched.
- `/simplify` pass: tightened the comment, and dropped `apply()`'s `root`
  parameter — dead at both call sites, and the only reason the listener
  needed a wrapper closure.

Roadmap.rkt not touched.