### PR TITLE
chat: the stream catches a connection up, so a panel opened mid-boot is not behind

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -292,7 +292,10 @@ olai: OLAI_ACP_AGENT does not exist: /nope
 
 — exit 1, the usage code. The agent is spawned **at startup**, in a background
 thread: the listener is up first, so pages serve while the subprocess starts
-and the last conversation replays into them (see *Sessions*). A boot that fails
+and the last conversation replays (see *Sessions*). A page answered inside that
+window is not behind for it — it carries no conversation to be stale, and the
+stream tells it what the boot said, whichever side of the boot it connected on.
+A boot that fails
 is an `error` frame and a log line, and the next chat message retries it — the
 same path a crashed agent takes, which is likewise replaced on the next message.
 Its stderr is a log sink, drained into the server's own stderr with an `acp:`
@@ -398,7 +401,7 @@ Routes:
 | `GET /` | HTML page (Workflowy-style skin from `olai/web/render.rkt`) |
 | `GET /n/<key>` | one node, zoomed: breadcrumbs (home, the file, each ancestor) plus that subtree and nothing else. `key` as in `tree` JSON. A key the current snapshot has no node for is a page saying so, with a `200` — a node can be deleted while a tab sits zoomed on it, and that tab re-fetches this page to find out |
 | `GET /today` | the first node titled with today's ISO date (the Daily day node), zoomed — the same view as `/n/<key>`, with today's key looked up per request; terse empty state when there is none yet |
-| `GET /events` | `text/event-stream`, never ends. `event: outline` with the store revision as its data whenever a watched file reloaded, plus one at local midnight; `event: chat` with one JSON frame from the agent per line; a `:hb` comment on connect and every 15s after, so a client knows it is subscribed and proxies leave it alone |
+| `GET /events` | `text/event-stream`, never ends. `event: outline` with the store revision as its data whenever a watched file reloaded, plus one at local midnight; `event: chat` with one JSON frame from the agent per line; a `:hb` comment on connect and every 15s after, so a client knows it is subscribed and proxies leave it alone. **A new connection is caught up first**: a `reset`, the conversation's `session` / `model` / `commands` as they stand, and the transcript as the frames that built it (`mark` for a break a live `reset` already cleared). Sent to that connection alone, before anything live, so a page opened while the agent was still waking up — or reloaded, or reconnected — knows exactly what one opened a minute earlier does |
 | `POST /chat` | prompt the agent; form field `text` (empty after trimming is `400`). `204` — what the panel draws comes back over `/events`, so every open tab stays in step. `409` with a terse `text/plain` body while a turn is running, `503` when the agent is gone |
 | `POST /chat/new` | new chat: the agent-side context goes away, `204`, and a `reset` frame clears every panel |
 | `POST /chat/cancel` | cancel the turn in flight, `204` (also while the agent is still booting); the `done` frame (`stopReason` `cancelled`) follows on its own |
@@ -444,10 +447,14 @@ no service worker and no offline mode: the view is live-or-nothing (SSE,
 agent). `static/pwa.js` only keeps `theme-color` in step with the picked theme.
 
 The chat panel (a `>_ agent` button, bottom right; open state remembered in
-`localStorage`) is server-rendered from the bridge's transcript on every page
-load — frames are ephemeral, so a reload or a second tab replays instead of
-missing the conversation — and kept live by `static/chat.js` off the page's one
-SSE connection. Its header names the model when the agent has reported one, and
+`localStorage`) comes out of the server EMPTY and in none of its states. Every
+word in it and every class on it arrives as a frame on the page's one SSE
+connection, `static/chat.js` drawing them — including the conversation that
+happened before the page existed, which `/events` replays down the connection
+as it is made. Nothing about the conversation is server-rendered: a page is
+answered while the agent may still be waking up, so a panel drawn from what was
+known then would be a panel that never finds out.
+Its header names the model when the agent has reported one, and
 the conversation when it has a title. The `chats` button beside `+ new` opens a
 popover over `GET /chat/sessions` — newest first, the current one marked, ↑/↓
 and Enter or a click to load one, Esc to close.
@@ -456,8 +463,8 @@ and a tool's title never are.
 
 Typing `/` in the panel's input — or pressing the `/` button on the input row,
 which shows the whole list — opens a completion popover over the agent's
-slash commands (replayed onto the panel as `data-commands`, kept live by the
-`commands` frame): ↑/↓ move, Enter or Tab accept the highlighted one into the
+slash commands (the whole list, from the `commands` frame — the catch-up's
+included): ↑/↓ move, Enter or Tab accept the highlighted one into the
 input, Esc closes, and Enter with nothing open sends the message as always.
 Accepting only writes `/name ` — sending is what invokes it.
 

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -132,9 +132,12 @@ panel's geometry.
   `@stored-sessions`, `@foreign-sessions` — because stored
   conversations are a fact about the machine, not something a step can
   arrange later (`e2e/support/hooks.js`).
-* `serve` answers requests while the agent is still booting, so a
-  scenario about what the panel comes up KNOWING says `Given the agent
-  has woken up` first (`world.waitForAgent`).
+* `serve` answers requests while the agent is still booting. What the
+  panel comes up knowing is not a page's to say — `/events` catches a
+  connection up as it is made — so `Given the agent has woken up`
+  (`world.waitForAgent`, which reads the stream) is for scenarios about
+  the AGENT: the picker asks it, and there is nothing to ask until it
+  is up.
 * `@skip` is the regression harness for known-broken behaviour: the
   scenario is written and excluded. `CUCUMBER_TAGS=@skip just e2e` runs
   exactly those. `CUCUMBER_RETRY` (CI sets 1) and `CUCUMBER_PARALLEL`

--- a/e2e/features/chat.feature
+++ b/e2e/features/chat.feature
@@ -23,6 +23,21 @@ Feature: the agent panel
     And I reload the page
     Then the chat panel is open
 
+  # The page carries no conversation at all — it comes out of the server empty,
+  # because what it could say about one would be as old as the request (the
+  # agent may still be waking up). So the conversation a reload comes back to
+  # is the one the new connection is caught up with, and nothing else.
+  Scenario: a reload comes back to the conversation
+    When I open the home page
+    And I press the agent toggle
+    And I send "what is in the outline" to the agent
+    Then the last turn reads "hello world"
+    When I reload the page
+    Then the last turn quotes me "what is in the outline"
+    And the last turn reads "hello world"
+    And the last turn ran the tool "read Tasks.rkt"
+    And the chat panel is idle
+
   # Issue #14: the gutter the panel needs was PADDING on .ol-main, and .ol-main
   # is border-box under `max-width: 56rem` — so --chat-w came out of the reading
   # column's own cap instead of out of the free space beside it. The outline

--- a/e2e/features/sessions.feature
+++ b/e2e/features/sessions.feature
@@ -60,16 +60,14 @@ Feature: past conversations, and whose they are
     And I send "what is in the outline" to the agent
     Then the last turn reads "hello world"
 
-  # KNOWN BROKEN: the panel a page opens with is only as current as the agent.
-  # `serve` prints its URL and answers requests while the agent is still waking
-  # up in its own thread, and its boot frames (model, session, commands) are
-  # BROADCAST — a page opened in that window is not listening yet, and the
-  # server-rendered panel it did get was drawn before any of them landed. The
-  # conversation is there; the panel does not say which one until something
-  # else makes it redraw. Every other scenario here waits the boot out
-  # (`the agent has woken up`), which is the harness admitting it.
-  # Same shape as the racket suite's parked boot-frame race (Roadmap.rkt).
-  @skip @stored-sessions
+  # No `Given the agent has woken up`, on purpose. `serve` prints its URL and
+  # answers requests while the agent is still waking up in its own thread, and
+  # its boot frames (session, model, commands) go out to whoever is listening —
+  # which a page opened in that window is not, and the panel it was served says
+  # nothing about the conversation either. So the conversation is not the
+  # page's to tell: the panel comes up empty and the stream catches the
+  # connection up on the way in, whichever side of the boot it lands on.
+  @stored-sessions
   Scenario: a page opened while the agent is still waking up says which chat it is in
     When I open the home page
     And I press the agent toggle

--- a/e2e/steps/chat_steps.js
+++ b/e2e/steps/chat_steps.js
@@ -9,9 +9,10 @@ import { Given, Then, When } from "@cucumber/cucumber";
 
 import { SLOW_PROMPT } from "../support/server.js";
 
-// Before the page is opened, not after: what the panel comes up KNOWING is
-// server-rendered, and a page opened mid-boot misses the frames that would
-// have told it (world.waitForAgent).
+// Before the page is opened, not after: a panel catches up on whatever the
+// agent has already said (that is the stream's job, and the last scenario in
+// features/sessions.feature is about it), but the PICKER asks the agent
+// itself, and there is nothing to ask until it is up (world.waitForAgent).
 Given("the agent has woken up", async function () {
   await this.waitForAgent();
 });

--- a/e2e/support/world.js
+++ b/e2e/support/world.js
@@ -87,23 +87,32 @@ export class OlaiWorld extends World {
    *
    *  `serve` prints its URL and starts answering while the agent is still
    *  waking up in its own thread, so the first second of a server's life is a
-   *  panel that does not know its model, its conversation or its commands yet.
-   *  A page opened in that window never learns: the frames are broadcast to
-   *  whoever is listening, and it was not born yet (see the @skip scenario in
-   *  features/sessions.feature).
+   *  conversation with no name, no model and no commands yet. A page opened in
+   *  that window does not miss them — the stream catches a connection up on
+   *  the way in, which is what features/sessions.feature's last scenario is
+   *  about — but the PICKER is a question for the agent itself, and a scenario
+   *  about what it can offer waits here first.
    *
-   *  The command list is the LAST boot frame — the same signal Roadmap.rkt
-   *  names for the racket suite's version of this race — so the page carrying
-   *  a non-empty one is the agent being all the way up. */
+   *  Asked of the stream, which is where the answer is: a connection is told
+   *  the conversation as it stands, and the command list is the last thing a
+   *  boot has to say about it. Frames are JSON; this parses them. */
   async waitForAgent(timeout = 20_000) {
-    const deadline = Date.now() + timeout;
-    for (;;) {
-      const html = await (await fetch(this.url("/"))).text();
-      if (/data-commands="\[\{/.test(html)) return;
-      if (Date.now() > deadline) {
+    const control = new AbortController();
+    const timer = setTimeout(() => control.abort(), timeout);
+    try {
+      const res = await fetch(this.url("/events"), { signal: control.signal });
+      for await (const frame of sseFrames(res.body)) {
+        if (frame.event === "chat" && JSON.parse(frame.data).type === "commands") return;
+      }
+      throw new Error("the event stream ended before the agent woke up");
+    } catch (e) {
+      if (control.signal.aborted) {
         throw new Error(`the agent was still waking up after ${timeout}ms`);
       }
-      await new Promise((r) => setTimeout(r, 50));
+      throw e;
+    } finally {
+      clearTimeout(timer);
+      control.abort();
     }
   }
 
@@ -142,5 +151,30 @@ export class OlaiWorld extends World {
 
   async marked() {
     return await this.page.evaluate((k) => window[k] === true, MARK);
+  }
+}
+
+// ---- reading a stream -------------------------------------------------------
+
+/** The events on an SSE body, one at a time: `{event, data}`, blank-line
+ *  framed, every `data:` line of a multi-line payload joined back up. The
+ *  heartbeat is a comment, which is framing rather than an event. */
+async function* sseFrames(body) {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for await (const chunk of body) {
+    buffer += decoder.decode(chunk, { stream: true });
+    let end;
+    while ((end = buffer.indexOf("\n\n")) !== -1) {
+      const block = buffer.slice(0, end);
+      buffer = buffer.slice(end + 2);
+      let event = null;
+      const data = [];
+      for (const line of block.split("\n")) {
+        if (line.startsWith("event: ")) event = line.slice(7);
+        else if (line.startsWith("data: ")) data.push(line.slice(6));
+      }
+      if (event !== null) yield { event, data: data.join("\n") };
+    }
   }
 }

--- a/olai/tests/integration/chat.rkt
+++ b/olai/tests/integration/chat.rkt
@@ -70,8 +70,13 @@
          [(equal? (hash-ref (cdr f) 'type #f) type) (reverse (cons f acc))]
          [else (loop (cons f acc) (add1 n))])])))
 
-(define (frame-types fs)
-  (for/list ([f (in-list fs)]) (hash-ref (cdr f) 'type #f)))
+;; What a list of frames SAYS it is, in order. Two spellings because frames
+;; come two ways: named pairs off the broadcast channel, and bare jsexprs off
+;; a stream or a catch-up.
+(define (frame-types fs) (jsexpr-types (map cdr fs)))
+
+(define (jsexpr-types fs)
+  (for/list ([f (in-list fs)]) (hash-ref f 'type #f)))
 
 ;; The frames of one type, in order — an assertion about WHAT a frame said
 ;; rather than about where in the sequence it landed (the sequence has its own
@@ -140,8 +145,10 @@
 ;; The server boots the agent itself now, in the background, so the body runs
 ;; only once that has finished: everything the boot says (the session, the
 ;; model, the commands) is already out, and what a test then asserts on the
-;; stream is the turn it asked for.
-(define (with-server proc)
+;; stream is the turn it asked for. #:booted? #f is the other side of that —
+;; the window in which `serve` answers requests while the agent is still waking
+;; up, which is a test's business only when it is about that window.
+(define (with-server proc #:booted? [booted? #t])
   (define dir (make-temporary-file "sfacp~a" 'directory))
   (define f (build-path dir "Tasks.rkt"))
   (display-to-file outline f #:exists 'truncate)
@@ -157,7 +164,7 @@
   (dynamic-wind
    void
    (λ ()
-     (check-true (wait-booted agent) "the agent never booted")
+     (when booted? (check-true (wait-booted agent) "the agent never booted"))
      (proc bound agent))
    (λ ()
      (stop)
@@ -195,9 +202,18 @@
 
 ;; /events never ends, so this keeps the port. Same shape as
 ;; tests/integration/serve.rkt.
-(define (open-events port)
+;;
+;; A connection is told the conversation on the way in (web/chat's catch-up),
+;; and every test here opens one after the boot — so what a test is ABOUT
+;; starts after that, and this reads it off. #:caught-up-through is the last
+;; frame of the catch-up: the command list is the last thing a booted, empty
+;; conversation has to say, and a server that adopted a stored session ends on
+;; the replayed turn's `done`. #f keeps the whole stream, which is what the
+;; tests about the catch-up itself want.
+(define (open-events port #:caught-up-through [through "commands"])
   (define-values (_status _headers in)
     (http-sendrecv "127.0.0.1" "/events" #:port port #:method #"GET"))
+  (when through (events-through in through))
   in)
 
 ;; Next real event on the stream: -> (cons name data) | #f. Heartbeats are
@@ -751,6 +767,83 @@
        (check-equal? (drain frames) '())
        (check-equal? (chat-transcript ch) '()))))
 
+  ;; ---- catching a connection up --------------------------------------------
+  ;;
+  ;; Frames are ephemeral; a browser is not. What it missed — the whole
+  ;; conversation, however long ago it started — it is told on the way in, in
+  ;; the same frames, and there is no other way it learns any of it.
+
+  (define (caught-up ch)
+    (define subscribed 0)
+    (define fs (chat-catch-up ch (λ () (set! subscribed (add1 subscribed)))))
+    ;; subscribed exactly once, and by the catch-up itself: that is what puts
+    ;; the subscription and the reading of this state under one lock
+    (check-equal? subscribed 1)
+    (for/list ([f (in-list fs)])
+      (check-equal? (car f) acp-event-name)
+      (string->jsexpr (cdr f))))
+
+  (test-case "a new connection is told the conversation: the header, then the turns"
+    (with-events
+     (λ (ch frames)
+       (feed! ch
+              (acp-session "fake-stored-new" "the last conversation")
+              (acp-config-model "fake-model-1" (hash))
+              (acp-commands (list (hash 'name "fake-init" 'description "start something")))
+              (acp-replay-started)
+              (acp-user-said "what did we do")
+              (acp-said "we **shipped** it")
+              (acp-tool "call-replay" "read Roadmap.rkt" "completed")
+              (acp-replay-ended))
+       (drain frames)
+       (define fs (caught-up ch))
+       (check-equal? (jsexpr-types fs)
+                     '("reset" "session" "model" "commands"
+                       "user" "chunk" "tool" "done"))
+       ;; a slate first: whatever this connection had drawn is not this
+       (check-equal? (hash-ref (car fs) 'type) "reset")
+       (check-equal? (hash-ref (list-ref fs 1) 'id) "fake-stored-new")
+       (check-equal? (hash-ref (list-ref fs 1) 'title) "the last conversation")
+       (check-equal? (hash-ref (list-ref fs 2) 'name) "fake-model-1")
+       (check-equal? (hash-ref (list-ref fs 4) 'text) "what did we do")
+       ;; the whole of what was said, as one chunk
+       (check-equal? (hash-ref (list-ref fs 5) 'text) "we **shipped** it")
+       (check-equal? (hash-ref (list-ref fs 6) 'status) "completed")
+       ;; and how it ended, Markdown and all — the same frame a lived turn ends
+       ;; with, so a panel needs to know nothing about any of this
+       (check-equal? (hash-ref (last fs) 'html) (note->html-string "we **shipped** it"))
+       (check-equal? (hash-ref (last fs) 'stopReason) (json-null)))))
+
+  ;; The states a conversation can be caught up in that are not "a finished
+  ;; turn": nothing said yet, a turn still running, and a break behind it.
+  (test-case "a conversation with nothing in it is caught up with a clean slate"
+    (with-events
+     (λ (ch frames)
+       (check-equal? (jsexpr-types (caught-up ch)) '("reset")))))
+
+  (test-case "a running turn is replayed open, and a break is a line across it"
+    (with-agent
+     (λ (ag frames _log)
+       ;; a break the panel draws a line for, and a turn that has said
+       ;; something but has not ended
+       (feed! ag (acp-gone "the agent exited (code 1)"))
+       (chat-prompt! ag "SLOW down and read it all")
+       (frames-through frames "chunk")
+       (define fs (caught-up ag))
+       (check-equal? (jsexpr-types fs)
+                     '("reset" "session" "model" "commands" "mark" "user" "chunk"))
+       ;; what the break was, and what it said. Which WORD goes on the line is
+       ;; the panel's business, so both are handed over.
+       (check-equal? (hash-ref (list-ref fs 4) 'mark) "restart")
+       (check-true (string-contains? (hash-ref (list-ref fs 4) 'message) "exited")
+                   (format "~a" (list-ref fs 4)))
+       ;; the turn ends in NO frame: it has not ended, and a panel caught up
+       ;; with it comes up busy, which is the state the conversation is in
+       (check-equal? (hash-ref (list-ref fs 5) 'text) "SLOW down and read it all")
+       (check-equal? (hash-ref (list-ref fs 6) 'text) "hello ")
+       (chat-cancel! ag)
+       (check-true (wait-idle ag)))))
+
   ;; Two sources for one header (see web/chat): whichever moved last wins, and
   ;; the first live id agrees with the config option by construction.
   (test-case "the live model and the picked one are one header, debounced"
@@ -863,9 +956,9 @@
        ;; 204 means 204: nothing to render, because the stream renders it
        (check-equal? body "" body)
        (define fs (events-through in "done"))
-       ;; the boot frames are not in here: the server booted the agent when it
-       ;; came up, which is before this connection existed
-       (check-equal? (for/list ([f (in-list fs)]) (hash-ref f 'type))
+       ;; the boot frames are not in here: this connection was caught up with
+       ;; them before the POST, and what follows is the turn it asked for
+       (check-equal? (jsexpr-types fs)
                      '("user" "chunk" "chunk" "tool" "tool" "done"))
        (check-equal? (hash-ref (car fs) 'text) "hello there")
        (define done (last fs))
@@ -894,8 +987,7 @@
        ;; Under way, not merely accepted: the `user` frame goes out before the
        ;; subprocess even exists. The first chunk is the agent actually
        ;; talking, which is the state this 409 is about.
-       (check-equal? (for/list ([f (in-list (events-through in "chunk"))])
-                       (hash-ref f 'type))
+       (check-equal? (jsexpr-types (events-through in "chunk"))
                      '("user" "chunk"))
        (define-values (busy body) (POST port "/chat" '((text . "and another"))))
        (check-equal? busy 409 body)
@@ -918,8 +1010,7 @@
        (check-equal? code 204 body)
        ;; the new session says which one it is on the way past; the reset is
        ;; the frame the panels act on
-       (define fs (for/list ([f (in-list (events-through in "reset"))])
-                    (hash-ref f 'type)))
+       (define fs (jsexpr-types (events-through in "reset")))
        (check-equal? (last fs) "reset" (format "~a" fs))
        (check-true (and (member "session" fs) #t) (format "~a" fs))
        (close-input-port in))))
@@ -952,12 +1043,14 @@
         (λ (port agent)
           ;; booted into the newest; move to the other one
           (check-equal? (chat-session-id agent) "fake-stored-new")
-          (define in (open-events port))
+          ;; the conversation this connection was caught up with is the adopted
+          ;; one, so its catch-up ends on that turn's `done`
+          (define in (open-events port #:caught-up-through "done"))
           (define-values (code body) (POST port "/chat/load" '((id . "fake-stored-old"))))
           (check-equal? code 204 body)
           (check-equal? body "" body)
           (define fs (events-through in "session"))
-          (check-equal? (for/list ([f (in-list fs)]) (hash-ref f 'type))
+          (check-equal? (jsexpr-types fs)
                         '("reset" "user" "chunk" "chunk" "tool" "tool" "done" "session"))
           (check-equal? (hash-ref (car fs) 'type) "reset")
           (check-equal? (hash-ref (last fs) 'id) "fake-stored-old")
@@ -973,7 +1066,7 @@
         (λ (port agent)
           (define-values (code body) (POST port "/chat/load" '()))
           (check-equal? code 400 body)
-          (define in (open-events port))
+          (define in (open-events port #:caught-up-through "done"))
           ;; accepted (there is nothing to know yet), and the failure is where
           ;; everything else about the conversation is: on the stream
           (define-values (c2 b2) (POST port "/chat/load" '((id . "nope"))))
@@ -983,10 +1076,15 @@
                       (format "~a" err))
           (close-input-port in))))))
 
-  ;; A browser that reloads (or connects late) missed the frames. The page is
-  ;; where the conversation comes back, and everything the agent or the user
-  ;; wrote is TEXT in it — an xexpr is what escapes it.
-  (test-case "the page replays the transcript, escaped"
+  ;; ---- what a connection is told on the way in -----------------------------
+  ;;
+  ;; A browser that reloads, connects late, or opens a page while the agent is
+  ;; still waking up missed the frames. The STREAM is where the conversation
+  ;; comes back: /events replays it to the connection being made, and the page
+  ;; itself says nothing about it (the panel comes out of the renderer empty,
+  ;; because what it could say would be as old as the request).
+
+  (test-case "a connection is caught up with the conversation, in frames"
     (with-server
      (λ (port agent)
        (define in (open-events port))
@@ -995,21 +1093,56 @@
        (events-through in "done")
        (check-true (wait-idle agent))
        (close-input-port in)
+       ;; a second browser, arriving now: it is told the whole thing
+       (define in2 (open-events port #:caught-up-through #f))
+       (define fs (events-through in2 "done"))
+       ;; one tool frame, not the two the live turn sent: a line is a line, and
+       ;; what a browser is caught up with is its latest state
+       (check-equal? (jsexpr-types fs)
+                     '("reset" "session" "model" "commands"
+                       "user" "chunk" "tool" "done"))
+       ;; the header the boot frames were ephemeral about: said again, to this
+       ;; connection alone
+       (check-equal? (hash-ref (list-ref fs 2) 'name) "fake-model-1")
+       (check-equal? (command-pairs (hash-ref (list-ref fs 3) 'commands))
+                     (command-pairs (chat-commands agent)))
+       ;; the turn, in the frames that built it: the prompt verbatim, the whole
+       ;; of what was said as one chunk, the tool line, and the Markdown the
+       ;; panel swaps in when the turn ends
+       (check-equal? (hash-ref (list-ref fs 4) 'text)
+                     "run <script>alert(1)</script> please")
+       (check-equal? (hash-ref (list-ref fs 5) 'text) "hello world")
+       (check-equal? (hash-ref (list-ref fs 6) 'id) "call-1")
+       (define done (last fs))
+       (check-equal? (hash-ref done 'stopReason) "end_turn")
+       (check-equal? (hash-ref done 'html) (note->html-string "hello world"))
+       (close-input-port in2)
+       ;; and none of it is in the page: what a browser was typed at rides as
+       ;; JSON on the stream, so there is nothing to escape into the markup
        (define-values (code body) (GET port "/"))
        (check-equal? code 200)
-       (check-true (string-contains? body "&lt;script&gt;alert(1)&lt;/script&gt;") body)
-       (check-false (string-contains? body "<script>alert(1)") body)
-       ;; the agent's finished text is Markdown; the tool line is one line
-       (check-true (string-contains? body "<p>hello world</p>") body)
-       (check-true (string-contains? body "data-tool-id=\"call-1\"") body)
-       (check-true (string-contains? body "data-status=\"completed\"") body)
-       ;; the header is replayed too: the model frame was ephemeral, the model
-       ;; the bridge learned from it is not
-       (check-true (string-contains? body "id=\"ol-chat-model\">fake-model-1<") body)
-       ;; and so are the commands, so a reloaded panel completes without
-       ;; waiting for the agent to say anything again
-       (check-true (string-contains? body "fake-init") body)
-       (check-true (string-contains? body "fake-review") body))))
+       (check-false (string-contains? body "alert(1)") body)
+       (check-false (string-contains? body "fake-model-1") body)
+       (check-false (string-contains? body "fake-init") body))))
+
+  ;; The window this is all about: `serve` prints its URL and answers requests
+  ;; while the agent is still waking up in its own thread. A browser born in it
+  ;; used to miss every frame the boot broadcast — the conversation was there
+  ;; and the panel could not say which one it was in until something else made
+  ;; it redraw. It cannot miss them now, whichever side of the boot it lands
+  ;; on: earlier, and the frames arrive live; later, and the catch-up carries
+  ;; them.
+  (test-case "a connection made while the agent is waking up still learns the conversation"
+    (with-stored-sessions
+     (λ ()
+       (with-server
+        #:booted? #f
+        (λ (port _agent)
+          (define in (open-events port #:caught-up-through #f))
+          (define session (last (events-through in "session")))
+          (check-equal? (hash-ref session 'id) "fake-stored-new")
+          (check-equal? (hash-ref session 'title) "the last conversation")
+          (close-input-port in))))))
 
   (test-case "the page carries the panel, its script, and ONE sse connection"
     (with-server
@@ -1021,9 +1154,6 @@
        (check-true (string-contains? body "action=\"/chat\"") body)
        (check-true (string-contains? body "data-post=\"/chat/new\"") body)
        (check-true (string-contains? body "data-post=\"/chat/cancel\"") body)
-       ;; the server booted the agent when it came up, so the panel is drawn
-       ;; knowing what it offers — no turn has been taken to learn it
-       (check-true (string-contains? body "fake-init") body)
        ;; and the picker's button, with the routes it drives
        (check-true (string-contains? body "data-chat-sessions=\"/chat/sessions\"") body)
        (check-true (string-contains? body "data-chat-load=\"/chat/load\"") body)

--- a/olai/tests/render.rkt
+++ b/olai/tests/render.rkt
@@ -539,46 +539,23 @@
 
   ;; ---- chat panel ----------------------------------------------------------
   ;;
-  ;; The panel is rendered from the bridge's transcript (jsexprs; see
-  ;; tests/integration/acp.rkt for the real ones). Hand-built here so the
-  ;; drawing is the only thing under test.
+  ;; The panel is CHROME: the dock, the header, an empty conversation and the
+  ;; input row. Nothing about the conversation is drawn here — a page is served
+  ;; while the agent may still be waking up, so anything it said about one
+  ;; would be as old as the request. What a panel shows is the stream's, which
+  ;; catches a connection up the moment it exists (web/chat's chat-catch-up;
+  ;; tests/integration/chat.rkt is where that is asserted).
 
-  (define (turn text agent
-                #:tools [tools '()] #:status [status "done"]
-                #:stop [stop "end_turn"] #:error [err (json-null)])
-    (hash 'type "turn" 'text text 'agent agent 'tools tools
-          'status status 'stopReason stop 'error err))
-
-  (define (panel transcript #:model [model #f] #:commands [commands '()]
-                 #:session-title [session-title #f] #:busy? [busy? #f])
-    (xstr (render-chat-panel transcript
-                             #:busy? busy?
-                             #:send-href "/chat"
+  (define (panel)
+    (xstr (render-chat-panel #:send-href "/chat"
                              #:new-href "/chat/new"
                              #:cancel-href "/chat/cancel"
                              #:sessions-href "/chat/sessions"
                              #:load-href "/chat/load"
-                             #:event "chat"
-                             #:model model
-                             #:session-title session-title
-                             #:commands commands)))
+                             #:event "chat")))
 
-  ;; The commands ride in an attribute as JSON, which means two escapings meet
-  ;; there. Reading it back the way a browser does is the only assertion that
-  ;; says the round trip works.
-  (define (unescape s)
-    (for/fold ([s s]) ([pair (in-list '(("&quot;" "\"") ("&lt;" "<") ("&gt;" ">")
-                                        ;; last: an escaped ampersand is what
-                                        ;; the others are made of
-                                        ("&amp;" "&")))])
-      (string-replace s (car pair) (cadr pair))))
-
-  (define (panel-commands s)
-    (define m (regexp-match #rx"data-commands=\"([^\"]*)\"" s))
-    (and m (string->jsexpr (unescape (cadr m)))))
-
-  (test-case "an empty panel is a form, a sink and the routes it was told"
-    (define s (panel '()))
+  (test-case "the panel is a form, a sink and the routes it was told"
+    (define s (panel))
     (check-true (string-contains? s "id=\"ol-chat\"") s)
     (check-true (string-contains? s "action=\"/chat\"") s)
     (check-true (string-contains? s "data-post=\"/chat/new\"") s)
@@ -589,118 +566,40 @@
     ;; an open panel covers the floating toggle, so the header carries a way
     ;; out of its own — two buttons, one toggle path
     (check-equal? (length (regexp-match* #rx"data-chat-toggle" s)) 2 s)
-    ;; idle: the input is live and there is nothing to stop
+    ;; the picker's button, with the routes it drives
+    (check-true (string-contains? s "data-chat-sessions=\"/chat/sessions\"") s)
+    (check-true (string-contains? s "data-chat-load=\"/chat/load\"") s)
+    ;; the commands button is drawn once and shown by a class, so a `commands`
+    ;; frame is all it takes to put it there
+    (check-true (string-contains? s "data-chat-commands") s))
+
+  ;; Every state the panel has is a class, and it comes out of the renderer in
+  ;; none of them: a page drawn while the agent was still waking up would be
+  ;; claiming something it cannot know.
+  (test-case "the panel is drawn in none of its states, and carries no conversation"
+    (define s (panel))
     (check-false (string-contains? s "is-busy") s)
-    (check-false (string-contains? s "disabled") s))
+    (check-false (string-contains? s "is-open") s)
+    (check-false (string-contains? s "has-commands") s)
+    (check-false (string-contains? s "disabled") s)
+    ;; nothing of the conversation: no turns, and no copy of the command list
+    (check-false (string-contains? s "ol-chat-turn") s)
+    (check-false (string-contains? s "data-commands") s)
+    (check-true (string-contains? s "<div class=\"ol-chat-body\" id=\"ol-chat-body\"></div>") s))
 
-  (test-case "a finished turn replays: user text verbatim, agent text Markdown"
-    (define s (panel (list (turn "do **not** bold me" "and **this** is bold"
-                                 #:tools (list (hash 'id "call-1"
-                                                     'title "read Tasks.rkt"
-                                                     'status "completed"))))))
-    ;; what the user typed is a string, not a document
-    (check-true (string-contains? s "do **not** bold me") s)
-    ;; what the agent said gets the same treatment a note gets
-    (check-true (string-contains? s "<strong>this</strong>") s)
-    (check-true (string-contains? s "data-tool-id=\"call-1\"") s)
-    (check-true (string-contains? s "data-status=\"completed\"") s)
-    (check-true (string-contains? s "✓") s)
-    ;; end_turn is the ordinary ending: it says nothing
-    (check-false (string-contains? s "ol-chat-note") s))
-
-  (test-case "a running turn comes up busy, with its text still verbatim"
-    (define s (panel (list (turn "go" "half a **sent"
-                                 #:status "running" #:stop (json-null)))
-                     #:busy? #t))
-    (check-true (string-contains? s "ol-chat is-busy") s)
-    ;; an open panel hides the toggle that breathes, so the header carries the
-    ;; working dot — drawn either way, and shown by that is-busy class
-    (check-true (string-contains? s "ol-chat-working") s)
-    (check-true (string-contains? (panel '()) "ol-chat-working") s)
-    (check-true (string-contains? s "disabled=\"disabled\"") s)
-    ;; mid-stream text is a fragment; Markdown waits for the done frame
-    (check-true (string-contains? s "half a **sent") s)
-    (check-false (string-contains? s "<strong") s))
-
-  (test-case "a failed turn keeps its error, and an odd ending says which"
-    (define s (panel (list (turn "go" "" #:status "error" #:stop (json-null)
-                                 #:error "the agent exited (code 1)")
-                           (turn "again" "" #:stop "cancelled"))))
-    (check-true (string-contains? s "the agent exited (code 1)") s)
-    (check-true (string-contains? s "ol-chat-msg is-error") s)
-    (check-true (string-contains? s "cancelled") s))
-
-  (test-case "markers draw a break in the conversation, not a turn"
-    (define s (panel (list (hash 'type "reset" 'message (json-null))
-                           (hash 'type "restart" 'message "the agent exited"))))
-    (check-true (string-contains? s "ol-chat-sep") s)
-    (check-true (string-contains? s "new chat") s)
-    (check-true (string-contains? s "the agent exited") s)
-    (check-false (string-contains? s "ol-chat-turn") s))
-
-  ;; User text and tool titles are never Markdown and never HTML. The xexpr
-  ;; is what guarantees it, so this is the test that says so.
-  (test-case "script payloads land as text, in messages and tool titles alike"
-    (define s (panel (list (turn "<script>alert(1)</script>" "<b>no</b>"
-                                 #:tools (list (hash 'id "c<1"
-                                                     'title "rm -rf <script>"
-                                                     'status "failed"))))))
-    (check-false (string-contains? s "<script>") s)
-    (check-true (string-contains? s "&lt;script&gt;alert(1)&lt;/script&gt;") s)
-    ;; the agent's Markdown is sanitized by the markdown module, raw HTML and all
-    (check-false (regexp-match? #rx"<b[ >]" s) s)
-    (check-true (string-contains? s "data-tool-id=\"c&lt;1\"") s)
-    (check-true (string-contains? s "✗") s))
-
-  ;; The model is the agent's word, replayed. Unknown is not "unknown": the
-  ;; span is there for a `model` frame to fill, and empty until one lands.
-  (test-case "the header names the model when there is one, and omits it when not"
-    (define named (panel '() #:model "fake-model-1"))
-    (check-true (string-contains? named "agent · claude code") named)
-    (check-true (string-contains? named
-                                  "<span class=\"ol-chat-model\" id=\"ol-chat-model\">fake-model-1</span>")
-                named)
-    (define bare (panel '()))
-    (check-true (string-contains? bare "id=\"ol-chat-model\"") bare)
-    (check-false (string-contains? bare "fake-model") bare)
-    (check-false (string-contains? bare "unknown") bare))
-
-  ;; Which conversation, same discipline as the model: the agent's word for it,
-  ;; replayed, and an empty span waiting for a `session` frame when there is
-  ;; none. The picker's button carries the routes it drives.
-  (test-case "the header names the conversation when it has one, and offers the others"
-    (define named (panel '() #:session-title "the last conversation"))
+  ;; The header's two live strings are empty spans waiting for the frames that
+  ;; name them. Unknown is not "unknown": an empty one the sheet takes away.
+  (test-case "the header has a slot for the model and one for the conversation"
+    (define s (panel))
+    (check-true (string-contains? s "agent · claude code") s)
     (check-true (string-contains?
-                 named
-                 "<span class=\"ol-chat-session\" id=\"ol-chat-session\">the last conversation</span>")
-                named)
-    (check-true (string-contains? named "data-chat-sessions=\"/chat/sessions\"") named)
-    (check-true (string-contains? named "data-chat-load=\"/chat/load\"") named)
-    (define bare (panel '()))
-    (check-true (string-contains? bare "id=\"ol-chat-session\"") bare)
-    (check-false (string-contains? bare "conversation") bare))
-
-  ;; The agent's slash commands, replayed so a reloaded page completes before
-  ;; the agent says anything. An empty list is an empty list, not a missing
-  ;; attribute: chat.js parses one thing.
-  (test-case "the panel carries the commands the agent offers, JSON in an attribute"
-    (define offered (list (hash 'name "fake-init" 'description "start something")
-                          (hash 'name "quote\"me" 'description "<b>not html</b>")))
-    (define s (panel '() #:commands offered))
-    ;; read back the way a browser reads it: unescape the attribute, parse the
-    ;; JSON (which is read-json's hasheq, not the hash that went in)
-    (check-equal? (panel-commands s)
-                  (list (hasheq 'name "fake-init" 'description "start something")
-                        (hasheq 'name "quote\"me" 'description "<b>not html</b>")))
-    ;; the attribute is escaped, so nothing in it can end the tag
-    (check-false (string-contains? s "<b>not html</b>") s)
-    ;; a list to show is what puts the commands button on the input row
-    (check-true (string-contains? s "ol-chat has-commands") s)
-    (check-true (string-contains? s "data-chat-commands") s)
-    (define bare (panel '()))
-    (check-equal? (panel-commands bare) '())
-    (check-true (string-contains? bare "data-commands=\"[]\"") bare)
-    (check-false (string-contains? bare "has-commands") bare))
+                 s "<span class=\"ol-chat-model\" id=\"ol-chat-model\"></span>") s)
+    (check-true (string-contains?
+                 s "<span class=\"ol-chat-session\" id=\"ol-chat-session\"></span>") s)
+    ;; an open panel hides the toggle that breathes, so the header carries the
+    ;; working dot — drawn either way, and shown by is-busy
+    (check-true (string-contains? s "ol-chat-working") s)
+    (check-false (string-contains? s "unknown") s))
 
   (test-case "the chat script stays tiny, framework-free and connection-free"
     (define js (file->string (build-path (web-static-dir) "chat.js")))

--- a/olai/tests/style.rkt
+++ b/olai/tests/style.rkt
@@ -22,7 +22,6 @@
 ;; tests read. Instantiation order is the cascade; that is the contract.
 
 (require rackunit
-         json
          racket/file
          racket/list
          racket/runtime-path
@@ -133,7 +132,7 @@
 
 ;; The pages the renderers can draw, from the demo outlines: the outline pane
 ;; with a sidebar and a banner, a zoom, an empty pane, a mirror site that names
-;; nothing, and the chat panel mid-turn. Between them they draw every state the
+;; nothing, and the chat panel's chrome. Between them they draw every state the
 ;; skin paints — which is what makes "nothing wears this class" mean something.
 (define example-today "2026-08-03")
 
@@ -168,18 +167,15 @@
                            #:children (list (mirror-ref "no-such-anchor" #f))))
           (hash)))
     #:today example-today)
+   ;; Markdown at render time: the anchor and the code a note (or a finished
+   ;; turn) makes are the classes the demo outlines never happen to contain.
+   (note->xexprs "see [the manual](https://example.com), `inline`\n\n```\nblock\n```\n")
+   ;; The panel is chrome: what a conversation looks like is chat.js's markup,
+   ;; and the classes it spells are read off the script (scripted-classes).
    (render-chat-panel
-    (list (hash 'type "turn"
-                'text "run it"
-                'agent "a **note**, `code`, [a link](https://example.com)\n\n```\nblock\n```\n"
-                'tools (list (hash 'id "call-1" 'title "read Tasks.rkt" 'status "completed"))
-                'status "done" 'stopReason "cancelled" 'error "the agent exited (code 1)")
-          (hash 'type "reset" 'message (json-null)))
-    #:busy? #t
     #:send-href "/chat" #:new-href "/chat/new" #:cancel-href "/chat/cancel"
     #:sessions-href "/chat/sessions" #:load-href "/chat/load"
-    #:event "chat" #:model "fake-model-1" #:session-title "the last conversation"
-    #:commands (list (hash 'name "fake-init" 'description "start something")))))
+    #:event "chat")))
 
 (define rendered-classes
   (for/fold ([acc (set)]) ([page (in-list (example-pages))])

--- a/olai/web/chat-panel.rkt
+++ b/olai/web/chat-panel.rkt
@@ -1,29 +1,25 @@
 #lang racket/base
 
-;; The agent panel, drawn: the dock, the conversation, the input row, and
-;; every rule that paints them.
+;; The agent panel, drawn: the dock, the header, the room the conversation
+;; goes in, the input row, and every rule that paints them.
 ;;
-;; PRESENTATION ONLY. What a turn IS, what a frame means, whether the agent is
-;; busy — that is web/chat.rkt over olai/acp. It is handed a transcript (plain
-;; JSON hashes), that busy flag, and a handful of URLs, and it gives back an
-;; xexpr. The route layer is what puts the two together. The one thing it takes
+;; PRESENTATION ONLY, and CHROME only. What a turn IS, what a frame means,
+;; whether the agent is busy — that is web/chat.rkt over olai/acp. This module
+;; is handed a handful of URLs and gives back an xexpr. The one thing it takes
 ;; from web/chat is the WORDS: a status is that module's vocabulary, and a
 ;; selector that spelled one by hand would be a second owner of it.
 ;;
-;; The panel is replayed from that transcript on every page load (frames are
-;; ephemeral: a browser that connects late, or reloads, missed them). From
-;; there static/chat.js keeps it live off the page's ONE SSE connection, and
-;; several classes below exist only for that script to build — style with no
-;; markup on this side, which is exactly why they are still defined here.
+;; Nothing about the conversation is drawn here. A page is served while the
+;; agent may still be waking up, so anything this rendered about the
+;; conversation would be as old as the request; what a panel shows arrives on
+;; the page's ONE SSE connection, which web/chat catches up the moment it
+;; exists (`chat-catch-up`) and keeps live from there. So the dock, the header,
+;; the empty conversation and the input row are markup, and every class inside
+;; the conversation is style with no markup on this side — static/chat.js
+;; builds them, which is exactly why they are still defined here.
 ;;
 ;; The URLs are the route layer's, and so is the SSE event name — a renderer
 ;; that spelled "chat" here would be a second owner of the wire format.
-;;
-;; What is Markdown and what is not: a FINISHED turn's agent text gets the
-;; same treatment a note gets. A running or failed turn's text is a fragment,
-;; so it stays verbatim (chat.js accumulates chunks as text and swaps in the
-;; server's HTML when the `done` frame lands). User text and tool titles are
-;; never Markdown — they are strings in an xexpr, which is what escapes them.
 ;;
 ;; The panel is an overlay on the outline, so its rules land after the
 ;; outline's: the require below is what puts them there, and the one rule whose
@@ -31,7 +27,6 @@
 ;; style.rkt on ordering).
 
 (require racket/contract
-         (only-in json jsexpr->string)
          olai/web/style
          ;; the skin's tokens and constants, and the page's own class — the
          ;; panel is positioned against the document
@@ -39,29 +34,21 @@
          ;; the words a transcript is written in: what a status MEANS is
          ;; web/chat's, and a selector here spells the same binding
          (only-in olai/web/chat
-                  turn-done tool-pending tool-in-progress tool-completed
-                  tool-failed stop-end-turn)
-         ;; the pane the panel makes room in, and the note renderer a finished
-         ;; turn is run through
-         (only-in olai/web/render ol-main note->xexprs))
+                  tool-pending tool-in-progress tool-completed tool-failed)
+         ;; the pane the panel makes room in
+         (only-in olai/web/render ol-main))
 
 (provide (contract-out
           [render-chat-panel
-           (->* ((listof hash?)
-                 #:busy? boolean?
-                 #:send-href string? #:new-href string? #:cancel-href string?
-                 #:sessions-href string? #:load-href string?
-                 #:event string?)
-                (#:model (or/c string? #f)
-                 #:session-title (or/c string? #f)
-                 #:commands (listof hash?))
-                list?)]))
+           (-> #:send-href string? #:new-href string? #:cancel-href string?
+               #:sessions-href string? #:load-href string?
+               #:event string?
+               list?)]))
 
 ;; ---- states ---------------------------------------------------------------
 ;;
-;; The panel's states. chat.js toggles all of them; the server sets is-busy
-;; and has-commands on the first draw so a reloaded page comes up in the state
-;; the conversation is actually in.
+;; The panel's states. chat.js owns every one of them: the panel is drawn in
+;; none of them and put into the ones the stream says it is in.
 
 (define-modifier is-open is-busy has-commands is-picked
                  is-user is-agent is-error)
@@ -420,106 +407,34 @@
 
 ;; ---- the markup -----------------------------------------------------------
 
-(define tool-glyphs (hash tool-completed "✓" tool-failed "✗"))
-
-(define (chat-tool-xexpr t)
-  (define status (chat-string t 'status tool-pending))
-  `(div ((class ,ol-chat-tool)
-         (data-tool-id ,(chat-string t 'id ""))
-         (data-status ,status))
-        (span ((class ,ol-chat-tool-glyph)) ,(hash-ref tool-glyphs status "⚙"))
-        (span ((class ,ol-chat-tool-title)) ,(chat-string t 'title ""))))
-
-;; A transcript field is JSON: a missing one and an explicit null are the
-;; same nothing, and neither may reach xexpr->string.
-(define (chat-string h k [default #f])
-  (define v (hash-ref h k #f))
-  (if (string? v) v default))
-
-(define (chat-turn-xexpr e)
-  (define status (chat-string e 'status turn-done))
-  (define text (chat-string e 'agent ""))
-  (define stop (chat-string e 'stopReason))
-  (define err (chat-string e 'error))
-  `(div ((class ,ol-chat-turn))
-        (div ((class ,(classes ol-chat-msg is-user))) ,(chat-string e 'text ""))
-        (div ((class ,(classes ol-chat-msg is-agent)))
-             ,@(if (equal? status turn-done)
-                   (note->xexprs text)
-                   (list text)))
-        ,@(for/list ([t (in-list (hash-ref e 'tools '()))]
-                     #:when (hash? t))
-            (chat-tool-xexpr t))
-        ,@(if err
-              (list `(div ((class ,(classes ol-chat-msg is-error))) ,err))
-              '())
-        ,@(if (and stop (not (equal? stop stop-end-turn)))
-              (list `(div ((class ,ol-chat-note)) ,stop))
-              '())))
-
-;; Not a turn: the conversation moved. A live `reset` clears the panel; a
-;; replayed one is a line across it, because the turns above it happened.
-(define (chat-marker-xexpr e)
-  (define type (chat-string e 'type ""))
-  `(div ((class ,ol-chat-sep))
-        ,(or (chat-string e 'message) (if (equal? type "reset") "new chat" type))))
-
-(define (chat-entry-xexpr e)
-  (if (equal? (chat-string e 'type "") "turn")
-      (chat-turn-xexpr e)
-      (chat-marker-xexpr e)))
-
-(define (render-chat-panel transcript
-                           ;; A turn was still running when this page was
-                           ;; rendered: the panel comes up in that state (input
-                           ;; disabled, stop showing) rather than idle. Whether
-                           ;; it is running is the conversation's to say — a
-                           ;; transcript read for it would be a second answer
-                           ;; to a question web/chat already has one for.
-                           #:busy? busy?
-                           #:send-href send-href
+(define (render-chat-panel #:send-href send-href
                            #:new-href new-href
                            #:cancel-href cancel-href
                            #:sessions-href sessions-href
                            #:load-href load-href
-                           #:event event
-                           #:model [model #f]
-                           #:session-title [session-title #f]
-                           #:commands [commands '()])
+                           #:event event)
   `(div ((class ,ol-chat-dock))
         (button ((type "button") (class ,ol-chat-open) (data-chat-toggle "")
                  (aria-label "open the agent panel"))
                 ">_ agent")
-        ;; The agent's slash commands, replayed onto the panel: chat.js reads
-        ;; them at init so a reloaded page completes immediately, and a
-        ;; `commands` frame replaces them from there. JSON in an attribute —
-        ;; the xexpr layer is what escapes it, same as any other string here.
-        (aside ((class ,(classes ol-chat (and busy? is-busy)
-                                 ;; nothing to offer, nothing to press: the
-                                 ;; commands button is one class away, so a
-                                 ;; `commands` frame can bring it back
-                                 (and (pair? commands) has-commands)))
-                (id "ol-chat")
-                (data-commands ,(jsexpr->string commands)))
+        ;; In none of its states: closed, idle, and with nothing to offer. Each
+        ;; of them is one class away, and the frames this connection is caught
+        ;; up with are what put it in the right ones.
+        (aside ((class ,ol-chat) (id "ol-chat"))
                (div ((class ,ol-chat-head))
-                    ;; Which model, when the bridge has heard one — never a
-                    ;; placeholder. Its own span, and the separator is the
-                    ;; span's, so a `model` frame sets one string.
+                    ;; Which model — never a placeholder: an empty span for a
+                    ;; `model` frame to fill, and the separator is the span's
+                    ;; own, so filling it is setting one string.
                     (span ((class ,ol-chat-title)) "agent · claude code"
-                          (span ((class ,ol-chat-model) (id "ol-chat-model"))
-                                ,(or model ""))
+                          (span ((class ,ol-chat-model) (id "ol-chat-model")))
                           ;; A running turn is visible on the floating toggle,
                           ;; which an OPEN panel hides — so the header carries
-                          ;; the same signal. Always drawn, shown by is-busy,
-                          ;; which the server sets for a turn in flight and
-                          ;; chat.js moves from there.
+                          ;; the same signal. Always drawn, shown by is-busy.
                           (span ((class ,ol-chat-working) (title "working")))
-                          ;; Which conversation, when it has a name. Same
-                          ;; pattern as the model, one line down: a `session`
-                          ;; frame sets one string, and an empty one takes the
-                          ;; line away with it.
-                          (span ((class ,ol-chat-session) (id "ol-chat-session"))
-                                ,(or session-title "")))
+                          ;; Which conversation. Same pattern as the model, one
+                          ;; line down: a `session` frame sets one string, and
+                          ;; an empty one takes the line away with it.
+                          (span ((class ,ol-chat-session) (id "ol-chat-session"))))
                     (div ((class ,ol-chat-actions))
                          ;; The conversations the agent has stored for this
                          ;; directory. The popover it opens is drawn by
@@ -547,8 +462,9 @@
                ;; connection, two consumers.
                (div ((class ,ol-chat-sink) (id "ol-chat-sink")
                      (sse-swap ,event) (hidden "hidden")))
-               (div ((class ,ol-chat-body) (id "ol-chat-body"))
-                    ,@(for/list ([e (in-list transcript)]) (chat-entry-xexpr e)))
+               ;; Empty, always: the conversation is what the stream says it
+               ;; is, from the frames it catches this connection up with.
+               (div ((class ,ol-chat-body) (id "ol-chat-body")))
                (form ((class ,ol-chat-form) (id "ol-chat-form")
                       (action ,send-href) (method "post"))
                      ;; The same popover a typed "/" opens, unfiltered: the
@@ -558,8 +474,7 @@
                               (aria-label "show the agent's commands"))
                              "/")
                      (input ((class ,ol-chat-input) (name "text") (type "text")
-                             (autocomplete "off") (placeholder "message the agent")
-                             ,@(if busy? '((disabled "disabled")) '())))
+                             (autocomplete "off") (placeholder "message the agent")))
                      (button ((type "submit") (class ,ol-chat-send)) "send")
                      (button ((type "button") (class ,ol-chat-stop)
                               (data-post ,cancel-href))

--- a/olai/web/chat.rkt
+++ b/olai/web/chat.rkt
@@ -16,7 +16,7 @@
 ;;     ops use (the CLI maps kinds to exit codes, a route maps them to statuses).
 ;;   * the transcript. Frames are ephemeral — a browser that connects late
 ;;     missed them — so a turn is also accumulated here, and that is what a
-;;     page load replays.
+;;     connection is caught up with (`chat-catch-up`).
 ;;   * what a header SAYS: which model, which slash commands, which
 ;;     conversation. Each of those is learned from the agent and pushed only
 ;;     when it actually moved, so a session that re-announces the same model on
@@ -37,6 +37,7 @@
 
 (require json
          racket/contract
+         racket/list
          olai/acp
          (only-in olai/ops exn:fail:op)
          ;; render-time Markdown has one owner; this module only asks it for
@@ -49,14 +50,10 @@
 (provide (contract-out
           [acp-event-name string?]
           ;; the words a transcript is written in (see "the vocabulary")
-          [turn-running string?]
-          [turn-done string?]
-          [turn-error string?]
           [tool-pending string?]
           [tool-in-progress string?]
           [tool-completed string?]
           [tool-failed string?]
-          [stop-end-turn string?]
           [make-chat (->* (#:command (or/c path? string?)
                            #:cwd (or/c path? string?)
                            #:broadcast (-> string? string? any))
@@ -76,6 +73,7 @@
           [chat-session-id (-> chat? (or/c string? #f))]
           [chat-session-title (-> chat? (or/c string? #f))]
           [chat-transcript (-> chat? (listof hash?))]
+          [chat-catch-up (-> chat? (-> any) (listof (cons/c string? string?)))]
           [chat-handle-event! (-> chat? acp-event? void?)]))
 
 ;; The SSE event name chat frames ride under. One owner: the page that
@@ -88,27 +86,18 @@
 
 ;; ---- the vocabulary ---------------------------------------------------------
 ;;
-;; The words a transcript is written in. What a turn's status IS, and what a
-;; tool call's means, is this module's business — so the panel that draws one
-;; and the selector that reacts to it spell a binding, not a string that
-;; happens to match. Append-only, like the frames themselves.
+;; The words a transcript is written in. What a tool call's status MEANS is
+;; this module's business — so the panel that draws one and the selector that
+;; reacts to it spell a binding, not a string that happens to match. The tool
+;; statuses are the agent's, passed through olai/acp unchanged.
 ;;
-;; A turn's status is a symbol in the struct below and these on the wire
-;; (symbol->string of the same word). The tool statuses are the agent's, passed
-;; through olai/acp unchanged.
-
-(define turn-running "running")
-(define turn-done "done")
-(define turn-error "error")
+;; A turn's status is a symbol in the struct below, and `symbol->string` of the
+;; same word on the wire.
 
 (define tool-pending "pending")
 (define tool-in-progress "in_progress")
 (define tool-completed "completed")
 (define tool-failed "failed")
-
-;; how a turn ends when nothing happened to it. Any other ending is worth
-;; saying out loud.
-(define stop-end-turn "end_turn")
 
 ;; ---- what a transcript remembers -------------------------------------------
 
@@ -119,9 +108,14 @@
 ;; `sent?` is whether the prompt is on the wire yet. A turn is accepted long
 ;; before that (the subprocess may not even exist), and a cancel that arrives in
 ;; between has nothing the agent could match it against.
+;;
+;; `html` is what the finished text came out as, rendered once when the turn
+;; ended — every connection told about that turn afterwards is owed the same
+;; frame, and Markdown is not a thing to render twice. #f until it ends; the
+;; transcript and the JSON keep the text verbatim, as they do everywhere else.
 (struct turn (text [agent #:mutable] [tools #:mutable]
                    [status #:mutable] [stop #:mutable] [err #:mutable]
-                   [sent? #:mutable]))
+                   [sent? #:mutable] [html #:mutable]))
 
 (struct tool (id [title #:mutable] [status #:mutable]))
 
@@ -203,6 +197,13 @@
 ;;                                            plain text the chunks built
 ;;   {"type":"error","message"}               the turn ended badly
 ;;   {"type":"reset"}                         new chat: panels clear
+;;   {"type":"mark","mark","message"}         a break that already happened,
+;;                                            replayed: the turns above it are
+;;                                            still there, so it is a line
+;;                                            across the conversation rather
+;;                                            than the clearing a live `reset`
+;;                                            is. `message` is null when the
+;;                                            break speaks for itself
 ;;   {"type":"model","name"}                  which model the session runs,
 ;;                                            the moment the agent says so —
 ;;                                            with the session, and again
@@ -221,6 +222,44 @@
 ;;                                            until the agent has one — it
 ;;                                            writes one for you, a turn or so
 ;;                                            in
+;;
+;; One constructor each, below, and every one of them has two callers: the
+;; thing happening, and a connection being caught up on it after the fact. A
+;; frame that grew a key on one of those paths and not the other would be two
+;; browsers in different conversations, depending on when they arrived.
+
+(define (reset-jsexpr) (hash 'type "reset"))
+
+(define (mark-jsexpr type message)
+  (hash 'type "mark" 'mark type 'message (or message (json-null))))
+
+(define (user-jsexpr text) (hash 'type "user" 'text text))
+
+(define (chunk-jsexpr text) (hash 'type "chunk" 'text text))
+
+(define (tool-jsexpr id title status)
+  (hash 'type "tool" 'id id 'title title 'status status))
+
+(define (error-jsexpr message) (hash 'type "error" 'message message))
+
+(define (model-jsexpr name) (hash 'type "model" 'name name))
+
+(define (commands-jsexpr commands) (hash 'type "commands" 'commands commands))
+
+;; Append-only, like every other frame: a title the agent has not written yet
+;; is null, never a placeholder.
+(define (session-jsexpr sid title)
+  (hash 'type "session" 'id (or sid (json-null)) 'title (or title (json-null))))
+
+;; How a turn ended. The Markdown is rendered the first time this is asked for
+;; — which is when the turn ends — and kept, because every connection told
+;; about the turn afterwards is owed the same frame. Callers hold `sema`.
+(define (done-jsexpr tn)
+  (unless (turn-html tn)
+    (set-turn-html! tn (note->html-string (turn-agent tn))))
+  (hash 'type "done"
+        'stopReason (or (turn-stop tn) (json-null))
+        'html (turn-html tn)))
 
 (define (broadcast! ch js)
   (with-handlers ([exn:fail? (λ (e) (log! ch (format "broadcast failed: ~a" (exn-message e))))])
@@ -236,7 +275,7 @@
 ;; Something went wrong outside a turn (a boot, a load): the panel is where it
 ;; is said, because there is no request left to answer.
 (define (error-frame! ch message)
-  (with-state ch (λ () (broadcast! ch (hash 'type "error" 'message message)))))
+  (with-state ch (λ () (broadcast! ch (error-jsexpr message)))))
 
 ;; ---- transcript ------------------------------------------------------------
 
@@ -259,13 +298,86 @@
 ;; A consistent copy, safe to read while a turn is streaming: the structs stay
 ;; behind the lock and what leaves is plain JSON values.
 (define (chat-transcript ch)
-  (with-state ch
-    (λ ()
-      (for/list ([e (in-list (reverse (conversation-entries ch)))])
-        (if (turn? e) (turn->jsexpr e) (marker->jsexpr e))))))
+  (with-state ch (λ () (transcript-jsexprs ch))))
+
+;; Callers hold `sema`.
+(define (transcript-jsexprs ch)
+  (for/list ([e (in-list (reverse (conversation-entries ch)))])
+    (if (turn? e) (turn->jsexpr e) (marker->jsexpr e))))
 
 (define (chat-busy? ch)
   (with-state ch (λ () (and (conversation-busy? ch) #t))))
+
+;; ---- catching up -------------------------------------------------------------
+;;
+;; A browser is born mid-conversation. It opens a page while the agent is still
+;; waking up, it reloads, its EventSource drops and comes back — and every
+;; frame it was not there for is gone, because frames are ephemeral and this is
+;; the only thing that remembers.
+;;
+;; So a connection is told the conversation on the way in, as the frames that
+;; built it, to that connection alone. This is the ONE path: the page renders
+;; the panel's chrome and nothing about the conversation, because a panel drawn
+;; from state read at render time is only as current as that instant — and the
+;; agent boots in its own thread, so the instant a page is served may be before
+;; the conversation has a name, a model or a command list. What is drawn from
+;; here cannot be early: it is read when the connection exists.
+;;
+;; The subscription is made INSIDE the lock, which is what makes it exact
+;; rather than nearly right: a frame broadcast after it is queued for this
+;; connection, a frame broadcast before it is in what is read here, and no
+;; frame can be both or neither. Nothing under that lock renders anything — a
+;; finished turn's Markdown was rendered when the turn ended (`done-jsexpr`),
+;; and this hands out the same HTML the browsers that were here got.
+
+(define (chat-catch-up ch subscribe!)
+  (define frames
+    (with-state ch
+      (λ ()
+        (subscribe!)
+        (append
+         ;; a clean slate first: what this connection has drawn (a reload's
+         ;; markup, a reconnect's) is not the conversation, and what follows is
+         (list (reset-jsexpr))
+         (header-frames ch)
+         (append* (map entry-frames (reverse (conversation-entries ch))))))))
+  (for/list ([js (in-list frames)])
+    (cons acp-event-name (jsexpr->string js))))
+
+;; What the header says, for a header that has heard none of it said. Each of
+;; these is a fact or it is nothing: an unknown model, an unnamed conversation
+;; and an empty command list are the state a panel comes up in. Callers hold
+;; `sema`.
+(define (header-frames ch)
+  (append
+   (if (conversation-session ch)
+       (list (session-jsexpr (conversation-session ch) (conversation-title ch)))
+       '())
+   (if (conversation-model ch)
+       (list (model-jsexpr (conversation-model ch)))
+       '())
+   (if (pair? (conversation-commands ch))
+       (list (commands-jsexpr (conversation-commands ch)))
+       '())))
+
+;; One transcript entry, as the frames it was assembled from. A turn that is
+;; still RUNNING ends in no frame at all — a turn is open until something ends
+;; it, which is exactly the state the conversation is in. Callers hold `sema`.
+(define (entry-frames e)
+  (cond
+    [(marker? e) (list (mark-jsexpr (marker-type e) (marker-message e)))]
+    [else
+     (append
+      (list (user-jsexpr (turn-text e)))
+      ;; the whole of what was said, as one chunk: a panel that accumulated it
+      ;; letter by letter ends up with the same string
+      (if (string=? (turn-agent e) "") '() (list (chunk-jsexpr (turn-agent e))))
+      (for/list ([t (in-list (reverse (turn-tools e)))])
+        (tool-jsexpr (tool-id t) (tool-title t) (tool-status t)))
+      (case (turn-status e)
+        [(done) (list (done-jsexpr e))]
+        [(error) (list (error-jsexpr (or (turn-err e) "")))]
+        [else '()]))]))
 
 ;; ---- the seam ---------------------------------------------------------------
 ;;
@@ -321,7 +433,7 @@
 (define (show-model! ch name)
   (unless (equal? name (conversation-model ch))
     (set-conversation-model! ch name)
-    (broadcast! ch (hash 'type "model" 'name name))))
+    (broadcast! ch (model-jsexpr name))))
 
 ;; The picked model, and the picker to label the live one with.
 (define (learn-config-model! ch name labels)
@@ -363,12 +475,9 @@
 (define (chat-session-title ch)
   (with-state ch (λ () (conversation-title ch))))
 
-;; Callers hold `sema`. Append-only, like every other frame: a title the agent
-;; has not written yet is null, never a placeholder.
+;; Callers hold `sema`.
 (define (broadcast-session! ch)
-  (broadcast! ch (hash 'type "session"
-                       'id (or (conversation-session ch) (json-null))
-                       'title (or (conversation-title ch) (json-null)))))
+  (broadcast! ch (session-jsexpr (conversation-session ch) (conversation-title ch))))
 
 ;; A session, however it was got. The title is only ever SET here, never
 ;; cleared (that happened when the last one ended): a name that landed while the
@@ -415,7 +524,7 @@
     (λ ()
       (unless (equal? commands (conversation-commands ch))
         (set-conversation-commands! ch commands)
-        (broadcast! ch (hash 'type "commands" 'commands commands))))))
+        (broadcast! ch (commands-jsexpr commands))))))
 
 ;; ---- turn bookkeeping ------------------------------------------------------
 
@@ -434,7 +543,7 @@
       (cond
         [tn
          (set-turn-agent! tn (string-append (turn-agent tn) text))
-         (broadcast! ch (hash 'type "chunk" 'text text))]
+         (broadcast! ch (chunk-jsexpr text))]
         [else (log! ch "text arrived outside a turn; dropped")]))))
 
 (define (tool-call! ch id title status)
@@ -448,7 +557,7 @@
                         t)))
         (set-tool-title! t title)
         (set-tool-status! t status)
-        (broadcast! ch (hash 'type "tool" 'id id 'title title 'status status))))))
+        (broadcast! ch (tool-jsexpr id title status))))))
 
 ;; An update carries only what changed; the line keeps whatever it had.
 (define (tool-update! ch id title status)
@@ -460,14 +569,12 @@
         [t
          (when title (set-tool-title! t title))
          (when status (set-tool-status! t status))
-         (broadcast! ch (hash 'type "tool" 'id id
-                              'title (tool-title t) 'status (tool-status t)))]
+         (broadcast! ch (tool-jsexpr id (tool-title t) (tool-status t)))]
         [tn
          ;; an update for a call we never saw: still a line worth showing
          (define t2 (tool id (or title "tool") (or status tool-in-progress)))
          (set-turn-tools! tn (cons t2 (turn-tools tn)))
-         (broadcast! ch (hash 'type "tool" 'id id
-                              'title (tool-title t2) 'status (tool-status t2)))]
+         (broadcast! ch (tool-jsexpr id (tool-title t2) (tool-status t2)))]
         [else (void)]))))
 
 (define (find-tool tn id)
@@ -501,16 +608,16 @@
       (set-conversation-replay-turn! ch #f)
       (set-conversation-replay-user! ch #f)
       (set-conversation-replaying?! ch #t)
-      (broadcast! ch (hash 'type "reset")))))
+      (broadcast! ch (reset-jsexpr)))))
 
 ;; Callers hold `sema`.
 (define (open-replay-turn! ch)
   (define text (or (conversation-replay-user ch) ""))
-  (define tn (turn text "" '() 'running #f #f #t))
+  (define tn (turn text "" '() 'running #f #f #t #f))
   (set-conversation-replay-user! ch #f)
   (set-conversation-replay-turn! ch tn)
   (push-entry! ch tn)
-  (broadcast! ch (hash 'type "user" 'text text))
+  (broadcast! ch (user-jsexpr text))
   tn)
 
 ;; Callers hold `sema`.
@@ -519,9 +626,7 @@
   (when tn
     (set-turn-status! tn 'done)
     (set-conversation-replay-turn! ch #f)
-    (broadcast! ch (hash 'type "done"
-                         'stopReason (json-null)
-                         'html (note->html-string (turn-agent tn))))))
+    (broadcast! ch (done-jsexpr tn))))
 
 (define (replay-user-chunk! ch text)
   (with-state ch
@@ -589,14 +694,14 @@
       (λ ()
         (when (acp-stopped? (client ch)) (stopped-fail))
         (when (conversation-busy? ch) (busy-fail))
-        (define tn (turn text "" '() 'running #f #f #f))
+        (define tn (turn text "" '() 'running #f #f #f #f))
         ;; a cancel left over from a turn that died before it could be sent
         ;; belongs to that turn, not this one
         (set-conversation-cancel-pending?! ch #f)
         (set-conversation-busy?! ch #t)
         (set-conversation-live-turn! ch tn)
         (push-entry! ch tn)
-        (broadcast! ch (hash 'type "user" 'text text))
+        (broadcast! ch (user-jsexpr text))
         tn)))
   (in-custodian ch (λ () (thread (λ () (run-turn ch tn)))))
   (void))
@@ -615,12 +720,11 @@
          ;; Markdown is render-time only: the turn keeps the raw text, and the
          ;; frame carries a rendered COPY so a panel that accumulated plain
          ;; chunks can swap in the real thing without parsing anything.
-         (broadcast! ch (hash 'type "done" 'stopReason (cdr outcome)
-                              'html (note->html-string (turn-agent tn))))]
+         (broadcast! ch (done-jsexpr tn))]
         [else
          (set-turn-status! tn 'error)
          (set-turn-err! tn (cdr outcome))
-         (broadcast! ch (hash 'type "error" 'message (cdr outcome)))])
+         (broadcast! ch (error-jsexpr (cdr outcome)))])
       (set-conversation-live-turn! ch #f)
       (set-conversation-busy?! ch #f))))
 
@@ -707,7 +811,7 @@
   (with-state ch
     (λ ()
       (push-entry! ch (marker "reset" #f))
-      (broadcast! ch (hash 'type "reset"))))
+      (broadcast! ch (reset-jsexpr))))
   (void))
 
 (define (chat-stop! ch)

--- a/olai/web/events.rkt
+++ b/olai/web/events.rkt
@@ -24,6 +24,12 @@
 ;;     the next broadcast.
 ;;   * an idle stream must not look dead to a proxy: a heartbeat comment
 ;;     goes out every heartbeat-seconds.
+;;   * a connection is born mid-story. What it missed is not the hub's to know,
+;;     so it ASKS: `hub-response`'s `#:catch-up` is handed the subscribe thunk
+;;     and answers with the frames this connection alone is owed (see
+;;     web/chat). Subscribing inside it is the point — a caller whose state
+;;     moves under a lock takes that lock around both, and then nothing can
+;;     fall between the two.
 
 (require racket/async-channel
          racket/contract
@@ -44,7 +50,11 @@
           [hub-unsubscribe! (-> hub? subscriber? void?)]
           [subscriber? (-> any/c boolean?)]
           [subscriber-evt (-> subscriber? evt?)]
-          [hub-response (->* (hub?) (#:heartbeat-seconds (>/c 0)) response?)]
+          [hub-response (->* (hub?)
+                             (#:heartbeat-seconds (>/c 0)
+                              #:catch-up (or/c #f (-> (-> any)
+                                                      (listof (cons/c string? string?)))))
+                             response?)]
           [sse-frame (-> string? string? string?)]
           [sse-heartbeat string?]))
 
@@ -131,9 +141,15 @@
 ;; chunked encoding, and pumps whatever this writes as it is written — and it
 ;; leases the connection another response-send-timeout on every chunk, which
 ;; is the other reason the heartbeat exists.
-(define (hub-response h #:heartbeat-seconds [heartbeat-seconds default-heartbeat-seconds])
+;; #:catch-up is what this connection is owed before the stream proper: it is
+;; handed a `subscribe!` thunk to call once (inside whatever lock makes its
+;; answer consistent) and returns (name . data) pairs. #f is a subscriber that
+;; is owed nothing, which is what the outline stream is.
+(define (hub-response h
+                      #:heartbeat-seconds [heartbeat-seconds default-heartbeat-seconds]
+                      #:catch-up [catch-up #f])
   (response/output
-   (λ (out) (stream-events h out heartbeat-seconds))
+   (λ (out) (stream-events h out heartbeat-seconds catch-up))
    #:code 200
    #:mime-type #"text/event-stream; charset=utf-8"
    ;; no-store for caches; X-Accel-Buffering for an nginx that would
@@ -141,15 +157,25 @@
    #:headers (list (make-header #"Cache-Control" #"no-store")
                    (make-header #"X-Accel-Buffering" #"no"))))
 
-(define (stream-events h out heartbeat-seconds)
-  (define s (hub-subscribe! h))
+(define (stream-events h out heartbeat-seconds catch-up)
+  (define sub #f)
+  (define (subscribe!) (unless sub (set! sub (hub-subscribe! h))) sub)
+  ;; Asked BEFORE a byte goes out: the answer is read under somebody else's
+  ;; lock, and a socket written while that lock is held would stop the thing
+  ;; the lock protects. A catch-up that forgot to subscribe still gets one.
+  (define owed (if catch-up (catch-up subscribe!) '()))
+  (define s (subscribe!))
   (define dead (subscriber-dead-evt s))
   (define (emit! str) (write-string str out) (flush-output out))
   ;; A broken socket is how these streams normally end, not a fault.
   (with-handlers ([exn:fail? void])
     ;; Open the stream before waiting for anything: the client's `open` does
-    ;; not fire until bytes land, and neither does a proxy's.
-    (emit! sse-heartbeat)
+    ;; not fire until bytes land, and neither does a proxy's. One write, owed
+    ;; frames and all — they are already in hand, and a flush apiece would be
+    ;; a chunk apiece on the wire.
+    (emit! (apply string-append
+                  sse-heartbeat
+                  (for/list ([f (in-list owed)]) (sse-frame (car f) (cdr f)))))
     (let loop ()
       (define woke (sync/timeout heartbeat-seconds (subscriber-evt s) dead))
       (cond

--- a/olai/web/serve.rkt
+++ b/olai/web/serve.rkt
@@ -6,7 +6,9 @@
 ;;   GET  /n/<key>      one node, zoomed: breadcrumbs + that subtree
 ;;   GET  /today        today's Daily day node, zoomed
 ;;   GET  /events       SSE stream; `outline` (data: store revision) per reload,
-;;                      `chat` (data: one JSON frame) per agent frame
+;;                      `chat` (data: one JSON frame) per agent frame — and,
+;;                      first, the conversation this connection was not there
+;;                      for, in those same frames
 ;;   POST /chat         prompt the agent (form field `text`) -> 204
 ;;   POST /chat/new     new chat -> 204
 ;;   POST /chat/cancel  cancel the turn in flight -> 204
@@ -32,7 +34,8 @@
 ;;
 ;; The chat routes answer with a STATUS, never with content: what a panel
 ;; draws arrives over the stream, so every open tab shows the same
-;; conversation whichever one typed into it.
+;; conversation whichever one typed into it — including the tab that has just
+;; opened, which the stream catches up before anything else.
 
 (require racket/async-channel
          racket/path
@@ -217,23 +220,21 @@
 
 ;; ---- handlers: the chat panel ---------------------------------------------
 
-;; Replayed from the conversation's transcript on every page load: frames are
-;; ephemeral, and web/chat is the only thing that remembers a turn. No agent,
-;; no panel — `serve` refuses to start without one (docs/cli.md), so that is a
-;; test's server, not a user's.
-(define (chat-panel agent)
-  (and agent
-       (render-chat-panel (chat-transcript agent)
-                          #:busy? (chat-busy? agent)
-                          #:send-href chat-href
-                          #:new-href chat-new-href
-                          #:cancel-href chat-cancel-href
-                          #:sessions-href chat-sessions-href
-                          #:load-href chat-load-href
-                          #:event acp-event-name
-                          #:model (chat-model agent)
-                          #:session-title (chat-session-title agent)
-                          #:commands (chat-commands agent))))
+;; The panel's chrome, and nothing about the conversation: what a page load
+;; could say about one is only as current as the moment it was drawn, and the
+;; agent boots in its own thread. The conversation arrives on the stream, which
+;; catches a connection up on the way in (web/chat) — which is also why this is
+;; one value rather than a render: every page gets the same markup, and only
+;; the routes it names could ever change it. No agent, no panel — `serve`
+;; refuses to start without one (docs/cli.md), so that is a test's server, not
+;; a user's.
+(define the-chat-panel
+  (render-chat-panel #:send-href chat-href
+                     #:new-href chat-new-href
+                     #:cancel-href chat-cancel-href
+                     #:sessions-href chat-sessions-href
+                     #:load-href chat-load-href
+                     #:event acp-event-name))
 
 ;; The conversation's failure kinds, as statuses: 'busy is a second prompt
 ;; while a turn runs, 'validation is an agent that has been stopped. Terse
@@ -336,7 +337,7 @@
 ;; handed the snapshot and answers (values main title) — the only thing three
 ;; pages differ in.
 (define (outline-page st agent live-href view)
-  (define chat (chat-panel agent))
+  (define chat (and agent the-chat-panel))
   (with-snapshot st (λ (err) (page-failure err #:live-href live-href #:chat chat))
     #:stale-ok? #t
     (λ (snap err)
@@ -436,8 +437,14 @@
      ;; one page per node, addressed by the key the load layer minted
      [("n" (string-arg)) (λ (req key) (node-handler st agent key))]
      [("today") (λ (req) (today-handler st agent))]
-     ;; mounted, not understood: what an event MEANS lives in web/events
-     [("events") (λ (req) (hub-response hub))]
+     ;; Mounted, not understood: what an event MEANS lives in web/events. The
+     ;; one thing this layer knows is that a new connection has a conversation
+     ;; to catch up on, and which module it asks for it.
+     [("events") (λ (req)
+                   (hub-response hub
+                                 #:catch-up (and agent
+                                                 (λ (subscribe!)
+                                                   (chat-catch-up agent subscribe!)))))]
      ;; the chat panel's verbs. What they DO lives in web/chat; this layer
      ;; only turns a request into a call and a failure into a status.
      [("chat") #:method "post" (λ (req) (chat-handler agent req))]

--- a/olai/web/static/chat.js
+++ b/olai/web/static/chat.js
@@ -2,6 +2,13 @@
 // page (the body's sse-connect), so this hooks the htmx sse extension rather
 // than opening an EventSource of its own — browsers cap those per origin.
 //
+// The panel comes out of the server empty and in none of its states. Every
+// word in it, and every class on it, arrives as a frame — including the ones
+// for what happened before this page existed, which the server replays down
+// the connection the moment it is made (web/chat's catch-up). So there is no
+// state to read out of the markup at init, and nothing here has to agree with
+// a renderer about what a turn looks like.
+//
 // Frames are JSON, one per event, and land as TEXT: user text, agent chunks
 // and tool titles are set with textContent, never innerHTML. The one
 // exception is the `html` a `done` frame carries — Markdown the server
@@ -86,11 +93,11 @@
 
   // ---- slash commands ----------------------------------------------------
   //
-  // The agent's own command list: server-rendered onto the panel as
-  // data-commands (a reloaded page completes right away) and replaced live by
-  // a `commands` frame. Typing "/" opens a popover over the input row; picking
-  // a row only WRITES "/name " into the input — a command is invoked by
-  // sending ordinary prompt text, so nothing about the send path changes.
+  // The agent's own command list: the whole of it in every `commands` frame,
+  // one of which this connection was caught up with. Typing "/" opens a
+  // popover over the input row; picking a row only WRITES "/name " into the
+  // input — a command is invoked by sending ordinary prompt text, so nothing
+  // about the send path changes.
   var commands=[],matches=[],picked=-1;
 
   // Two strings per command, and only what has a name: this list is drawn.
@@ -274,8 +281,15 @@
       endTurn();
       body.textContent='';
     }
+    // A break that already happened, replayed with the conversation: the turns
+    // above it are still there, so it draws a line rather than clearing. What
+    // the break WAS is the frame's; the word on the line is this side's.
+    else if(f.type==='mark'){
+      endTurn();
+      append(line('ol-chat-sep',f.message||(f.mark==='reset'?'new chat':f.mark)));
+    }
     // the header's one live bit: which model, learned with the session and
-    // again if it changes under one. The page renders whatever was known then.
+    // again if it changes under one.
     else if(f.type==='model'){
       if(modelEl)modelEl.textContent=typeof f.name==='string'?f.name:'';
     }
@@ -329,9 +343,6 @@
     sink=document.getElementById('ol-chat-sink');
     modelEl=document.getElementById('ol-chat-model');
     sessionEl=document.getElementById('ol-chat-session');
-    // What the server knew when it drew the page. Bad JSON is no commands,
-    // not a broken panel.
-    try{setCommands(JSON.parse(panel.getAttribute('data-commands')||'[]'))}catch(e){}
     // The popover belongs to the input row and to nothing else, so it is made
     // here rather than rendered: there is no server state in it.
     pop=line('ol-chat-pop');
@@ -353,16 +364,6 @@
     var open='0';
     try{open=localStorage.getItem(KEY)||'0'}catch(e){}
     setOpen(open==='1');
-    // A turn was still running when the page was rendered: the panel comes
-    // up in the state the server says it is in, not idle. Adopt the
-    // replayed turn too, or the next live frame would start a duplicate.
-    if(panel.classList.contains('is-busy')){
-      setBusy(true);
-      var turns=body?body.querySelectorAll('.ol-chat-turn'):[];
-      turn=turns[turns.length-1]||null;
-      agentEl=turn?turn.querySelector('.ol-chat-msg.is-agent'):null;
-    }
-    if(body)body.scrollTop=body.scrollHeight;
 
     document.addEventListener('click',function(e){
       var t=e.target.closest('[data-post],[data-chat-toggle],[data-chat-commands],[data-chat-sessions]');


### PR DESCRIPTION
Fixes the parked `panel opened during boot misses its conversation #bug` (Roadmap.rkt, chat subtree) and takes the `@skip` off the scenario written for it in `e2e/features/sessions.feature`.

## The bug

`serve` prints its URL and answers requests while the agent boots in its own thread. The boot frames — which conversation, which model, which commands, and the turns a stored session replays into it — were broadcast only to whoever was already on `/events`. A page opened in that window was served a panel drawn *before* any of them landed, and never heard them: nameless, empty, and only as current as the request that drew it, until something else made it redraw.

Not really a boot bug: the panel was rendered at T1 and the browser subscribed at T2, and everything in between was lost. Boot just makes that window a second wide and consequential.

## The fix

The panel is no longer where a browser learns any of that.

* **`web/chat-panel`** draws chrome: the dock, the header, an empty conversation, the input row. No transcript, no `data-commands`, no initial `is-busy`, no model/session strings. The turn markup it used to render was a second renderer for what `static/chat.js` builds from frames; that is gone.
* **`web/chat`** gains `chat-catch-up`: what a connection is owed on the way in — a `reset`, the session/model/commands as they stand, and the transcript as the frames that built it. One owner for what a late browser sees, the same frames a live one gets, and it cannot be early because it is read when the connection exists. One new frame, `mark`: a break that already happened (a live `reset` clears a panel; a replayed one is a line across it, which is what the old server-rendered transcript drew).
* **`web/events`** gains `#:catch-up` on `hub-response`. The hub stays generic — it traffics in `(name . data)` and `#f` means "owed nothing", which is what the outline side is. The callback is handed the `subscribe!` thunk rather than being asked after the fact: subscribing inside it is what lets `web/chat` take its own lock around the subscription AND the reading, so no frame can be both queued and replayed, or neither.

A finished turn's Markdown is now rendered once, when the turn ends, and kept on the turn — every connection told about it afterwards is owed the same frame.

## Tests

* the `@skip` comes off `a page opened while the agent is still waking up says which chat it is in`, and it passes with no `Given the agent has woken up`
* new e2e: `a reload comes back to the conversation` (the page carries none of it)
* racket: the catch-up at the bridge (header then turns, a clean slate, a running turn replayed open with a break above it, subscribed exactly once), and at the server — including a connection made with `#:booted? #f`, i.e. inside the window this bug is about
* `world.waitForAgent` no longer polls the page for `data-commands` (there is none): it reads the stream and waits for the `commands` frame, which is the last thing a boot says

`just test` (190) / `just test-integration` (104) / `just e2e` (37) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
