### PR TITLE
web: the chat panel is a usable sheet on a phone

### DIFF
--- a/e2e/features/mobile.feature
+++ b/e2e/features/mobile.feature
@@ -1,0 +1,40 @@
+@phone
+Feature: the agent panel on a phone
+
+  A phone has no room for two columns, so below phone-max the panel stops
+  being a side panel and becomes a sheet over the outline (web/chat-panel,
+  sheet mode). These are the desktop panel's geometry scenarios read the
+  other way round — the outline gives up no gutter, because it is covered —
+  plus the two things a finger and an on-screen keyboard need.
+
+  Every scenario here runs on a 390x844 screen, which the tag above the
+  feature is what asks for (support/world.js, PHONE_VIEWPORT).
+
+  Scenario: the panel is a sheet over the outline, not a column beside it
+    When I open the home page
+    And I press the agent toggle
+    Then the chat panel is open
+    And the chat panel is as wide as the screen
+    And the outline reserves no gutter for the chat panel
+
+  # The floating toggle is under the open sheet, so the header's × is the ONLY
+  # way out of it — and it was a 25x20 box around an 11px glyph. The input's
+  # type is the other number: iOS Safari zooms the page in on a focused input
+  # smaller than 16px and does not zoom back out.
+  Scenario: everything you have to hit is a target for a finger
+    When I open the home page
+    And I press the agent toggle
+    Then every chat control is at least 44 pixels tall
+    And the chat input is at least 16 pixels of type
+
+  # The report this feature comes from. The panel is position:fixed, so it is
+  # placed against the LAYOUT viewport — and an on-screen keyboard covers the
+  # bottom of that without shrinking it, which put the input row 354px below
+  # the last visible pixel on an iPhone 14. You typed into a box you could not
+  # see.
+  Scenario: the keyboard does not take the input row down with it
+    When I open the home page
+    And I press the agent toggle
+    And the on-screen keyboard covers the bottom of the screen
+    Then the chat input is on screen
+    And the chat panel stops above the keyboard

--- a/e2e/steps/chat_steps.js
+++ b/e2e/steps/chat_steps.js
@@ -184,6 +184,89 @@ Then("the outline column stops before the chat panel", async function () {
   );
 });
 
+// ---- the same panel, on a phone -------------------------------------------
+//
+// Below phone-max the panel is a sheet OVER the outline, so the desktop
+// geometry above reads the other way: it takes the whole width, and the
+// reading column it used to make room for is covered rather than narrowed.
+
+Then("the chat panel is as wide as the screen", async function () {
+  const m = await sheet(this.page);
+  assert.equal(Math.round(m.width), Math.round(m.screen),
+    `the panel is ${m.width}px on a ${m.screen}px screen`);
+});
+
+Then("the outline reserves no gutter for the chat panel", async function () {
+  const gutter = await this.page.evaluate(
+    () => getComputedStyle(document.querySelector(".ol-main")).marginRight);
+  assert.equal(gutter, "0px", `the outline still gives up ${gutter} to a sheet that covers it`);
+});
+
+// Every control the sheet actually shows — a stop button that is hidden while
+// the panel is idle is not something anyone has to hit.
+Then("every chat control is at least {int} pixels tall", async function (px) {
+  const small = await this.page.evaluate(() =>
+    [...document.querySelectorAll("#ol-chat button, #ol-chat input")]
+      .map((el) => ({ what: (el.textContent || el.placeholder || "").trim(),
+                      h: Math.round(el.getBoundingClientRect().height) }))
+      .filter((c) => c.h > 0));
+  const under = small.filter((c) => c.h < px);
+  assert.deepEqual(under, [], `${under.map((c) => `"${c.what}" is ${c.h}px`).join(", ")}`);
+});
+
+Then("the chat input is at least {int} pixels of type", async function (px) {
+  const size = await this.page.evaluate(() =>
+    parseFloat(getComputedStyle(document.querySelector("#ol-chat-form .ol-chat-input")).fontSize));
+  assert.ok(size >= px, `the input's type is ${size}px, under the ${px}px iOS zooms at`);
+});
+
+// What a keyboard IS, to a page: the visual viewport shrinks and the layout
+// viewport does not. Chromium has no on-screen keyboard to raise, so the
+// scenario says that in the only place it is observable — and a page that
+// listens to visualViewport (static/chat.js) cannot tell the difference, which
+// is the point. A page that does not listen fails the two assertions after it,
+// exactly as an iPhone did.
+When("the on-screen keyboard covers the bottom of the screen", async function () {
+  await this.page.evaluate(() => {
+    const vv = window.visualViewport;
+    Object.defineProperty(vv, "height", {
+      value: Math.round(vv.height * 0.55), configurable: true,
+    });
+    document.querySelector("#ol-chat-form .ol-chat-input").focus();
+    vv.dispatchEvent(new Event("resize"));
+  });
+});
+
+Then("the chat input is on screen", async function () {
+  const m = await sheet(this.page);
+  assert.ok(m.input.bottom <= m.visible + 1,
+    `the input row ends ${Math.round(m.input.bottom - m.visible)}px below the visible screen`);
+  assert.ok(m.input.top >= -1, `the input row starts ${Math.round(m.input.top)}px above it`);
+});
+
+Then("the chat panel stops above the keyboard", async function () {
+  const m = await sheet(this.page);
+  assert.ok(m.bottom <= m.visible + 1,
+    `the sheet ends ${Math.round(m.bottom - m.visible)}px below the visible screen`);
+});
+
+/** The sheet's box, its input row, and the strip of screen the browser is
+ *  actually showing (which an on-screen keyboard is what shrinks). */
+async function sheet(page) {
+  await page.locator(OPEN).waitFor({ state: "visible" });
+  return await page.evaluate(() => {
+    const box = document.querySelector("#ol-chat").getBoundingClientRect();
+    const input = document.querySelector("#ol-chat-form .ol-chat-input").getBoundingClientRect();
+    const vv = window.visualViewport;
+    return {
+      width: box.width, bottom: box.bottom,
+      input: { top: input.top - vv.offsetTop, bottom: input.bottom },
+      screen: vv.width,
+      visible: vv.offsetTop + vv.height,
+    };
+  });
+}
+
 // ---- the conversation -----------------------------------------------------
 
 /** The turn being drawn. A turn owns its user bubble, the agent's text and its

--- a/e2e/support/hooks.js
+++ b/e2e/support/hooks.js
@@ -16,7 +16,7 @@ import {
 } from "@cucumber/cucumber";
 import { chromium } from "playwright";
 
-import { OlaiWorld } from "./world.js";
+import { OlaiWorld, PHONE_VIEWPORT } from "./world.js";
 
 // A step here can be waiting on a racket start-up, a filesystem watcher's
 // 2-second poll fallback, and an agent subprocess. Cucumber's 5s default is a
@@ -45,12 +45,18 @@ const STORED_SESSIONS = {
   "@foreign-sessions": "foreign",
 };
 
+// The screen is the other thing a scenario asks for by tag. Not an assertion
+// but a LAYOUT: below phone-max the skin puts the sidebar above the outline and
+// the chat panel over it (web/chat-panel, sheet mode), and a scenario about
+// that has to be run there.
 Before(async function ({ pickle }) {
   const env = {};
+  let viewport;
   for (const { name } of pickle.tags) {
     if (name in STORED_SESSIONS) env.OLAI_FAKE_ACP_STORED = STORED_SESSIONS[name];
+    if (name === "@phone") viewport = PHONE_VIEWPORT;
   }
-  await this.boot(browser, env);
+  await this.boot(browser, env, viewport);
 });
 
 // The server's own output is the first thing worth reading when a scenario

--- a/e2e/support/world.js
+++ b/e2e/support/world.js
@@ -12,11 +12,16 @@ import { World } from "@cucumber/cucumber";
 import { FIXTURE } from "./outline.js";
 import { startServer } from "./server.js";
 
-// A desktop, because the layout the scenarios assert is the desktop one: the
+// A desktop, because the layout most scenarios assert is the desktop one: the
 // sidebar is a column, and the chat panel sits BESIDE the outline rather than
 // over it (the phone rules are a @media away and would make the geometry
 // assertions say nothing).
 const VIEWPORT = { width: 1280, height: 900 };
+
+// And the other layout, for the scenarios that are about it: an iPhone 14 in
+// CSS pixels, well under phone-max (48rem), where the panel is a sheet OVER
+// the outline. A scenario asks for it with @phone (hooks.js).
+export const PHONE_VIEWPORT = { width: 390, height: 844 };
 
 // The sentinel a mark leaves on the page. A reload wipes it; an htmx swap does
 // not — which is the whole difference "without a reload" is about.
@@ -25,8 +30,9 @@ const MARK = "__olai_e2e_mark";
 export class OlaiWorld extends World {
   /** Temp outline + server + a fresh browser context. `browser` is the run's
    *  (hooks.js owns it): a context per scenario is what makes localStorage —
-   *  the fold state, the theme, the chat panel's open bit — start empty. */
-  async boot(browser, env = {}) {
+   *  the fold state, the theme, the chat panel's open bit — start empty. The
+   *  viewport is a desktop unless the scenario asked for the other one. */
+  async boot(browser, env = {}, viewport = VIEWPORT) {
     this.dir = await fs.mkdtemp(path.join(os.tmpdir(), "olai-e2e-"));
     this.outlinePath = path.join(this.dir, "Tasks.rkt");
     await this.rewrite(FIXTURE);
@@ -35,7 +41,7 @@ export class OlaiWorld extends World {
     // second the scenario actually waits for; it may as well cover both.
     const [server, context] = await Promise.all([
       startServer(this.dir, env),
-      browser.newContext({ viewport: VIEWPORT }),
+      browser.newContext({ viewport }),
     ]);
     this.server = server;
     this.context = context;

--- a/olai/tests/style.rkt
+++ b/olai/tests/style.rkt
@@ -38,7 +38,7 @@
          ;; tables, their blocks, and which of them promise AA
          (only-in olai/web/theme
                   ol-body ol-pill theme-names theme-default
-                  palette-tokens layout-tokens
+                  palette-tokens layout-tokens phone-max touch-min
                   theme-entries theme-blocks aa-theme-names)
          ;; the renderers: what the skin is FOR, and the only honest answer to
          ;; "does anything wear this class"
@@ -203,10 +203,18 @@
   (remove-duplicates
    (regexp-match* class-rx (strip-element-ids (file->string path)) #:match-select cadr)))
 
+;; The other name a script and the skin have to spell the same way: a custom
+;; property. Same broad scan as the classes above — anywhere in the file, so a
+;; selector string or a getPropertyValue argument counts alike.
+(define (js-custom-properties path)
+  (remove-duplicates
+   (map (λ (s) (string->symbol (substring s 2)))
+        (regexp-match* #px"--[a-z][a-z0-9-]*" (file->string path)))))
+
 ;; olai's own scripts plus the vendored sse extension. htmx itself is not in
 ;; the list: it spells no olai class, and scanning a minified bundle for
 ;; class-shaped names would find noise, not a border.
-(define script-names '("chat.js" "collapse.js" "prefs.js" "sse.js"))
+(define script-names '("chat.js" "collapse.js" "prefs.js" "pwa.js" "sse.js"))
 
 (define scripted-classes
   (for/fold ([acc (set)]) ([js (in-list script-names)])
@@ -352,6 +360,63 @@
                 "the panel's gutter is no longer a margin on the reading column")
     (check-false (regexp-match? #px"padding-right" overlay)
                  "the gutter is padding again: border-box takes it out of max-width"))
+
+  ;; The other thing a fixed panel gets wrong on a phone, and the one the
+  ;; report was about: `top: 0; bottom: 0` is as tall as the LAYOUT viewport,
+  ;; and an on-screen keyboard covers the bottom of that without shrinking it,
+  ;; so the input row spent the whole turn behind the keyboard. The panel is
+  ;; sized by the visible strip instead, and the home-bar inset it pads for is
+  ;; only the part no keyboard is over.
+  (test-case "the panel is as tall as what the browser is showing"
+    (define box (fragment->css (cdr (list-ref ordered-fragments (at "ol-chat")))))
+    (check-true (regexp-match? #px"height\\s*:\\s*var\\(--visible-h\\)" box)
+                "the panel's height is not the visible viewport's")
+    (check-true (regexp-match? #px"bottom\\s*:\\s*var\\(--visible-bottom\\)" box)
+                "the panel's bottom edge is not the visible viewport's")
+    (check-false (regexp-match? #px"top\\s*:\\s*0" box)
+                 "the panel is pinned to the layout viewport's top again")
+    (check-true (regexp-match? #px"padding-bottom[^;]*safe-area-inset-bottom[^;]*--visible-bottom"
+                               box)
+                "the home-bar inset is padded for even where a keyboard covers it"))
+
+  ;; Sheet mode: below phone-max there is no room beside the outline, so the
+  ;; panel covers it instead. That is ONE decision, and this is the test that
+  ;; it stays one — every phone-width rule about the panel is in that block,
+  ;; save the outline's gutter, whose subject is another module's class and
+  ;; which therefore has to sit in the 'overlay fragment.
+  (define phone-media-rx
+    (pregexp (string-append "@media\\s*\\(max-width\\s*:\\s*"
+                            (regexp-quote (format "~a" phone-max)))))
+
+  (test-case "everything the panel does at phone width is in one block"
+    (define chat-phone
+      (for/list ([f (in-list ordered-fragments)]
+                 #:when (and (ormap (λ (c) (string-prefix? c "ol-chat"))
+                                    (fragment-classes (cdr f)))
+                             (regexp-match? phone-media-rx (fragment->css (cdr f)))))
+        (cons (car f) (fragment->css (cdr f)))))
+    (check-equal? (map car chat-phone) '(component overlay)
+                  "a phone-width rule about the panel landed outside sheet mode")
+    ;; the 'overlay one is the outline's gutter, which a sheet does not need
+    (check-true (regexp-match? #px"margin-right\\s*:\\s*0" (cdr (last chat-phone)))
+                "the outline still reserves a gutter for a panel that covers it")
+    (define sheet (cdr (car chat-phone)))
+    (check-true (regexp-match? #px"width\\s*:\\s*100%" sheet) "the sheet is not full-bleed")
+    ;; the header's × is the only way out of a sheet — the toggle it would
+    ;; otherwise be is underneath it — so it is a target, not an 11px glyph
+    (check-true (regexp-match? (pregexp (string-append "min-height\\s*:\\s*"
+                                                       (regexp-quote (format "~a" touch-min))))
+                               sheet)
+                "the panel's controls are back to mouse-sized")
+    ;; iOS Safari zooms the page in when a focused input's type is under 16px
+    ;; and does not zoom back out: the sheet ends up wider than the screen
+    (check-true (regexp-match? #px"font-size\\s*:\\s*1rem" sheet)
+                "the input is small enough for iOS to zoom the page into it")
+    ;; and `display` is the panel's own states (a stop button that hides while
+    ;; idle, a commands button with nothing to offer): a rule here would land
+    ;; after them and show both
+    (check-false (regexp-match? #px"display\\s*:" sheet)
+                 "sheet mode has an opinion about display; the panel's states own that"))
 
   ;; ---- theme --------------------------------------------------------------
 
@@ -527,6 +592,19 @@
       (for ([c (in-list (js-class-names (build-path (web-static-dir) js)))])
         (check-true (or (set-member? known c) (set-member? allowed c))
                     (format "~a spells .~a; no module defines it" js c)))))
+
+  ;; The same border one level down. A custom property is the other name two
+  ;; sides spell — pwa.js reads --paper to paint the browser chrome, chat.js
+  ;; writes the two the panel's height is measured in — and a script spelling
+  ;; one no module defines is the same silent nothing a class would be. Asked
+  ;; of the VOCABULARY, the way the theme tests are: the token lists are what
+  ;; the skin has to say on the subject, and the sheet is downstream of them.
+  (test-case "every custom property the scripts spell is one of the skin's tokens"
+    (define tokens (list->set (append palette-tokens layout-tokens chat-viewport-tokens)))
+    (for* ([js (in-list script-names)]
+           [property (in-list (js-custom-properties (build-path (web-static-dir) js)))])
+      (check-true (set-member? tokens property)
+                  (format "~a spells --~a; no module defines that token" js property))))
 
   ;; ---- the border the other way -------------------------------------------
 

--- a/olai/web/chat-panel.rkt
+++ b/olai/web/chat-panel.rkt
@@ -69,7 +69,9 @@
 ;; ---- the dock -------------------------------------------------------------
 
 ;; The outline stays the star. The panel is fixed to the right edge, closed
-;; until asked for, and the main pane makes room rather than being covered.
+;; until asked for, and the main pane makes room rather than being covered —
+;; until the screen is too narrow for two columns, where it is a sheet over the
+;; outline instead (sheet mode, at the end of the rules below).
 ;; The dock itself is not a box: its two children place themselves.
 (define-style ol-chat-dock #:display contents)
 
@@ -80,7 +82,8 @@
   #:bottom (apply max 1rem (apply env safe-area-inset-bottom))
   #:z-index 20
   #:padding (0.5rem 0.875rem)
-  #:min-height 2.75rem
+  ;; a thing a thumb aims at, whatever the label says (theme.rkt, touch-min)
+  #:min-height ,touch-min
   #:border (1px solid ,line)
   #:border-radius 9999px
   #:background ,paper-2
@@ -111,13 +114,34 @@
 
 ;; ---- the panel ------------------------------------------------------------
 
+;; What the browser is SHOWING, which on a phone is not what it laid out. The
+;; panel is fixed, so it is placed against the LAYOUT viewport — and an
+;; on-screen keyboard covers the bottom of that without shrinking it. A panel
+;; at `top: 0; bottom: 0` therefore spent the whole time you were typing with
+;; its input row behind the keyboard, which is the one thing you are looking
+;; at. --visible-h is the height of the strip that is actually on screen and
+;; --visible-bottom is how far below it the layout viewport's bottom edge sits,
+;; which is what a fixed box has to be lifted by.
+;;
+;; The panel's own vocabulary, not the theme's: nothing else reads them, and
+;; they are not a design choice but a reading of one browser. static/chat.js
+;; takes that reading (visualViewport) and keeps them in step; the values here
+;; are what a page whose scripts have not run gets, and where a desktop browser
+;; stays — the whole viewport, flush with the bottom, which is what the side
+;; panel always was.
+(define-tokens chat-viewport-tokens visible-h visible-bottom)
+
+(register-fragment!
+ #:layer 'base
+ (css-expr [(: root) #:--visible-h 100dvh #:--visible-bottom 0px]))
+
 (define-style ol-chat
   #:position fixed
-  #:top 0
   #:right 0
-  #:bottom 0
   #:z-index 19
   #:width ,chat-w
+  #:bottom ,visible-bottom
+  #:height ,visible-h
   #:display none
   #:flex-direction column
   #:border-left (1px solid ,line)
@@ -127,10 +151,11 @@
   ;; fixed, so body padding does not protect it: pad for the notch / home bar
   #:padding-top (apply env safe-area-inset-top)
   #:padding-right (apply env safe-area-inset-right)
-  #:padding-bottom (apply env safe-area-inset-bottom)
-  [,(sel '& is-open) #:display flex]
-  ;; a phone has no room beside the outline: the panel is a sheet over it
-  [@ media (#:max-width ,phone-max) #:width 100% #:left 0 #:border-left 0])
+  ;; the home-bar inset, minus whatever a keyboard is already covering: pad for
+  ;; it twice and the input row floats a thumb's width above the keyboard
+  #:padding-bottom (apply max 0px (apply calc (- (apply env safe-area-inset-bottom)
+                                                 ,visible-bottom)))
+  [,(sel '& is-open) #:display flex])
 
 ;; The panel does not cover the outline: the reading column gives up the width
 ;; it takes. The SUBJECT here is another module's — the document and the
@@ -149,7 +174,10 @@
  (css-expr
   [((: ,(sel 'body ol-body) (apply has ,(sel ol-chat is-open))) ,(sel ol-main))
    #:margin-right (apply calc (+ ,chat-w 1.5rem))
-   ;; on a phone the sheet covers it anyway, so there is nothing to make room for
+   ;; The other half of sheet mode (see the block at the end of this module):
+   ;; below phone-max the panel covers the outline instead of sitting beside it,
+   ;; so there is nothing to make room for — and a gutter the width of the
+   ;; panel would leave the reading column with nothing.
    [@ media (#:max-width ,phone-max) #:margin-right 0]]))
 
 (define-style ol-chat-head
@@ -417,6 +445,45 @@
  (css-expr
   [,(sel ol-chat-stop) (,(sel ol-chat is-busy) ,(sel ol-chat-send)) #:display none]
   [(,(sel ol-chat is-busy) ,(sel ol-chat-stop)) #:display inline-block]))
+
+;; ---- sheet mode -----------------------------------------------------------
+;;
+;; A phone has no room beside the outline: below phone-max the panel stops
+;; being a side panel and becomes a SHEET over it. That is ONE decision, so it
+;; is one block — everything that is different about the narrow panel is here,
+;; and nothing anywhere else has a phone-width opinion about it. (The one rule
+;; it cannot hold is the outline's gutter, whose subject is another module's
+;; class and which therefore has to live in the 'overlay fragment above; it
+;; says there that it is the same mode.)
+;;
+;; Last in the module, because every rule here repaints one stated above it,
+;; and a media query adds no specificity to win with.
+;;
+;; What it does NOT touch is `display`: the panel's own states hang off that
+;; (a stop button that hides while idle, a commands button that hides with
+;; nothing to offer), and a phone-width rule landing after them would show
+;; both.
+(register-fragment!
+ (css-expr
+  [@ media (#:max-width ,phone-max)
+     ;; full bleed, and no border against a column that is not beside it
+     [,(sel ol-chat) #:width 100% #:border-left 0]
+     ;; The same target the floating toggle keeps, for the same reason: at the
+     ;; panel's own scale these were 20px boxes around 11px glyphs, and on a
+     ;; phone the header's × is the ONLY way out of the sheet — the toggle it
+     ;; would otherwise be is underneath it. A button centres its own label, so
+     ;; a minimum is all this takes.
+     [,(sel ol-chat-btn) ,(sel ol-chat-send) ,(sel ol-chat-stop)
+      #:min-height ,touch-min
+      #:padding (0.25rem 0.75rem)
+      #:font-size 0.8125rem
+      ;; a two-word label in a box this size wraps, and a wrapped label makes
+      ;; the row it sits in taller than the finger it was widened for
+      #:white-space nowrap]
+     ;; 16px is a threshold, not a taste: iOS Safari zooms the page in when you
+     ;; focus an input whose type is smaller and does not zoom back out, so the
+     ;; sheet ends up wider than the screen with the send button off the edge.
+     [,(sel ol-chat-input) #:min-height ,touch-min #:font-size 1rem]]))
 
 ;; ---- the markup -----------------------------------------------------------
 

--- a/olai/web/render.rkt
+++ b/olai/web/render.rkt
@@ -946,8 +946,16 @@
   `(html ((lang "en"))
          (head
           (meta ((charset "utf-8")))
+          ;; viewport-fit=cover puts the page under the notch and the home bar
+          ;; (the insets are then real). interactive-widget says what an
+          ;; on-screen keyboard should do to it: shrink the viewport, so a
+          ;; panel fixed to the bottom stays above the keyboard. Where it is
+          ;; honoured that is the whole fix; iOS ignores it, and static/chat.js
+          ;; measures visualViewport for those (web/chat-panel, --visible-*).
           (meta ((name "viewport")
-                 (content "width=device-width, initial-scale=1, viewport-fit=cover")))
+                 (content ,(string-append "width=device-width, initial-scale=1"
+                                          ", viewport-fit=cover"
+                                          ", interactive-widget=resizes-content"))))
           ,@(if color-scheme
                 (list `(meta ((name "color-scheme") (content ,color-scheme))))
                 '())

--- a/olai/web/static/chat.js
+++ b/olai/web/static/chat.js
@@ -33,6 +33,39 @@
     if(b)closePop();
   }
 
+  // ---- how tall the panel may be -----------------------------------------
+  //
+  // visualViewport is the strip the browser is actually showing, which on a
+  // phone is not the viewport it laid the page out in — the keyboard covers
+  // the bottom of that without shrinking it. --visible-h / --visible-bottom
+  // are that reading, and web/chat-panel is where they are declared and what
+  // the panel is sized by; this is the mirror that keeps them true.
+  var visibleH,visibleBottom;
+
+  function measureViewport(){
+    var vv=window.visualViewport;
+    if(!vv)return;
+    // clientHeight, not innerHeight: the layout viewport a fixed box is placed
+    // in has no room for scrollbars either, and visualViewport does not count
+    // them
+    var h=Math.round(vv.height)+'px';
+    var bottom=Math.max(0,Math.round(document.documentElement.clientHeight
+                                     -vv.height-vv.offsetTop))+'px';
+    // Both properties inherit, so writing one costs every node on the page a
+    // style recalc — and this fires on every frame of a keyboard sliding up
+    // and of an address bar sliding away, most of which move nothing.
+    if(h===visibleH&&bottom===visibleBottom)return;
+    visibleH=h;visibleBottom=bottom;
+    // read before the write that reflows: the panel is about to get shorter,
+    // and a reader at the bottom of the transcript stays there rather than
+    // watching the message they are answering scroll off
+    var stick=body&&panel.classList.contains('is-open')&&nearBottom();
+    var style=document.documentElement.style;
+    style.setProperty('--visible-h',h);
+    style.setProperty('--visible-bottom',bottom);
+    if(stick)body.scrollTop=body.scrollHeight;
+  }
+
   // ---- the message body --------------------------------------------------
 
   function nearBottom(){
@@ -363,6 +396,16 @@
       agentEl=turn?turn.querySelector('.ol-chat-msg.is-agent'):null;
     }
     if(body)body.scrollTop=body.scrollHeight;
+
+    // The keyboard coming up and going down is a visualViewport resize; so is
+    // an address bar sliding away, and so is a rotation. Its `scroll` is the
+    // visible strip moving inside the layout viewport, which moves the panel's
+    // bottom edge just as much.
+    measureViewport();
+    if(window.visualViewport){
+      window.visualViewport.addEventListener('resize',measureViewport);
+      window.visualViewport.addEventListener('scroll',measureViewport);
+    }
 
     document.addEventListener('click',function(e){
       var t=e.target.closest('[data-post],[data-chat-toggle],[data-chat-commands],[data-chat-sessions]');

--- a/olai/web/theme.rkt
+++ b/olai/web/theme.rkt
@@ -83,10 +83,10 @@
 (define-tokens layout-tokens
   sans mono sidebar-w chat-w indent radius)
 
-;; Three constants that are not custom properties because CSS cannot read one
-;; where they are used — a media query's width, and two values a rule repeats
+;; Four constants that are not custom properties because CSS cannot read one
+;; where they are used — a media query's width, and three values a rule repeats
 ;; verbatim. They are still the skin's, and still spelled once.
-(provide phone-max busy-beat micro-size)
+(provide phone-max busy-beat micro-size touch-min)
 
 ;; where two columns stop fitting: no sidebar beside the outline, no panel
 ;; beside either
@@ -96,6 +96,10 @@
 (define busy-beat '1.8s)
 ;; the smallest type in the skin: a label, a timestamp, a tool line
 (define micro-size '0.6875rem)
+;; how big a thing a finger aims at has to be — 44px, the number both mobile
+;; platforms print in their guidelines. The floating toggle and the panel's
+;; controls in sheet mode are the same decision, so it is one binding
+(define touch-min '2.75rem)
 
 ;; ---- the themes -----------------------------------------------------------
 ;;


### PR DESCRIPTION
Fixes the parked `mobile chat unusable #bug` (Roadmap.rkt, chat subtree).

## What was actually broken

Reproduced at 390x844 and 375x667 (headless Chrome, CDP, panel open). Three
failures, and together they are the report:

1. **The input row was behind the keyboard.** The panel is `position: fixed`
   at `top: 0; bottom: 0`, which is as tall as the LAYOUT viewport — and an
   on-screen keyboard covers the bottom of that without shrinking it. With a
   390x490 visible strip the form's bottom edge sat **354px below the last
   visible pixel**. You typed blind, into a box you could not see.
2. **Nothing was a target.** The header's × — the only way out of the sheet,
   since the floating toggle is underneath it — was a 25x20 box around an 11px
   glyph. So were `chats`, `+ new`, `/` and `send`.
3. **The input's type was 14px**, under the 16px line at which iOS Safari zooms
   the page in on focus and does not zoom back out (the sheet then ends up
   wider than the screen, send button off the edge).

The brief's hypothesis — that `.ol-main` gets squeezed by the #14 gutter on a
phone — did **not** reproduce: #13 already put the panel at `width: 100%` and
the gutter at `margin-right: 0` below `phone-max`. That part was a regression
guard to keep, not a bug to fix.

## The fix

**The panel is bounded by what the browser is SHOWING**, not by the box it laid
out: `--visible-h` / `--visible-bottom`, the panel's own two properties
(declared in `web/chat-panel`, kept in step with `visualViewport` by
`static/chat.js`, and the whole viewport where no script runs — which is what
the side panel always was). The home-bar inset is padded for only where no
keyboard covers it: `max(0px, calc(env(safe-area-inset-bottom) - var(--visible-bottom)))`.
The page also asks for the declarative half, `interactive-widget=resizes-content`,
which is the entire fix wherever it is honoured; iOS ignores it.

**Sheet mode is one block** at the end of `web/chat-panel`: below `phone-max`
the panel is full-bleed with no left border, and its controls are `touch-min`
(2.75rem — the number the floating toggle already kept, now one binding in
`web/theme`) with a 16px input. The one rule it cannot hold is the outline's
gutter, whose subject is another module's class; that sits in the `'overlay`
fragment and says it is the same mode. Sheet mode touches no `display` — the
panel's own states own that, and a phone-width rule landing after them would
show the stop button while idle.

**Desktop is unchanged**, measured before and after at 1280x800: panel 422px
wide, full height, `.ol-main` gutter 446.4px, 14px input, 25x29 buttons.

## Tests

* `olai/tests/style.rkt`: the panel's box is the visible viewport (and not
  `top: 0` again); everything phone-width about the panel is in exactly two
  fragments (sheet + gutter, one per layer); and a new border with the scripts
  — every custom property a `.js` spells is one of the skin's tokens, which is
  what pins `--visible-*` to `chat.js`. `pwa.js` joins the scanned scripts; it
  was missing from that list.
* `e2e/features/mobile.feature`: the harness merged while this was in flight,
  so the scenario is here rather than described. `@phone` is the second thing a
  scenario can ask the machine for (next to `@stored-sessions`) — a 390x844
  context. Two of the three scenarios fail on master; the third is the desktop
  gutter scenario read the other way. Chromium has no keyboard to raise, so the
  step says what a keyboard IS to a page (the visual viewport shrinks, the
  layout viewport does not) — which a page that listens to `visualViewport`
  cannot tell from the real thing.

`just test` (199) and `just e2e` (38 scenarios) green locally.

## Known gap

A phone in LANDSCAPE is 844px wide, so it is above `phone-max` and keeps the
desktop side panel: the keyboard fix applies there (the panel is sized by the
visible strip at every width), but the 44px targets and the 16px input do not.
Keyed on width because that is the skin's one breakpoint vocabulary
(`.ol-toggle` and `.ol-check` size up the same way); the honest condition for
those two is `pointer: coarse`, and if the landscape case bites, that is the
one-line follow-up.