### PR TITLE
docs: full Markdown across every .md (format only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,90 +1,42 @@
 # CLAUDE.md
 
-Read README.md and docs/*.md first (especially docs/hacking.md for the
-edit-verify loop and css-expr). This file is only what you can't infer.
+Read [README.md](README.md) and `docs/*.md` first (especially [docs/hacking.md](docs/hacking.md) for the edit-verify loop and css-expr). This file is only what you can't infer.
 
 ## HARD RULES
 
-* If your model is Fable, a) use subagents for implementation (typically
-  Opus), b) reserve Fable only where truly necessary.
-* Personal outline DATA lives outside the repo, in `$OLAI_HOME` —
-  `Tasks.rkt`, `Daily.rkt` (+ `Daily/`). No default path: unset is a usage
-  error, and the repo never names anyone's data dir. NEVER commit or invent
-  content for these; user-owned, re-validate after edits. `examples/` is demo
-  fiction for CI. `Roadmap.rkt` is public, at repo root, committed and
-  re-validated like any file — a private `Tasks.rkt` may `@include` it.
-* No hand-rolling where a maintained library exists. In use: racket/cmdline,
-  json (write-json/read-json), xml (xexprs), gregor (dates), markdown
-  (title/note formatting in the web view only).
-* No ANSI, no plain mode. Human view is the web app: `olai serve` (routes in
-  docs/cli.md; `just serve` launches it). The CLI is the agent surface and
-  the write-safety layer: every command answers JSON but `ics` (the format
-  IS the reply) and `serve`. `--json` is accepted everywhere it used to be,
-  and does nothing.
-* The LANGUAGE is the only validator (closed grammar): one checker
-  (lang/graph) runs over a module's syntax at compile time, and over the whole
-  spliced tree at run time when it has `@include`s (cross-file anchors exist
-  only after the splice). Same rules, same messages, both ways. Readers just
-  translate to (t ...) forms. Never validate in the reader, the CLI, the
-  store, or the web layer.
-* Agents are the only CLI users: replies and errors are JSON (errors on
-  stderr); exit codes are contract (see docs/cli.md). JSON fields are
-  append-only within a "version".
-* Error messages carry file:line:col of the OFFENDING form. srcloc fidelity
-  has tests; keep them passing.
-* Module boundaries ship with `contract-out` (flat, cheap checks — never a
-  tree walk); blame + srcloc are part of the error contract, and have tests.
-* Markdown is render-time only (web view). Strings in the struct/JSON stay
-  verbatim.
-* Code organization/review: https://kolu.dev/blog/hickey-lowy/ — separate
-  spatial (complected concepts, Hickey) and temporal (volatility mismatches,
-  Lowy) passes; ship only when both lenses go quiet.
+* If your model is Fable, a) use subagents for implementation (typically Opus), b) reserve Fable only where truly necessary.
+* Personal outline DATA lives outside the repo, in `$OLAI_HOME` — `Tasks.rkt`, `Daily.rkt` (+ `Daily/`). No default path: unset is a usage error, and the repo never names anyone's data dir. NEVER commit or invent content for these; user-owned, re-validate after edits. `examples/` is demo fiction for CI. `Roadmap.rkt` is public, at repo root, committed and re-validated like any file — a private `Tasks.rkt` may `@include` it.
+* No hand-rolling where a maintained library exists. In use: `racket/cmdline`, `json` (`write-json`/`read-json`), `xml` (xexprs), `gregor` (dates), `markdown` (title/note formatting in the web view only).
+* No ANSI, no plain mode. Human view is the web app: `olai serve` (routes in [docs/cli.md](docs/cli.md); `just serve` launches it). The CLI is the agent surface and the write-safety layer: every command answers JSON but `ics` (the format IS the reply) and `serve`. `--json` is accepted everywhere it used to be, and does nothing.
+* The LANGUAGE is the only validator (closed grammar): one checker (`lang/graph`) runs over a module's syntax at compile time, and over the whole spliced tree at run time when it has `@include`s (cross-file anchors exist only after the splice). Same rules, same messages, both ways. Readers just translate to `(t ...)` forms. Never validate in the reader, the CLI, the store, or the web layer.
+* Agents are the only CLI users: replies and errors are JSON (errors on stderr); exit codes are contract (see [docs/cli.md](docs/cli.md)). JSON fields are append-only within a `"version"`.
+* Error messages carry `file:line:col` of the OFFENDING form. srcloc fidelity has tests; keep them passing.
+* Module boundaries ship with `contract-out` (flat, cheap checks — never a tree walk); blame + srcloc are part of the error contract, and have tests.
+* Markdown is render-time only (web view). Strings in the struct/JSON stay verbatim.
+* Code organization/review: [kolu.dev/blog/hickey-lowy](https://kolu.dev/blog/hickey-lowy/) — separate spatial (complected concepts, Hickey) and temporal (volatility mismatches, Lowy) passes; ship only when both lenses go quiet.
 
 ## LAYERING
 
-* lang/ readers -> lang/expander (t forms, closed grammar) -> task struct
-* main.rkt exports data model + pure queries + web render. CLI is app code,
-  not library. Pure logic takes `today` as an argument (testable, no clocks).
-* Writes live in ops.rkt (add/done/move/daily -> result struct, or an
-  exn:fail:op naming a kind). cli.rkt is a shell: parse, call an op, render,
-  map kind -> exit code. The web mutation routes will call the same ops.
-* Node keys are minted in the load layer, not the expander (see docs/cli.md);
-  store.rkt owns snapshots and binds mirror sites before anything draws them.
-  index.rkt inverts the keys (key -> node + its parent's key) and derives the
-  trail above a node on demand — what /n/<key> and its breadcrumbs are drawn
-  from. Addressing is not snapshotting: the store builds one index per load
-  and asks it nothing.
-* Live view: store (what) -> web/watch.rkt (when) -> web/events.rkt (generic
-  SSE hub); they meet only in serve.rkt, and the chat rides the same hub.
-* olai/acp.rkt speaks ACP: one subprocess, typed events out of one
-  handler, no web/. web/chat.rkt makes those events a conversation — one turn
-  at a time, chat frames, transcript. Nothing else spells either.
-* Core must build without web/: file naming is olai/paths (file-label,
-  key-label), not a renderer helper.
-* JSON is two modules, two version counters: json/model (what a node/tree IS,
-  durable) and json/reply (command envelopes, agenda, calendar).
-* CSS cascade = layer ('base | 'component | 'overlay) then instantiation
-  order; a class is defined in the module that DRAWS it. No native @layer.
-* web/skin.rkt composes the sheet (require order = cascade) and owns its URL;
-  render-page is TOLD the href, so nothing downstream requires skin.
+* `lang/` readers -> `lang/expander` (`t` forms, closed grammar) -> task struct
+* `main.rkt` exports data model + pure queries + web render. CLI is app code, not library. Pure logic takes `today` as an argument (testable, no clocks).
+* Writes live in `ops.rkt` (`add`/`done`/`move`/`daily` -> result struct, or an `exn:fail:op` naming a kind). `cli.rkt` is a shell: parse, call an op, render, map kind -> exit code. The web mutation routes will call the same ops.
+* Node keys are minted in the load layer, not the expander (see [docs/cli.md](docs/cli.md)); `store.rkt` owns snapshots and binds mirror sites before anything draws them. `index.rkt` inverts the keys (key -> node + its parent's key) and derives the trail above a node on demand — what `/n/<key>` and its breadcrumbs are drawn from. Addressing is not snapshotting: the store builds one index per load and asks it nothing.
+* Live view: store (what) -> `web/watch.rkt` (when) -> `web/events.rkt` (generic SSE hub); they meet only in `serve.rkt`, and the chat rides the same hub.
+* `olai/acp.rkt` speaks ACP: one subprocess, typed events out of one handler, no `web/`. `web/chat.rkt` makes those events a conversation — one turn at a time, chat frames, transcript. Nothing else spells either.
+* Core must build without `web/`: file naming is `olai/paths` (`file-label`, `key-label`), not a renderer helper.
+* JSON is two modules, two version counters: `json/model` (what a node/tree IS, durable) and `json/reply` (command envelopes, agenda, calendar).
+* CSS cascade = layer (`'base` | `'component` | `'overlay`) then instantiation order; a class is defined in the module that DRAWS it. No native `@layer`.
+* `web/skin.rkt` composes the sheet (require order = cascade) and owns its URL; `render-page` is TOLD the href, so nothing downstream requires skin.
 
 ## WORKFLOW
 
-* just check / serve / test / ci — recipes handle PLTUSERHOME + raco link.
-  Racket comes from the nix dev shell (nixpkgs 9.2). Don't fight raco setup;
-  PLTUSERHOME must be writable.
-* `just test` runs `just build` first (`raco setup --pkgs olai`) so
-  compiled/*.zo exist and stay coherent after edits. `just install` alone
-  does not recompile. Linklet mismatch → `just clean && just build` (see
-  docs/hacking.md). Repo-specific facts agents rediscover otherwise live
-  in docs/hacking.md — read it before probing css-expr or the toolchain.
-* `just test` is the only test command you run. It is the fast set; CI
-  runs everything else on the PR.
-* Branch + PR for every change (agents included); CI green before merge.
-  Master rejects direct pushes.
-* CI = https://github.com/juspay/odu/blob/master/.apm/skills/odu/SKILL.md 
+* `just check` / `serve` / `test` / `ci` — recipes handle `PLTUSERHOME` + `raco link`. Racket comes from the nix dev shell (nixpkgs 9.2). Don't fight `raco setup`; `PLTUSERHOME` must be writable.
+* `just test` runs `just build` first (`raco setup --pkgs olai`) so `compiled/*.zo` exist and stay coherent after edits. `just install` alone does not recompile. Linklet mismatch → `just clean && just build` (see [docs/hacking.md](docs/hacking.md)). Repo-specific facts agents rediscover otherwise live in [docs/hacking.md](docs/hacking.md) — read it before probing css-expr or the toolchain.
+* `just test` is the only test command you run. It is the fast set; CI runs everything else on the PR.
+* Branch + PR for every change (agents included); CI green before merge. Master rejects direct pushes.
+* CI = [juspay/odu `.apm/skills/odu/SKILL.md`](https://github.com/juspay/odu/blob/master/.apm/skills/odu/SKILL.md)
   * GitHub Workflows may eventually be retired in favour of Odu; so look for Odu status checks green.
-* Tests parse JSON output with read-json. Never string-match JSON.
+* Tests parse JSON output with `read-json`. Never string-match JSON.
 
 ## VOICE
 

--- a/README.md
+++ b/README.md
@@ -4,43 +4,28 @@
 
 # olai
 
-ஓலை: the palm leaf Tamil was written on for two millennia — nodes are
-leaves, your files are the manuscript.
+ஓலை: the palm leaf Tamil was written on for two millennia — nodes are leaves, your files are the manuscript.
 
 An outliner for people who think the filesystem was right all along.
 
-Self-hosted, AI-native alternative to Workflowy. Your outline is a bunch
-of `#lang olai` files in a git repo. You edit them with `$EDITOR` or
-point a coding agent at them. A small Racket server renders the tree to
-your phone. That's it. No cloud, no accounts, no Electron.
+Self-hosted, AI-native alternative to Workflowy. Your outline is a bunch of `#lang olai` files in a git repo. You edit them with `$EDITOR` or point a coding agent at them. A small Racket server renders the tree to your phone. That's it. No cloud, no accounts, no Electron.
 
 ## WHY
 
-Workflowy got the data model right (one big tree, mirrors, dates) and
-the ownership model wrong (their server, their format, their AI).
+Workflowy got the data model right (one big tree, mirrors, dates) and the ownership model wrong (their server, their format, their AI).
 
 olai inverts it:
 
-  * tasks are CODE      -- a Racket #lang; the expander is the validator
-  * git is the HISTORY  -- no sync protocol, no CRDT, no vendor
-  * agents are USERS    -- Claude Code & friends edit your files; the
-                           DSL's error messages are their REPL. The web
-                           view spawns one over ACP and puts it in a
-                           chat panel.
-  * the web UI is a VIEW -- htmx, pushed over SSE: save a file and every
-                           open tab redraws itself. It still does not
-                           WRITE — capture and check-off in the browser
-                           are next. Until then the chat panel is how
-                           you change an outline without an editor.
+* tasks are CODE -- a Racket `#lang`; the expander is the validator
+* git is the HISTORY -- no sync protocol, no CRDT, no vendor
+* agents are USERS -- Claude Code & friends edit your files; the DSL's error messages are their REPL. The web view spawns one over ACP and puts it in a chat panel.
+* the web UI is a VIEW -- htmx, pushed over SSE: save a file and every open tab redraws itself. It still does not WRITE — capture and check-off in the browser are next. Until then the chat panel is how you change an outline without an editor.
 
-Mirrors fall out of the language for free: a node is a binding,
-referencing it twice is a mirror. define-before-use kills most cycles
-before they exist.
+Mirrors fall out of the language for free: a node is a binding, referencing it twice is a mirror. define-before-use kills most cycles before they exist.
 
 ## SYNTAX
 
-Quoteless outline (flagship). Nest with 2 spaces; attach notes and dates
-under a title:
+Quoteless outline (flagship). Nest with 2 spaces; attach notes and dates under a title:
 
 ```racket
 #lang olai
@@ -55,10 +40,7 @@ Inbox #capture
     @done 2026-08-03
 ```
 
-Titles and notes are Markdown at **render** time (web view only); stored
-strings stay raw. Check off with `[x] ` OR `@done` — one node, one of them
-(or `olai done TITLE`). `[/] ` / `@doing` is the state in between, same rules
-(`olai doing TITLE`); done clears it. Full rules: `docs/syntax.md`.
+Titles and notes are Markdown at **render** time (web view only); stored strings stay raw. Check off with `[x] ` OR `@done` — one node, one of them (or `olai done TITLE`). `[/] ` / `@doing` is the state in between, same rules (`olai doing TITLE`); done clears it. Full rules: [docs/syntax.md](docs/syntax.md).
 
 Under the hood every outline becomes s-expressions. Same expander:
 
@@ -89,46 +71,19 @@ racket web-server --- spawns ---> ACP agent (Claude Code; JSON-RPC on stdio)
     +-- PWA: installable (manifest + icons); live view only, no offline shell
 ```
 
-Personal outlines are plain files you sync however you like (Dropbox,
-git, rsync). The repo holds the tool; your data stays outside it — point
-`OLAI_HOME` at that directory. Without it the repo serves its own
-`examples/` plus `Roadmap.rkt`, and the write commands ask you to set it.
-`add` / `done` / `doing` / `move` / `daily` auto-commit only when the written
-file's dir is a git work tree; otherwise they write the file and leave
-history to your sync layer.
+Personal outlines are plain files you sync however you like (Dropbox, git, rsync). The repo holds the tool; your data stays outside it — point `OLAI_HOME` at that directory. Without it the repo serves its own `examples/` plus `Roadmap.rkt`, and the write commands ask you to set it. `add` / `done` / `doing` / `move` / `daily` auto-commit only when the written file's dir is a git work tree; otherwise they write the file and leave history to your sync layer.
 
-Single user, many devices. The server runs on your headless box behind
-Caddy or Tailscale. Install the web view as a PWA on your phone; it still
-needs the network (SSE + agent). Live with it, or open your laptop.
+Single user, many devices. The server runs on your headless box behind Caddy or Tailscale. Install the web view as a PWA on your phone; it still needs the network (SSE + agent). Live with it, or open your laptop.
 
 ## STATUS
 
-Outline `#lang olai` + sexp core + agent CLI (`check` / `tree` / `agenda` /
-`calendar` / `add` / `done` / `doing` / `move` / `daily` / `ics` / `serve` —
-all JSON but `ics` and `serve`; the human-facing plain output and the `css`
-dump are retired). Three node states (open / doing / done), mirrors and
-`@include` composition are first class; the agenda groups what is in flight
-above what is due today, and mirrors reach anchors anywhere in the loaded
-tree, fragments included. The
-human view is the web app served by `olai serve` — htmx, no auth (bind
-it to localhost or Tailscale). Every node has a permalink that zooms to
-it, breadcrumbs and all. It reloads an outline when the file changes
-and pushes that over SSE, so open tabs redraw with no refresh, and it carries
-a chat panel driving Claude Code over ACP (`OLAI_ACP_AGENT`). Installable
-as a PWA (manifest, icons, theme-color; no offline shell). The page itself
-still writes nothing; there is no static HTML export. (Ancestor: srid/Tend.)
+Outline `#lang olai` + sexp core + agent CLI (`check` / `tree` / `agenda` / `calendar` / `add` / `done` / `doing` / `move` / `daily` / `ics` / `serve` — all JSON but `ics` and `serve`; the human-facing plain output and the `css` dump are retired). Three node states (open / doing / done), mirrors and `@include` composition are first class; the agenda groups what is in flight above what is due today, and mirrors reach anchors anywhere in the loaded tree, fragments included. The human view is the web app served by `olai serve` — htmx, no auth (bind it to localhost or Tailscale). Every node has a permalink that zooms to it, breadcrumbs and all. It reloads an outline when the file changes and pushes that over SSE, so open tabs redraw with no refresh, and it carries a chat panel driving Claude Code over ACP (`OLAI_ACP_AGENT`). Installable as a PWA (manifest, icons, theme-color; no offline shell). The page itself still writes nothing; there is no static HTML export. (Ancestor: srid/Tend.)
 
 ## ROADMAP
 
-The project tracks its own plan the same way it wants you to track yours:
-`Roadmap.rkt` at the repo root is a `#lang olai` outline, edited and
-committed like any other file. `olai tree Roadmap.rkt` gives the JSON view.
+The project tracks its own plan the same way it wants you to track yours: `Roadmap.rkt` at the repo root is a `#lang olai` outline, edited and committed like any other file. `olai tree Roadmap.rkt` gives the JSON view.
 
-Track your own plan as a `#lang olai` outline wherever you like
-(`$OLAI_HOME`) — a private `Tasks.rkt` can `@include` the repo's
-`Roadmap.rkt` to pull it into your own outline; that's exactly what the
-author does. Repo demos live in `examples/` (see `examples/Daily.rkt` for
-`@include` composition).
+Track your own plan as a `#lang olai` outline wherever you like (`$OLAI_HOME`) — a private `Tasks.rkt` can `@include` the repo's `Roadmap.rkt` to pull it into your own outline; that's exactly what the author does. Repo demos live in `examples/` (see `examples/Daily.rkt` for `@include` composition).
 
 ## BUILDING
 
@@ -147,34 +102,21 @@ just clean                       # drop olai/**/compiled
 just css-classes                 # regenerate olai/tests/classes.golden
 ```
 
-`olai serve DIR` serves `DIR/*.rkt` and runs the agent in `DIR`
-(default: `$PWD`; `just serve` passes `$OLAI_HOME`, or names the repo's
-own outlines when it is unset). Naming files instead still works — see
-docs/cli.md.
+`olai serve DIR` serves `DIR/*.rkt` and runs the agent in `DIR` (default: `$PWD`; `just serve` passes `$OLAI_HOME`, or names the repo's own outlines when it is unset). Naming files instead still works — see [docs/cli.md](docs/cli.md).
 
-`serve` refuses to start without `OLAI_ACP_AGENT` — the path to an
-executable speaking the Agent Client Protocol. The Nix package defaults it
-to the bundled, pinned Claude Code adapter (`--set-default`); `nix develop`
-(hence `just serve`) exports the same. Outside nix, export it yourself.
+`serve` refuses to start without `OLAI_ACP_AGENT` — the path to an executable speaking the Agent Client Protocol. The Nix package defaults it to the bundled, pinned Claude Code adapter (`--set-default`); `nix develop` (hence `just serve`) exports the same. Outside nix, export it yourself.
 
 ## CLI (agents)
 
-Machine-readable contract (JSON shapes, exit codes, `add`): **docs/cli.md**.
-No ANSI, no plain mode — the CLI is the agent surface and the write-safety
-layer, and it answers in JSON. Humans use the web app.
+Machine-readable contract (JSON shapes, exit codes, `add`): **[docs/cli.md](docs/cli.md)**. No ANSI, no plain mode — the CLI is the agent surface and the write-safety layer, and it answers in JSON. Humans use the web app.
 
 ## HACKING
 
-**No hand-rolling where a library exists.** Prefer maintained packages
-(`racket/cmdline`, `json`, `gregor`, `markdown`, `xml` xexprs,
-`web-server` for routing and static files) over home-grown parsers,
-routers and escape codes.
+**No hand-rolling where a library exists.** Prefer maintained packages (`racket/cmdline`, `json`, `gregor`, `markdown`, `xml` xexprs, `web-server` for routing and static files) over home-grown parsers, routers and escape codes.
 
-Toolchain traps, css-expr spelling, and the stale-`.zo` symptom:
-**docs/hacking.md**.
+Toolchain traps, css-expr spelling, and the stale-`.zo` symptom: **[docs/hacking.md](docs/hacking.md)**.
 
-Patches welcome. Keep it small, keep it boring. The interesting part is
-the DSL; write good expander error messages -- the agents read them.
+Patches welcome. Keep it small, keep it boring. The interesting part is the DSL; write good expander error messages -- the agents read them.
 
 ## LICENSE
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,14 +1,8 @@
 # olai CLI — agent contract
 
-Agents are the only users. Every command that has a reply emits **JSON**,
-always — `--json` is still accepted and does nothing. Fields within a
-`version` are **append-only**; a bump of `version` is a breaking change.
+Agents are the only users. Every command that has a reply emits **JSON**, always — `--json` is still accepted and does nothing. Fields within a `version` are **append-only**; a bump of `version` is a breaking change.
 
-**Human view is the web app** (`olai/web`). There is no ANSI terminal tree, no
-static HTML export, and no plain-text mode: what was printed for a person to
-read at a terminal is gone. Two commands do not answer JSON — `ics`, whose
-output IS a format (RFC 5545), and `serve`, which serves the web view. Their
-errors are `olai: message` on stderr.
+**Human view is the web app** (`olai/web`). There is no ANSI terminal tree, no static HTML export, and no plain-text mode: what was printed for a person to read at a terminal is gone. Two commands do not answer JSON — `ics`, whose output IS a format (RFC 5545), and `serve`, which serves the web view. Their errors are `olai: message` on stderr.
 
 ## Exit codes
 
@@ -19,19 +13,12 @@ errors are `olai: message` on stderr.
 | 2 | the outline said no: load or validation error, no such task, ambiguous title, already done, a write aimed at a `#lang olai/sexp` file |
 | 3 | file not found |
 
-The write commands know nothing about exit codes: an op (`olai/ops`) fails with
-a KIND — usage, validation, not-found — and the CLI maps the kind to a code.
-The codes are the contract; the kinds are how the layer below talks about
-failure.
+The write commands know nothing about exit codes: an op (`olai/ops`) fails with a KIND — usage, validation, not-found — and the CLI maps the kind to a code. The codes are the contract; the kinds are how the layer below talks about failure.
 
 ## Global
 
-- Default outline file when no paths given: `$OLAI_HOME/Tasks.rkt`.
-  `add` / `done` / `doing` / `move` always target one file via `--file`, same
-  default.
-- **`OLAI_HOME` has no default.** Unset, any command that would need it —
-  the file defaults above, `daily` without `--home` — is a **usage error**
-  (exit 1, the error object on stderr), nothing is read or written:
+- Default outline file when no paths given: `$OLAI_HOME/Tasks.rkt`. `add` / `done` / `doing` / `move` always target one file via `--file`, same default.
+- **`OLAI_HOME` has no default.** Unset, any command that would need it — the file defaults above, `daily` without `--home` — is a **usage error** (exit 1, the error object on stderr), nothing is read or written:
 
   ```json
   {"version":1,"ok":false,
@@ -40,18 +27,9 @@ failure.
   ```
 
   Naming files (or `--file` / `--home`) works with the variable unset.
-- **Read commands** (`check` / `tree` / `agenda` / `calendar` / `ics` /
-  `serve`) accept **one or more** outline paths. The justfile defaults to
-  `$OLAI_HOME/*.rkt`, or the repo's own `examples/Example.rkt Roadmap.rkt`
-  when `OLAI_HOME` is unset. `serve` also takes the DIRECTORY and globs it
-  itself — that is its front door, see below.
-- Personal data lives outside the repo, in the directory `OLAI_HOME`
-  names. Auto-commit (`add` / `done` / `doing` / `move` / `daily`) only runs
-  when the directory of the file actually written is a git work tree;
-  otherwise it no-ops (`committed: false`) and Dropbox (or your sync) is the history layer.
-- `--json` may appear after the subcommand everywhere it used to; it is a
-  no-op, kept so an invocation an agent already knows does not become a
-  usage error.
+- **Read commands** (`check` / `tree` / `agenda` / `calendar` / `ics` / `serve`) accept **one or more** outline paths. The justfile defaults to `$OLAI_HOME/*.rkt`, or the repo's own `examples/Example.rkt Roadmap.rkt` when `OLAI_HOME` is unset. `serve` also takes the DIRECTORY and globs it itself — that is its front door, see below.
+- Personal data lives outside the repo, in the directory `OLAI_HOME` names. Auto-commit (`add` / `done` / `doing` / `move` / `daily`) only runs when the directory of the file actually written is a git work tree; otherwise it no-ops (`committed: false`) and Dropbox (or your sync) is the history layer.
+- `--json` may appear after the subcommand everywhere it used to; it is a no-op, kept so an invocation an agent already knows does not become a usage error.
 
 ## `check [file ...]`
 
@@ -63,10 +41,7 @@ Validate `#lang olai` or `#lang olai/sexp` module(s).
 {"version":1,"ok":true,"file":".../Example.rkt","tasks":12,"anchors":1,"mirrors":1}
 ```
 
-`tasks` counts each defining node once (mirrors do not inflate the count).
-`anchors` / `mirrors` are counts of `^id` declarations and `*id` sites. A file
-that splices `@include` fragments also carries `includes` — absent, not empty,
-when there are none:
+`tasks` counts each defining node once (mirrors do not inflate the count). `anchors` / `mirrors` are counts of `^id` declarations and `*id` sites. A file that splices `@include` fragments also carries `includes` — absent, not empty, when there are none:
 
 ```json
 {"version":1,"ok":true,"file":".../IncludeRoot.rkt","tasks":6,"anchors":1,
@@ -87,9 +62,7 @@ when there are none:
 }
 ```
 
-Top-level `ok` is false if any file failed. Per-file errors ride in the array
-on **stdout** and nothing goes to stderr — the single-file shape is the one
-that reports on stderr (see *Errors*). Exit is still 2.
+Top-level `ok` is false if any file failed. Per-file errors ride in the array on **stdout** and nothing goes to stderr — the single-file shape is the one that reports on stderr (see [Errors](#errors)). Exit is still 2.
 
 ## `tree [file ...]`
 
@@ -123,13 +96,9 @@ Single file:
 }
 ```
 
-Mirror sites in `children` are `{"mirror":"agent"}` — never an inlined subtree.
-The `anchors` object holds each anchored node once (same shape as a task).
+Mirror sites in `children` are `{"mirror":"agent"}` — never an inlined subtree. The `anchors` object holds each anchored node once (same shape as a task).
 
-A root that splices `@include` fragments also carries `includes`
-(`[{"file":"..."}]`, absent when there are none), and every node whose
-**defining** file differs from the loaded file carries its own `file` — that is
-where writes go (see *Write routing under `@include`*).
+A root that splices `@include` fragments also carries `includes` (`[{"file":"..."}]`, absent when there are none), and every node whose **defining** file differs from the loaded file carries its own `file` — that is where writes go (see [Write routing under `@include`](#write-routing-under-include)).
 
 Multiple files:
 
@@ -146,48 +115,22 @@ Multiple files:
 }
 ```
 
-`date` / `description` are raw strings or `null` (Markdown is not interpreted
-here). `done` and `doing` are the stored marks: `null` (not in that state),
-`true` (marked, no timestamp), or an ISO timestamp string. A node carries at
-most one of them — the language rejects both. `status` is what they MEAN —
-`"open"`, `"doing"` or `"done"` — and is the one to switch on: it is where a
-future state would show up, while `done` / `doing` keep their type. `id` is
-`null` or the anchor string. `tags` is always an array.
+`date` / `description` are raw strings or `null` (Markdown is not interpreted here). `done` and `doing` are the stored marks: `null` (not in that state), `true` (marked, no timestamp), or an ISO timestamp string. A node carries at most one of them — the language rejects both. `status` is what they MEAN — `"open"`, `"doing"` or `"done"` — and is the one to switch on: it is where a future state would show up, while `done` / `doing` keep their type. `id` is `null` or the anchor string. `tags` is always an array.
 
-`key` is the node's stable identity — its `^anchor` when it has one, else a
-hash of its **defining** file plus the child ordinals that reach it inside
-that file. Only the anchor case comes from the expander (a module sees one
-entry point and would key a spliced node twice); the rest are minted by the
-load layer, over the whole set of files you loaded, at once. A key survives
-renaming the node or any ancestor and cannot collide between same-titled
-siblings; it changes when siblings are reordered (anchor the node if you need
-more). Because the file is the one that DEFINES the node, an `@include`d node
-keys the same through any root that includes it, and two roots sharing a
-fragment agree about it.
+`key` is the node's stable identity — its `^anchor` when it has one, else a hash of its **defining** file plus the child ordinals that reach it inside that file. Only the anchor case comes from the expander (a module sees one entry point and would key a spliced node twice); the rest are minted by the load layer, over the whole set of files you loaded, at once. A key survives renaming the node or any ancestor and cannot collide between same-titled siblings; it changes when siblings are reordered (anchor the node if you need more). Because the file is the one that DEFINES the node, an `@include`d node keys the same through any root that includes it, and two roots sharing a fragment agree about it.
 
-The file's name inside that hash is its path **relative to the common
-directory of the loaded set** — so two roots named `Daily.rkt` in different
-directories do not collide, and moving the whole outline home does not re-key
-it. The corollary is that the base moves with the set: load a nested fragment
-as its own root and its label re-bases, so its nodes key differently than they
-do under the root that includes them.
+The file's name inside that hash is its path **relative to the common directory of the loaded set** — so two roots named `Daily.rkt` in different directories do not collide, and moving the whole outline home does not re-key it. The corollary is that the base moves with the set: load a nested fragment as its own root and its label re-bases, so its nodes key differently than they do under the root that includes them.
 
-```console
+```bash
 $ olai tree examples/Daily.rkt           # "Setup day" -> p8cfece7b
 $ olai tree examples/Daily/2026-08.rkt   # "Setup day" -> p3dd3c447
 ```
 
-Load the files you always load (`serve` keys against the set it was given) and
-keys are stable. The web view addresses nodes by this key (element ids,
-permalinks, stored collapse state).
+Load the files you always load (`serve` keys against the set it was given) and keys are stable. The web view addresses nodes by this key (element ids, permalinks, stored collapse state).
 
 ## `agenda [file ...]`
 
-What is on the plate, relative to local today, **merged across all given
-files**. **Done tasks are excluded** even if they still have a `@date`. When
-more than one file is given, breadcrumbs are rooted at each file's basename
-(`Tasks.rkt > Inbox > Buy milk`). All four arrays are always present, possibly
-empty.
+What is on the plate, relative to local today, **merged across all given files**. **Done tasks are excluded** even if they still have a `@date`. When more than one file is given, breadcrumbs are rooted at each file's basename (`Tasks.rkt > Inbox > Buy milk`). All four arrays are always present, possibly empty.
 
 Stdout:
 
@@ -203,23 +146,13 @@ Stdout:
 }
 ```
 
-`doing` sits above `today_items` in the reading order the groups have.
-An item's `status` is why it is in the group it is in: `"open"` for the three
-date buckets, `"doing"` for that one.
+`doing` sits above `today_items` in the reading order the groups have. An item's `status` is why it is in the group it is in: `"open"` for the three date buckets, `"doing"` for that one.
 
-A node in flight is on the agenda **whether or not anyone dated it** — that is
-the point of the group — so `date` is `null` there where the date buckets
-always have one, and a dated `@doing` node appears in `doing` and nowhere
-else. Within the group, dated items come first by date and undated ones follow
-in tree order.
+A node in flight is on the agenda **whether or not anyone dated it** — that is the point of the group — so `date` is `null` there where the date buckets always have one, and a dated `@doing` node appears in `doing` and nowhere else. Within the group, dated items come first by date and undated ones follow in tree order.
 
 ## `calendar [--month YYYY-MM] [file ...]`
 
-Group **dated** tasks by calendar day for one month (default: current).
-**Done tasks are included** (JSON `done` is `true` or a timestamp, `status` is
-`"done"`). Days that
-have a bare-ISO day node in Daily-style outlines set `day_node: true` (for
-web deep-links). Multi-file merge like agenda.
+Group **dated** tasks by calendar day for one month (default: current). **Done tasks are included** (JSON `done` is `true` or a timestamp, `status` is `"done"`). Days that have a bare-ISO day node in Daily-style outlines set `day_node: true` (for web deep-links). Multi-file merge like agenda.
 
 ```json
 {
@@ -240,174 +173,66 @@ web deep-links). Multi-file merge like agenda.
 
 ## `serve [--port N] [--bind ADDR] [DIR | file ...]`
 
-Run the web view over an outline directory. Blocks until Ctrl-C, which shuts
-the listener down cleanly.
+Run the web view over an outline directory. Blocks until Ctrl-C, which shuts the listener down cleanly.
 
-**A DIRECTORY is the front door** — one argument that is a directory, or no
-argument at all, which means `$PWD`. The roots are that directory's `*.rkt` at
-the **top level only** (`@include` fragments live in subdirectories, so a
-recursive walk would load every one of them twice), sorted, so the node keys
-minted against the set are stable. The glob is evaluated once at startup: a new
-top-level file is picked up by restarting, not while running. A directory with
-no `*.rkt` in it is refused, naming the directory, exit 3. `just serve` is this
-form over `$OLAI_HOME` (with it unset, `just serve` names the repo's own
-outlines instead).
+**A DIRECTORY is the front door** — one argument that is a directory, or no argument at all, which means `$PWD`. The roots are that directory's `*.rkt` at the **top level only** (`@include` fragments live in subdirectories, so a recursive walk would load every one of them twice), sorted, so the node keys minted against the set are stable. The glob is evaluated once at startup: a new top-level file is picked up by restarting, not while running. A directory with no `*.rkt` in it is refused, naming the directory, exit 3. `just serve` is this form over `$OLAI_HOME` (with it unset, `just serve` names the repo's own outlines instead).
 
-The agent runs **in that directory** — exactly it, not the base derived from
-the files. That is the point of the form: Claude Code keys its stored sessions
-by the directory it was started in, so a stable one is what makes "the session
-you were last in" a thing that survives a restart (see *Sessions* below).
+The agent runs **in that directory** — exactly it, not the base derived from the files. That is the point of the form: Claude Code keys its stored sessions by the directory it was started in, so a stable one is what makes "the session you were last in" a thing that survives a restart (see [Sessions](#sessions) below).
 
-```console
+```text
 $ olai serve ~/notes
 olai serve http://127.0.0.1:8080 dir: /home/me/notes files: /.../Daily.rkt /.../Tasks.rkt
 ```
 
-**Explicit `.rkt` files are the plumbing** — the roots are those files, and the
-agent works from the directory they hang off (one file: its directory; several:
-the deepest directory holding all of them, the base keys are minted against).
+**Explicit `.rkt` files are the plumbing** — the roots are those files, and the agent works from the directory they hang off (one file: its directory; several: the deepest directory holding all of them, the base keys are minted against).
 
-```console
+```text
 $ olai serve examples/Example.rkt
 olai serve http://127.0.0.1:8080 files: /.../examples/Example.rkt
 ```
 
-- `--port N` — default `8080`. `0` binds a free port and logs which one. The
-  default is a preference: with `8080` taken, `serve` binds a free port
-  instead, says so on stderr (`olai: port 8080 is taken; serving on 41235`),
-  and the URL it prints is the port it actually bound. A port you typed is a
-  request — taken, `serve` refuses to start (exit 1).
-  The printed URL is a contract: the e2e harness reads the port back out of
-  it (`e2e/support/server.js`), which is how a scenario gets a server nobody
-  else can collide with.
+- `--port N` — default `8080`. `0` binds a free port and logs which one. The default is a preference: with `8080` taken, `serve` binds a free port instead, says so on stderr (`olai: port 8080 is taken; serving on 41235`), and the URL it prints is the port it actually bound. A port you typed is a request — taken, `serve` refuses to start (exit 1). The printed URL is a contract: the e2e harness reads the port back out of it (`e2e/support/server.js`), which is how a scenario gets a server nobody else can collide with.
 - `--bind ADDR` — default `127.0.0.1`. `--bind ""` listens on all interfaces.
 - **No auth.** The network is the auth: put it behind Tailscale or Caddy.
 
-**`OLAI_ACP_AGENT`** is an absolute path to an executable that speaks the
-[Agent Client Protocol](https://agentclientprotocol.com/) on stdio; `serve`
-spawns it as a subprocess. There is no PATH lookup: with the variable unset
-(or pointing at something that is not executable) the server refuses to start.
-The Nix package is self-sufficient — `makeWrapper --set-default` bakes the
-bundled Claude Code adapter (`packages.acp-agent`) into `bin/olai`, so
-`nix build` / `nix run` / the home-manager unit need no ambient env. The
-dev shell (so `just serve` on a raco-linked tree) exports the same default.
-Exporting the variable yourself wins, which is how you point `serve` at a
-different agent.
+**`OLAI_ACP_AGENT`** is an absolute path to an executable that speaks the [Agent Client Protocol](https://agentclientprotocol.com/) on stdio; `serve` spawns it as a subprocess. There is no PATH lookup: with the variable unset (or pointing at something that is not executable) the server refuses to start. The Nix package is self-sufficient — `makeWrapper --set-default` bakes the bundled Claude Code adapter (`packages.acp-agent`) into `bin/olai`, so `nix build` / `nix run` / the home-manager unit need no ambient env. The dev shell (so `just serve` on a raco-linked tree) exports the same default. Exporting the variable yourself wins, which is how you point `serve` at a different agent.
 
-Unset, or pointing at a file that is missing or not executable, is a **usage
-error**: nothing binds a port and the reason goes to stderr naming the
-variable —
+Unset, or pointing at a file that is missing or not executable, is a **usage error**: nothing binds a port and the reason goes to stderr naming the variable —
 
-```console
+```text
 $ olai serve
 olai: OLAI_ACP_AGENT is not set; serve needs the path to an ACP agent (docs/cli.md)
 $ OLAI_ACP_AGENT=/nope olai serve
 olai: OLAI_ACP_AGENT does not exist: /nope
 ```
 
-— exit 1, the usage code. The agent is spawned **at startup**, in a background
-thread: the listener is up first, so pages serve while the subprocess starts
-and the last conversation replays (see *Sessions*). A page answered inside that
-window is not behind for it — it carries no conversation to be stale, and the
-stream tells it what the boot said, whichever side of the boot it connected on.
-A boot that fails
-is an `error` frame and a log line, and the next chat message retries it — the
-same path a crashed agent takes, which is likewise replaced on the next message.
-Its stderr is a log sink, drained into the server's own stderr with an `acp:`
-prefix; only its stdout is protocol. Chat frames ride `/events` under the `chat`
-event name, one JSON object per event:
-`{"type":"user","text"}`, `{"type":"chunk","text"}`,
-`{"type":"tool","id","title","status"}` (the same `id` twice means the same
-line, updated), `{"type":"done","stopReason","html"}` (`html` is the turn's
-agent text rendered as Markdown), `{"type":"error","message"}`,
-`{"type":"reset"}`, `{"type":"model","name"}`,
-`{"type":"commands","commands":[{"name","description"}]}`,
-`{"type":"session","id","title"}`. New keys may appear;
-existing ones keep their meaning.
+— exit 1, the usage code. The agent is spawned **at startup**, in a background thread: the listener is up first, so pages serve while the subprocess starts and the last conversation replays (see [Sessions](#sessions)). A page answered inside that window is not behind for it — it carries no conversation to be stale, and the stream tells it what the boot said, whichever side of the boot it connected on. A boot that fails is an `error` frame and a log line, and the next chat message retries it — the same path a crashed agent takes, which is likewise replaced on the next message. Its stderr is a log sink, drained into the server's own stderr with an `acp:` prefix; only its stdout is protocol. Chat frames ride `/events` under the `chat` event name, one JSON object per event: `{"type":"user","text"}`, `{"type":"chunk","text"}`, `{"type":"tool","id","title","status"}` (the same `id` twice means the same line, updated), `{"type":"done","stopReason","html"}` (`html` is the turn's agent text rendered as Markdown), `{"type":"error","message"}`, `{"type":"reset"}`, `{"type":"model","name"}`, `{"type":"commands","commands":[{"name","description"}]}`, `{"type":"session","id","title"}`. New keys may appear; existing ones keep their meaning.
 
-The `model` frame is which model the session is running, and it is the agent's
-word for it — said two ways, because one is not enough. The adapter reports the
-**picked** model as a session config option (`configOptions`, the entry with id
-`model`), once in the `session/new` result and again in a
-`config_option_update` whenever it changes under a live session. But a `/model`
-slash command is handled inside the wrapped Claude Code CLI: the adapter never
-sees it as a config change, so `configOptions` go on naming the model the
-session started on. The **running** model is in the CLI's own `system`/`init`
-message, which the adapter forwards verbatim as a `_claude/sdkMessage`
-notification — to a client that asked, for the kinds it asked for, which is why
-`session/new` carries
-`_meta.claudeCode.emitRawSDKMessages = [{"type":"system","subtype":"init"}]`.
-Only the `model` field of it is read.
+The `model` frame is which model the session is running, and it is the agent's word for it — said two ways, because one is not enough. The adapter reports the **picked** model as a session config option (`configOptions`, the entry with id `model`), once in the `session/new` result and again in a `config_option_update` whenever it changes under a live session. But a `/model` slash command is handled inside the wrapped Claude Code CLI: the adapter never sees it as a config change, so `configOptions` go on naming the model the session started on. The **running** model is in the CLI's own `system`/`init` message, which the adapter forwards verbatim as a `_claude/sdkMessage` notification — to a client that asked, for the kinds it asked for, which is why `session/new` carries `_meta.claudeCode.emitRawSDKMessages = [{"type":"system","subtype":"init"}]`. Only the `model` field of it is read.
 
-Whichever source moved last wins, and each is debounced against its own
-previous value: the picker resends its whole set whenever anything in it moves,
-and the running model repeats every turn. The first running model is a baseline
-(it agrees with the config option) and is not announced twice. A running model
-the picker offers is labelled with the picker's name; one it does not offer is
-shown raw and named once in the log — truthful, where a guess would not be. An
-agent that never says leaves the header alone; nothing is inferred from a
-command line or a version, and an agent that is not the Claude Code adapter
-ignores the `_meta` and loses nothing.
+Whichever source moved last wins, and each is debounced against its own previous value: the picker resends its whole set whenever anything in it moves, and the running model repeats every turn. The first running model is a baseline (it agrees with the config option) and is not announced twice. A running model the picker offers is labelled with the picker's name; one it does not offer is shown raw and named once in the log — truthful, where a guess would not be. An agent that never says leaves the header alone; nothing is inferred from a command line or a version, and an agent that is not the Claude Code adapter ignores the `_meta` and loses nothing.
 
-The `commands` frame is the agent's slash commands — the adapter pushes the
-whole list as an `available_commands_update` (`availableCommands`, each entry
-`{name, description, input}`) just after `session/new`, and again whenever the
-set moves under a live session. The bridge keeps the names and descriptions,
-drops `input` (an argument hint the panel does not draw), and pushes a frame
-only when the list actually changed. A command is INVOKED as ordinary prompt
-text — `/name arguments` in a `POST /chat` — so nothing else on the wire knows
-about them.
+The `commands` frame is the agent's slash commands — the adapter pushes the whole list as an `available_commands_update` (`availableCommands`, each entry `{name, description, input}`) just after `session/new`, and again whenever the set moves under a live session. The bridge keeps the names and descriptions, drops `input` (an argument hint the panel does not draw), and pushes a frame only when the list actually changed. A command is INVOKED as ordinary prompt text — `/name arguments` in a `POST /chat` — so nothing else on the wire knows about them.
 
 ### Sessions
 
-An agent that keeps its conversations keys them by the directory it was started
-in — which is why `serve DIR` runs it in exactly that directory. So there is a
-LAST session, and the server comes up in it:
+An agent that keeps its conversations keys them by the directory it was started in — which is why `serve DIR` runs it in exactly that directory. So there is a LAST session, and the server comes up in it:
 
-- After `initialize`, if the agent advertises `loadSession` and
-  `sessionCapabilities.list`, the bridge asks `session/list` for that directory
-  and **adopts the most recently updated** session with `session/load`. Nothing
-  stored, or an agent that advertises neither: `session/new`, as before.
-- `session/load` **replays the whole conversation** as `session/update`
-  notifications and only then answers. The replay has no live turn and nothing
-  in it says where one turn ended, so the bridge reconstructs them from the one
-  boundary it has: a `user_message_chunk` opens a turn, agent chunks and tool
-  calls fill it, the next user message closes it. Replayed turns land in the
-  transcript in the same shape as lived ones, and go out as the same frames —
-  `user`, `chunk`, `tool`, `done` — so open tabs fill in as they arrive. Their
-  `stopReason` is **null**: a replay does not carry how a turn ended, and
-  `end_turn` would be a guess.
-- The `session` frame is which conversation this is. It goes out when a session
-  is established (new, adopted, or picked) and again when its title moves — the
-  agent writes the title in the background and pushes it as a
-  `session_info_update` (which also carries `updatedAt`; only the title is
-  read). `title` is null until there is one, so a fresh session says its id
-  first and its name later. The panel header shows the title, quietly, beside
-  the model.
-- `+ new` still means `session/new`: the agent-side context goes away, a
-  `session` frame names the new one, and a `reset` clears the panels.
+- After `initialize`, if the agent advertises `loadSession` and `sessionCapabilities.list`, the bridge asks `session/list` for that directory and **adopts the most recently updated** session with `session/load`. Nothing stored, or an agent that advertises neither: `session/new`, as before.
+- `session/load` **replays the whole conversation** as `session/update` notifications and only then answers. The replay has no live turn and nothing in it says where one turn ended, so the bridge reconstructs them from the one boundary it has: a `user_message_chunk` opens a turn, agent chunks and tool calls fill it, the next user message closes it. Replayed turns land in the transcript in the same shape as lived ones, and go out as the same frames — `user`, `chunk`, `tool`, `done` — so open tabs fill in as they arrive. Their `stopReason` is **null**: a replay does not carry how a turn ended, and `end_turn` would be a guess.
+- The `session` frame is which conversation this is. It goes out when a session is established (new, adopted, or picked) and again when its title moves — the agent writes the title in the background and pushes it as a `session_info_update` (which also carries `updatedAt`; only the title is read). `title` is null until there is one, so a fresh session says its id first and its name later. The panel header shows the title, quietly, beside the model.
+- `+ new` still means `session/new`: the agent-side context goes away, a `session` frame names the new one, and a `reset` clears the panels.
 
-The picker is two routes. `GET /chat/sessions` asks the agent every time (its
-list is the only one that is right):
+The picker is two routes. `GET /chat/sessions` asks the agent every time (its list is the only one that is right):
 
 ```json
 {"sessions":[{"id":"…","title":"Investigate the crash",
               "updatedAt":"2026-08-05T14:41:21.471Z","current":true}]}
 ```
 
-Newest first; `title` / `updatedAt` may be `null`; `current` marks the one the
-server is in. `POST /chat/load` (form field `id`) moves to one: `204`, then a
-`reset`, the replayed turns, and the `session` frame on `/events`, so every open
-tab repopulates. `409` while a turn is running or another load is in flight;
-`503` when the agent is gone or does not keep sessions. The load is not a turn —
-it does not appear in the transcript as one, and the transcript it replaces is
-dropped, because a transcript of a session you are no longer in is a lie.
+Newest first; `title` / `updatedAt` may be `null`; `current` marks the one the server is in. `POST /chat/load` (form field `id`) moves to one: `204`, then a `reset`, the replayed turns, and the `session` frame on `/events`, so every open tab repopulates. `409` while a turn is running or another load is in flight; `503` when the agent is gone or does not keep sessions. The load is not a turn — it does not appear in the transcript as one, and the transcript it replaces is dropped, because a transcript of a session you are no longer in is a lie.
 
-A turn is accepted (and its `user` frame pushed) before the subprocess exists,
-so a cancel can arrive during the handshake. It is remembered and sent as soon
-as the prompt is on the wire: every cancelled turn ends the same way, a `done`
-frame whose `stopReason` the agent chose (`cancelled` from a Claude Code
-adapter).
+A turn is accepted (and its `user` frame pushed) before the subprocess exists, so a cancel can arrive during the handshake. It is remembered and sent as soon as the prompt is on the wire: every cancelled turn ends the same way, a `done` frame whose `stopReason` the agent chose (`cancelled` from a Claude Code adapter).
 
 Routes:
 
@@ -420,7 +245,7 @@ Routes:
 | `POST /chat` | prompt the agent; form field `text` (empty after trimming is `400`). `204` — what the panel draws comes back over `/events`, so every open tab stays in step. `409` with a terse `text/plain` body while a turn is running, `503` when the agent is gone |
 | `POST /chat/new` | new chat: the agent-side context goes away, `204`, and a `reset` frame clears every panel |
 | `POST /chat/cancel` | cancel the turn in flight, `204` (also while the agent is still booting); the `done` frame (`stopReason` `cancelled`) follows on its own |
-| `GET /chat/sessions` | the agent's stored conversations for this directory, JSON (see *Sessions*); `503` while the agent is gone |
+| `GET /chat/sessions` | the agent's stored conversations for this directory, JSON (see [Sessions](#sessions)); `503` while the agent is gone |
 | `POST /chat/load` | load one of them; form field `id` (missing is `400`). `204` — the reset, the replayed turns and the `session` frame come back over `/events`. `409` while a turn or another load is running, `503` when the agent is gone |
 | `GET /api/tree` | byte-identical to `olai tree` |
 | `GET /api/agenda` | byte-identical to `olai agenda` |
@@ -429,101 +254,41 @@ Routes:
 | `GET /static/*` | files under `olai/web/static/` (icons, htmx, scripts, `pwa.js`) |
 | anything else | `404`, terse `text/plain` |
 
-A node's permalink is `/n/<key>` (`key` as in `tree` JSON): every bullet in the
-outline and every entry in the sidebar tree links to that node's own zoom page.
-A key survives a rename — of the node or of any ancestor — but an unanchored
-node keys off its position, so moving it to a new ordinal mints a new key and
-the old link stops resolving. `^anchor` a node whose link has to outlive that.
+A node's permalink is `/n/<key>` (`key` as in `tree` JSON): every bullet in the outline and every entry in the sidebar tree links to that node's own zoom page. A key survives a rename — of the node or of any ancestor — but an unanchored node keys off its position, so moving it to a new ordinal mints a new key and the old link stops resolving. `^anchor` a node whose link has to outlive that.
 
-Within a page, anchored nodes and bare-ISO day nodes also keep a plain
-`#<anchor>` / `#<YYYY-MM-DD>` target, so links people wrote by hand still
-resolve, and every node carries `id="n-<key>"`.
+Within a page, anchored nodes and bare-ISO day nodes also keep a plain `#<anchor>` / `#<YYYY-MM-DD>` target, so links people wrote by hand still resolve, and every node carries `id="n-<key>"`.
 
 Paths that climb out of `static/` are 404, not files.
 
-**Prefs** are a sidebar section, one row per preference — client state, stored
-in `localStorage` under `olai.<pref>`, never sent to the server (same standing
-as the collapse state) and therefore per browser. The first row is `theme`: one
-chip per theme in `olai/web/theme`'s table, and nothing else. The sheet carries
-all of them, so picking one is a value on `<html data-theme>` and nothing else
-— no round trip, no re-render. A page that has picked nothing reads in the
-default theme (the sheet's bare `:root`) and that chip is the lit one; the OS's
-`prefers-color-scheme` is never consulted, and a stored theme the sheet no
-longer carries is forgotten on sight. A tiny inline script in `<head>` restores
-stored prefs before the first paint (`static/prefs.js` is the picker); each
-theme declares its own `color-scheme`, so scrollbars and form controls follow.
-`<meta name="theme-color">` starts as the default theme's paper and is rewritten
-from `--paper` by `static/pwa.js` whenever a chip flips, so the browser chrome
-tracks the page.
+**Prefs** are a sidebar section, one row per preference — client state, stored in `localStorage` under `olai.<pref>`, never sent to the server (same standing as the collapse state) and therefore per browser. The first row is `theme`: one chip per theme in `olai/web/theme`'s table, and nothing else. The sheet carries all of them, so picking one is a value on `<html data-theme>` and nothing else — no round trip, no re-render. A page that has picked nothing reads in the default theme (the sheet's bare `:root`) and that chip is the lit one; the OS's `prefers-color-scheme` is never consulted, and a stored theme the sheet no longer carries is forgotten on sight. A tiny inline script in `<head>` restores stored prefs before the first paint (`static/prefs.js` is the picker); each theme declares its own `color-scheme`, so scrollbars and form controls follow. `<meta name="theme-color">` starts as the default theme's paper and is rewritten from `--paper` by `static/pwa.js` whenever a chip flips, so the browser chrome tracks the page.
 
-**PWA.** The page links the manifest and icons and is installable (Add to
-Home Screen / install prompt) when served over HTTPS or localhost. There is
-no service worker and no offline mode: the view is live-or-nothing (SSE,
-agent). `static/pwa.js` only keeps `theme-color` in step with the picked theme.
+**PWA.** The page links the manifest and icons and is installable (Add to Home Screen / install prompt) when served over HTTPS or localhost. There is no service worker and no offline mode: the view is live-or-nothing (SSE, agent). `static/pwa.js` only keeps `theme-color` in step with the picked theme.
 
-The chat panel (a `>_ agent` button, bottom right; open state remembered in
-`localStorage`) comes out of the server EMPTY and in none of its states. Every
-word in it and every class on it arrives as a frame on the page's one SSE
-connection, `static/chat.js` drawing them — including the conversation that
-happened before the page existed, which `/events` replays down the connection
-as it is made. Nothing about the conversation is server-rendered: a page is
-answered while the agent may still be waking up, so a panel drawn from what was
-known then would be a panel that never finds out.
-Its header names the model when the agent has reported one, and
-the conversation when it has a title. The `chats` button beside `+ new` opens a
-popover over `GET /chat/sessions` — newest first, the current one marked, ↑/↓
-and Enter or a click to load one, Esc to close.
-Agent text is Markdown at render time, same as titles and notes; what you typed
-and a tool's title never are.
+The chat panel (a `>_ agent` button, bottom right; open state remembered in `localStorage`) comes out of the server EMPTY and in none of its states. Every word in it and every class on it arrives as a frame on the page's one SSE connection, `static/chat.js` drawing them — including the conversation that happened before the page existed, which `/events` replays down the connection as it is made. Nothing about the conversation is server-rendered: a page is answered while the agent may still be waking up, so a panel drawn from what was known then would be a panel that never finds out. Its header names the model when the agent has reported one, and the conversation when it has a title. The `chats` button beside `+ new` opens a popover over `GET /chat/sessions` — newest first, the current one marked, ↑/↓ and Enter or a click to load one, Esc to close. Agent text is Markdown at render time, same as titles and notes; what you typed and a tool's title never are.
 
-Typing `/` in the panel's input — or pressing the `/` button on the input row,
-which shows the whole list — opens a completion popover over the agent's
-slash commands (the whole list, from the `commands` frame — the catch-up's
-included): ↑/↓ move, Enter or Tab accept the highlighted one into the
-input, Esc closes, and Enter with nothing open sends the message as always.
-Accepting only writes `/name ` — sending is what invokes it.
+Typing `/` in the panel's input — or pressing the `/` button on the input row, which shows the whole list — opens a completion popover over the agent's slash commands (the whole list, from the `commands` frame — the catch-up's included): ↑/↓ move, Enter or Tab accept the highlighted one into the input, Esc closes, and Enter with nothing open sends the message as always. Accepting only writes `/name ` — sending is what invokes it.
 
-**Edits are pushed, and picked up on the next request either way.** The server
-keeps a snapshot of the outlines (roots plus every `@include` fragment) and
-reloads it when a watched file's mtime or size changes; a reload runs in a
-fresh namespace, so the module registry cannot serve you yesterday's file. A
-watcher holds a `filesystem-change-evt` on each watched file's *directory*
-(saves are atomic renames, which fire there), debounces the flurry, and pushes
-an `outline` event on `/events` when the store actually reloaded. Open pages
-re-fetch themselves and swap the pane and the error banner — no refresh.
+**Edits are pushed, and picked up on the next request either way.** The server keeps a snapshot of the outlines (roots plus every `@include` fragment) and reloads it when a watched file's mtime or size changes; a reload runs in a fresh namespace, so the module registry cannot serve you yesterday's file. A watcher holds a `filesystem-change-evt` on each watched file's *directory* (saves are atomic renames, which fire there), debounces the flurry, and pushes an `outline` event on `/events` when the store actually reloaded. Open pages re-fetch themselves and swap the pane and the error banner — no refresh.
 
 A file is broken for a moment during every edit, so the two surfaces differ:
 
-- `/api/*` answers `500` with the JSON error object (same shape as the CLI's
-  errors, `file` / `line` / `col` / `message`) — agents never get stale data
-  quietly.
-- `/` keeps rendering the **last good** snapshot and puts the error, with its
-  `file:line:col`, in a banner at the top of the page. With no last-good
-  snapshot (the first load failed) it answers `500` with the same banner.
+- `/api/*` answers `500` with the JSON error object (same shape as the CLI's errors, `file` / `line` / `col` / `message`) — agents never get stale data quietly.
+- `/` keeps rendering the **last good** snapshot and puts the error, with its `file:line:col`, in a banner at the top of the page. With no last-good snapshot (the first load failed) it answers `500` with the same banner.
 
-A broken file pushes an event too — the banner appearing IS the news — so the
-revision moves on a failed reload as well as a good one. It is a counter, not
-a version: compare it, do not parse it.
+A broken file pushes an event too — the banner appearing IS the news — so the revision moves on a failed reload as well as a good one. It is a counter, not a version: compare it, do not parse it.
 
-Exit codes: 0 on clean shutdown, 1 on bad flags, a port it cannot bind, or a
-missing / unusable `OLAI_ACP_AGENT`; 3 when an outline path does not
-exist, or a directory holds no top-level `*.rkt`.
+Exit codes: 0 on clean shutdown, 1 on bad flags, a port it cannot bind, or a missing / unusable `OLAI_ACP_AGENT`; 3 when an outline path does not exist, or a directory holds no top-level `*.rkt`.
 
-There is no static HTML export — `curl http://127.0.0.1:8080/ > snap.html`
-if you want one.
+There is no static HTML export — `curl http://127.0.0.1:8080/ > snap.html` if you want one.
 
 ## `add [--file F] [--date ISO] [--description TEXT] [--parent TITLE|^anchor] [--no-commit] TITLE...`
 
-`--date` accepts `YYYY-MM-DD` or a datetime (`YYYY-MM-DDTHH:MM` / `…:SS`; a space
-instead of `T` is fine).
+`--date` accepts `YYYY-MM-DD` or a datetime (`YYYY-MM-DDTHH:MM` / `…:SS`; a space instead of `T` is fine).
 
-Capture under a parent node: default top-level `Inbox` (created if missing), or
-`--parent ^anchor` / `--parent TITLE`. Writes **outline** syntax only. TITLE
-words join with spaces (no shell quoting required).
+Capture under a parent node: default top-level `Inbox` (created if missing), or `--parent ^anchor` / `--parent TITLE`. Writes **outline** syntax only. TITLE words join with spaces (no shell quoting required).
 
 - Validates by re-loading after write; on failure restores the prior file.
-- If the file's directory is a git work tree, auto-commits that file with
-  message `capture: TITLE` unless `--no-commit`.
+- If the file's directory is a git work tree, auto-commits that file with message `capture: TITLE` unless `--no-commit`.
 - Never prompts; never opens an editor.
 
 Stdout:
@@ -543,30 +308,19 @@ Stdout:
 }
 ```
 
-`parent` echoes `--parent` verbatim (`null` for the default Inbox). `file` is
-the file actually written — with `--parent ^anchor` that may be an `@include`
-fragment, not `--file`.
+`parent` echoes `--parent` verbatim (`null` for the default Inbox). `file` is the file actually written — with `--parent ^anchor` that may be an `@include` fragment, not `--file`.
 
 ## `done [--file F] [--undo] [--no-commit] TITLE...|^anchor`
 
-Mark a task done by exact title match or `^anchor` (or undo). **One file only**
-(`--file`). Writes **outline** syntax only — same safety as `add`: write temp →
-re-validate → rename; restore on failure.
+Mark a task done by exact title match or `^anchor` (or undo). **One file only** (`--file`). Writes **outline** syntax only — same safety as `add`: write temp → re-validate → rename; restore on failure.
 
-- Exact title match across the file (a `[x] ` / `[/] ` checkbox prefix and a
-  trailing `^anchor` are not part of the matched title), or a single `^id`
-  addressing the defining site.
+- Exact title match across the file (a `[x] ` / `[/] ` checkbox prefix and a trailing `^anchor` are not part of the matched title), or a single `^id` addressing the defining site.
 - **0 matches** → exit 2.
-- **>1 matches** → exit 2; message lists each `file:line` and suggests
-  `add a ^anchor to disambiguate`.
-- On success: inserts `@done YYYY-MM-DD` (today) after the task's metadata,
-  preserving the rest of the file. Rejects tasks already done.
-- **Clears doing**: an `@doing` line goes with the edit and a `[/] ` prefix is
-  stripped off the title. A node carrying both marks is a form the language
-  rejects, so this is not tidiness — it is what makes the write valid.
+- **>1 matches** → exit 2; message lists each `file:line` and suggests `add a ^anchor to disambiguate`.
+- On success: inserts `@done YYYY-MM-DD` (today) after the task's metadata, preserving the rest of the file. Rejects tasks already done.
+- **Clears doing**: an `@doing` line goes with the edit and a `[/] ` prefix is stripped off the title. A node carrying both marks is a form the language rejects, so this is not tidiness — it is what makes the write valid.
 - `--undo`: remove `@done` metadata and strip a leading `[x] ` / `[X] ` prefix.
-- Auto-commit `done: TITLE` / `undone: TITLE` in a git work tree unless
-  `--no-commit`.
+- Auto-commit `done: TITLE` / `undone: TITLE` in a git work tree unless `--no-commit`.
 
 Stdout:
 
@@ -587,17 +341,12 @@ On `--undo`, `done` is `null` and `undone` is `true`.
 
 ## `doing [--file F] [--undo] [--no-commit] TITLE...|^anchor`
 
-Put a task in the third state, between open and done (or take it back out).
-Same resolver, same write safety and same shape as `done` — it is the same op
-with a different mark.
+Put a task in the third state, between open and done (or take it back out). Same resolver, same write safety and same shape as `done` — it is the same op with a different mark.
 
 - On success: inserts `@doing YYYY-MM-DD` (today) after the task's metadata.
-- Rejects a task **already doing**, and a task **already done** — undo the
-  done first, so nothing decides for you that finished work is not. Both are
-  exit 2.
+- Rejects a task **already doing**, and a task **already done** — undo the done first, so nothing decides for you that finished work is not. Both are exit 2.
 - `--undo`: remove `@doing` metadata and strip a leading `[/] ` prefix.
-- Auto-commit `doing: TITLE` / `not-doing: TITLE` in a git work tree unless
-  `--no-commit`.
+- Auto-commit `doing: TITLE` / `not-doing: TITLE` in a git work tree unless `--no-commit`.
 
 ```json
 {"version":1,"ok":true,"file":".../Tasks.rkt","title":"Buy milk","line":5,
@@ -606,64 +355,47 @@ with a different mark.
 
 On `--undo`, `doing` is `null` and `undone` is `true`.
 
-Who is doing it, and where, live in the node's notes — not in the grammar. An
-orchestrator marks a task `[/]` and writes the terminal id under it.
+Who is doing it, and where, live in the node's notes — not in the grammar. An orchestrator marks a task `[/]` and writes the terminal id under it.
 
 ## `move [--file F] [--no-commit] [--clear] TITLE...|^anchor DATE`
 
-Set or rewrite `@date` on a task (same write-safety as `add`/`done`). `DATE`
-is ISO date or datetime. `--clear` removes `@date` instead (no DATE arg).
-Auto-commit message: `move: TITLE -> DATE` (or cleared).
+Set or rewrite `@date` on a task (same write-safety as `add`/`done`). `DATE` is ISO date or datetime. `--clear` removes `@date` instead (no DATE arg). Auto-commit message: `move: TITLE -> DATE` (or cleared).
 
 ```json
 {"version":1,"ok":true,"file":"...","title":"Buy milk","line":6,"date":"2026-08-10","committed":false}
 ```
 
-With `--clear`, `date` is `null`. `title` is always the node's resolved title,
-never the raw `^anchor` you passed.
+With `--clear`, `date` is `null`. `title` is always the node's resolved title, never the raw `^anchor` you passed.
 
 ## `ics [--out PATH] [file ...]`
 
-RFC 5545 `VCALENDAR` of all dated tasks (done included) on stdout, or into
-`--out PATH` (which prints the path it wrote). Minimal writer — no catalog ics
-package. UID is `anchor@olai` when present, else a stable hash of
-path/title/date. `DTSTART` is `VALUE=DATE` or local datetime.
+RFC 5545 `VCALENDAR` of all dated tasks (done included) on stdout, or into `--out PATH` (which prints the path it wrote). Minimal writer — no catalog ics package. UID is `anchor@olai` when present, else a stable hash of path/title/date. `DTSTART` is `VALUE=DATE` or local datetime.
 
-The one command whose output is neither JSON nor the web view: nothing else
-produces a calendar feed, so a calendar client is the consumer and the format
-is the reply. Errors are plain (`olai: ...`), exit codes as above.
+The one command whose output is neither JSON nor the web view: nothing else produces a calendar feed, so a calendar client is the consumer and the format is the reply. Errors are plain (`olai: ...`), exit codes as above.
 
 ## `daily [--date YYYY-MM-DD] [--home DIR] [--no-commit]`
 
-Ensure a day node exists in the personal Daily structure under `$OLAI_HOME`
-(or `--home`):
+Ensure a day node exists in the personal Daily structure under `$OLAI_HOME` (or `--home`):
 
 - Fragment: `Daily/YYYY-MM.rkt` (day nodes only at top level)
 - Root: `Daily.rkt` with `year > MonthName > @include Daily/YYYY-MM.rkt`
 
-Creates the month fragment and `@include` line on first use in a month;
-idempotent thereafter. Writes use add-style validate-then-rename, and
-auto-commit like the other write commands — the fragment and the root that
-includes it in ONE commit (`daily: YYYY-MM-DD`).
+Creates the month fragment and `@include` line on first use in a month; idempotent thereafter. Writes use add-style validate-then-rename, and auto-commit like the other write commands — the fragment and the root that includes it in ONE commit (`daily: YYYY-MM-DD`).
 
 ```json
 {"version":1,"ok":true,"day":"2026-08-04","file":".../Daily/2026-08.rkt",
  "created_month":true,"created_day":true,"line":2,"committed":true}
 ```
 
-Both `created_*` are `false` on every run after the first for that day, and
-`committed` is `false` when there was nothing to write (or `--no-commit`).
+Both `created_*` are `false` on every run after the first for that day, and `committed` is `false` when there was nothing to write (or `--no-commit`).
 
 ## Write routing under `@include`
 
-`done` / `doing` / `move` / `add --parent ^anchor` resolve the target against the loaded
-tree (including fragments), then edit the **defining file** of that node.
-JSON `file` fields on tree nodes show where agents should write.
+`done` / `doing` / `move` / `add --parent ^anchor` resolve the target against the loaded tree (including fragments), then edit the **defining file** of that node. JSON `file` fields on tree nodes show where agents should write.
 
 ## Errors
 
-Single object on **stderr**, exit non-zero — for every command that replies in
-JSON, which is every one but `ics` and `serve`:
+Single object on **stderr**, exit non-zero — for every command that replies in JSON, which is every one but `ics` and `serve`:
 
 ```json
 {
@@ -678,9 +410,7 @@ JSON, which is every one but `ics` and `serve`:
 }
 ```
 
-`line` / `col` / `file` are `null` when not applicable — a load failure carries
-all three (and repeats them as a `file:line:col` prefix in `message`), a
-"you asked for something that is not there" failure names the file only:
+`line` / `col` / `file` are `null` when not applicable — a load failure carries all three (and repeats them as a `file:line:col` prefix in `message`), a "you asked for something that is not there" failure names the file only:
 
 ```json
 {"version":1,"ok":false,
@@ -688,25 +418,19 @@ all three (and repeats them as a `file:line:col` prefix in `message`), a
           "message":"\"Wire the CLI\" is already done (line 16)"}}
 ```
 
-`message` is addressed to a person, not to a stack: no `some-private-function:`
-prefix in front of the answer. Agents must not regex pretty-printed messages.
+`message` is addressed to a person, not to a stack: no `some-private-function:` prefix in front of the answer. Agents must not regex pretty-printed messages.
 
 ## Stability
 
-- Two counters, both `1` today and free to move apart: the **model** version
-  rides on `tree` payloads (what a node/tree/anchor IS), the **reply** version
-  on command envelopes (`ok` / `error`, `agenda`, `calendar`, the write
-  commands) — a new node field bumps the first, a reshaped envelope the second.
+- Two counters, both `1` today and free to move apart: the **model** version rides on `tree` payloads (what a node/tree/anchor IS), the **reply** version on command envelopes (`ok` / `error`, `agenda`, `calendar`, the write commands) — a new node field bumps the first, a reshaped envelope the second.
 - Top-level objects always include `"version": 1`.
 - Within v1, new keys may appear; existing keys keep meaning and type.
 - Removing or renaming a key requires a version bump.
-- The JSON is the contract; the plain text that used to come out without
-  `--json` was not, and is gone. No key changed with it.
+- The JSON is the contract; the plain text that used to come out without `--json` was not, and is gone. No key changed with it.
 
 ## Retired
 
-The web app is the daily surface, so the CLI keeps only what an agent calls and
-what guards a write:
+The web app is the daily surface, so the CLI keeps only what an agent calls and what guards a write:
 
 | Gone | Instead |
 |------|---------|
@@ -714,10 +438,8 @@ what guards a write:
 | `css` | `GET /static/app.css` from a running `serve`; in-tree, `racket -e '(require olai/web/skin) (displayln (stylesheet))'` |
 | `html` (earlier) | `serve`, or `curl http://127.0.0.1:8080/ > snap.html` |
 
-`--json` still parses everywhere it did. An invocation of a retired COMMAND is
-an unknown command: exit 1.
+`--json` still parses everywhere it did. An invocation of a retired COMMAND is an unknown command: exit 1.
 
 ## Nix build note
 
-Runtime deps (`gregor`, `markdown`) and nixpkgs are pinned with **npins**
-(`npins/sources.json`). `nix build` is fully offline/sandboxed.
+Runtime deps (`gregor`, `markdown`) and nixpkgs are pinned with **npins** (`npins/sources.json`). `nix build` is fully offline/sandboxed.

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -1,26 +1,17 @@
 # Hacking
 
-Facts an agent cannot infer from the code and would otherwise probe for.
-Not a tutorial. Read README and docs/cli.md first.
+Facts an agent cannot infer from the code and would otherwise probe for. Not a tutorial. Read [README](../README.md) and [docs/cli.md](cli.md) first.
 
 ## Toolchain
 
-* Racket comes from `nix develop` (nixpkgs 9.2). `just` recipes set
-  `PLTUSERHOME` to `$PWD/.plt-user` so user packages and the `olai` link
-  live in the worktree, not `~`. That directory must be writable.
-* `just install` — deps + `raco pkg install --skip-installed --link olai/`.
-  Cheap to repeat. Does **not** recompile after you edit sources.
-* `just build` — `raco setup --pkgs olai`. Writes `compiled/*.zo` for the
-  collection and its tests, and keeps them coherent after edits.
-  Incremental when nothing changed. `just test` / `test-integration` /
-  `test-all` depend on it.
+* Racket comes from `nix develop` (nixpkgs 9.2). `just` recipes set `PLTUSERHOME` to `$PWD/.plt-user` so user packages and the `olai` link live in the worktree, not `~`. That directory must be writable.
+* `just install` — deps + `raco pkg install --skip-installed --link olai/`. Cheap to repeat. Does **not** recompile after you edit sources.
+* `just build` — `raco setup --pkgs olai`. Writes `compiled/*.zo` for the collection and its tests, and keeps them coherent after edits. Incremental when nothing changed. `just test` / `test-integration` / `test-all` depend on it.
 * `just clean` — delete every `olai/**/compiled`. Escape hatch only.
 
 ### Why build exists
 
-This Racket does **not** write `.zo` on load. `racket -e '(require …)'`
-and a bare `raco test` leave no bytecode on disk; every run recompiles
-in memory. Measured baseline (16 cores, 184 unit tests):
+This Racket does **not** write `.zo` on load. `racket -e '(require …)'` and a bare `raco test` leave no bytecode on disk; every run recompiles in memory. Measured baseline (16 cores, 184 unit tests):
 
 | path | wall |
 |---|---|
@@ -28,14 +19,13 @@ in memory. Measured baseline (16 cores, 184 unit tests):
 | `just test` after `just build` | ~5.5–6 s |
 | edit `olai/web/style.rkt` → `just test` (with build) | ~6–9 s |
 
-So the agent edit-verify loop is dominated by missing bytecode, not by
-the suite. Build once; keep it.
+So the agent edit-verify loop is dominated by missing bytecode, not by the suite. Build once; keep it.
 
 ### Stale `.zo` / linklet mismatch
 
 Symptom:
 
-```
+```text
 instantiate-linklet: mismatch;
  reference to a variable that is not exported
   …
@@ -43,9 +33,7 @@ instantiate-linklet: mismatch;
   possible solution: running `racket -y`, `raco make`, or `raco setup`
 ```
 
-Cause: a low-level module was recompiled (or its exports changed) while
-a dependent's `.zo` still expects the old linklet — classic after
-editing `web/style.rkt` / `web/theme.rkt` and only partially rebuilding.
+Cause: a low-level module was recompiled (or its exports changed) while a dependent's `.zo` still expects the old linklet — classic after editing `web/style.rkt` / `web/theme.rkt` and only partially rebuilding.
 
 Cure, in order:
 
@@ -55,36 +43,23 @@ Cure, in order:
 
 ## css-expr (web/style.rkt and friends)
 
-The sheet is generated; the serializer is css-expr's. Rules that are not
-obvious from the package docs:
+The sheet is generated; the serializer is css-expr's. Rules that are not obvious from the package docs:
 
-* **Hex colors** must be escaped symbols: `|#E4ECCA|`, not `"#E4ECCA"`
-  or `#E4ECCA`. See the theme tables in `olai/web/theme.rkt`.
-* **Multi-value properties** (e.g. `box-shadow` layers, `transition`
-  lists) are **comma**-joined by the serializer.
-* **Parenthesized groups** inside a property (function args, nested
-  value lists) are **space**-joined.
-* **`@media` / `@keyframes`** are spelled as css-expr at-rules, not raw
-  strings when the form can express them:
+* **Hex colors** must be escaped symbols: `|#E4ECCA|`, not `"#E4ECCA"` or `#E4ECCA`. See the theme tables in `olai/web/theme.rkt`.
+* **Multi-value properties** (e.g. `box-shadow` layers, `transition` lists) are **comma**-joined by the serializer.
+* **Parenthesized groups** inside a property (function args, nested value lists) are **space**-joined.
+* **`@media` / `@keyframes`** are spelled as css-expr at-rules, not raw strings when the form can express them:
 
   ```racket
   [@ media (#:max-width ,phone-max) #:padding-right 1rem]
   [@ keyframes ol-spin [to #:transform (apply rotate 360deg)]]
   ```
 
-* **`apply`** is css-expr's way to emit a CSS function:
-  `(apply color-mix (in srgb) (,green 45%) transparent)` →
-  `color-mix(in srgb, …)`.
-* **Raw CSS strings** are the escape hatch (`register-fragment!` with a
-  string). Use only when css-expr cannot spell it; comment why. The
-  generated-file banner in `theme.rkt` is the one permanent example.
-* **Cascade order** is not CSS `@layer`. It is (1) fragment layer
-  `'base` | `'component` | `'overlay`, then (2) module instantiation
-  order (= require order through `olai/web/skin.rkt`). A class is
-  defined in the module that **draws** it.
+* **`apply`** is css-expr's way to emit a CSS function: `(apply color-mix (in srgb) (,green 45%) transparent)` → `color-mix(in srgb, …)`.
+* **Raw CSS strings** are the escape hatch (`register-fragment!` with a string). Use only when css-expr cannot spell it; comment why. The generated-file banner in `theme.rkt` is the one permanent example.
+* **Cascade order** is not CSS `@layer`. It is (1) fragment layer `'base` | `'component` | `'overlay`, then (2) module instantiation order (= require order through `olai/web/skin.rkt`). A class is defined in the module that **draws** it.
 
-Class-name renames: run `just css-classes` to regenerate
-`olai/tests/classes.golden`; never edit the golden by hand.
+Class-name renames: run `just css-classes` to regenerate `olai/tests/classes.golden`; never edit the golden by hand.
 
 ## Tests
 
@@ -93,53 +68,20 @@ Class-name renames: run `just css-classes` to regenerate
 * `just test-all` — both, one `-j` pool
 * `just e2e` — browser journeys (see below); never in `just test`
 * Parse JSON with `read-json`. Never string-match JSON.
-* Personal outline data is `$OLAI_HOME` (outside the repo). CI and
-  tests use `examples/` only.
+* Personal outline data is `$OLAI_HOME` (outside the repo). CI and tests use `examples/` only.
 
 ## e2e (browser)
 
-`e2e/` is cucumber-js + Playwright over a real headless Chromium: the
-journeys the racket tests cannot see, because they stop at HTTP and no
-JS runs there — folding, the theme picker, the live re-swap, the chat
-panel's geometry.
+`e2e/` is cucumber-js + Playwright over a real headless Chromium: the journeys the racket tests cannot see, because they stop at HTTP and no JS runs there — folding, the theme picker, the live re-swap, the chat panel's geometry.
 
-* `just e2e` runs the suite; arguments go straight to cucumber, so
-  `just e2e features/chat.feature` and `just e2e features/chat.feature:12`
-  both work. `--tags` on the command line is ANDed with the profile's
-  `not @skip`, so it can only ever narrow: to run a skipped scenario,
-  replace the filter — `CUCUMBER_TAGS='@skip' just e2e`.
-* It is **not** in `just test` (that stays the fast racket set) and it
-  is its own CI node (`ci/mod.just`, Linux only).
-* Node, the browser and the harness's `node_modules` come from a
-  SEPARATE devShell (`nix develop .#e2e`); the recipe enters it itself.
-  Nothing racket-only pays for a 500 MB browser.
-* `e2e/package.json` pins `playwright` to the same version as nixpkgs'
-  `playwright-driver` (the browser bundle `PLAYWRIGHT_BROWSERS_PATH`
-  points at). Bump them together or scenario one says "Executable
-  doesn't exist".
-* Deps are a derivation (`e2e/default.nix`, one fixed-output
-  `fetchNpmDeps`, like `acp/`); the regenerate-the-hash recipe is in
-  that file's header, next to the hash it is about.
-* The fixture outline is a real file, `e2e/fixtures/Tasks.rkt`, checked
-  by the `smoke` lane like any other committed outline.
-* Each scenario gets its own temp outline, its own `olai serve` on an
-  ephemeral port (`--port 0`; the server prints the port it took), and
-  a fresh browser context — so localStorage, folds and prefs start
-  empty every time.
-* The agent is ALWAYS `olai/tests/integration/fake-acp-agent.rkt`
-  (`e2e/support/server.js` sets `OLAI_ACP_AGENT`). No real Claude Code
-  is ever spawned by a test. What it woke up with is a scenario TAG —
-  `@stored-sessions`, `@foreign-sessions` — because stored
-  conversations are a fact about the machine, not something a step can
-  arrange later (`e2e/support/hooks.js`).
-* `serve` answers requests while the agent is still booting. What the
-  panel comes up knowing is not a page's to say — `/events` catches a
-  connection up as it is made — so `Given the agent has woken up`
-  (`world.waitForAgent`, which reads the stream) is for scenarios about
-  the AGENT: the picker asks it, and there is nothing to ask until it
-  is up.
-* `@skip` is the regression harness for known-broken behaviour: the
-  scenario is written and excluded. `CUCUMBER_TAGS=@skip just e2e` runs
-  exactly those. `CUCUMBER_RETRY` (CI sets 1) and `CUCUMBER_PARALLEL`
-  are the other two knobs.
+* `just e2e` runs the suite; arguments go straight to cucumber, so `just e2e features/chat.feature` and `just e2e features/chat.feature:12` both work. `--tags` on the command line is ANDed with the profile's `not @skip`, so it can only ever narrow: to run a skipped scenario, replace the filter — `CUCUMBER_TAGS='@skip' just e2e`.
+* It is **not** in `just test` (that stays the fast racket set) and it is its own CI node (`ci/mod.just`, Linux only).
+* Node, the browser and the harness's `node_modules` come from a SEPARATE devShell (`nix develop .#e2e`); the recipe enters it itself. Nothing racket-only pays for a 500 MB browser.
+* `e2e/package.json` pins `playwright` to the same version as nixpkgs' `playwright-driver` (the browser bundle `PLAYWRIGHT_BROWSERS_PATH` points at). Bump them together or scenario one says "Executable doesn't exist".
+* Deps are a derivation (`e2e/default.nix`, one fixed-output `fetchNpmDeps`, like `acp/`); the regenerate-the-hash recipe is in that file's header, next to the hash it is about.
+* The fixture outline is a real file, `e2e/fixtures/Tasks.rkt`, checked by the `smoke` lane like any other committed outline.
+* Each scenario gets its own temp outline, its own `olai serve` on an ephemeral port (`--port 0`; the server prints the port it took), and a fresh browser context — so localStorage, folds and prefs start empty every time.
+* The agent is ALWAYS `olai/tests/integration/fake-acp-agent.rkt` (`e2e/support/server.js` sets `OLAI_ACP_AGENT`). No real Claude Code is ever spawned by a test. What it woke up with is a scenario TAG — `@stored-sessions`, `@foreign-sessions` — because stored conversations are a fact about the machine, not something a step can arrange later (`e2e/support/hooks.js`).
+* `serve` answers requests while the agent is still booting. What the panel comes up knowing is not a page's to say — `/events` catches a connection up as it is made — so `Given the agent has woken up` (`world.waitForAgent`, which reads the stream) is for scenarios about the AGENT: the picker asks it, and there is nothing to ask until it is up.
+* `@skip` is the regression harness for known-broken behaviour: the scenario is written and excluded. `CUCUMBER_TAGS=@skip just e2e` runs exactly those. `CUCUMBER_RETRY` (CI sets 1) and `CUCUMBER_PARALLEL` are the other two knobs.
 * Assert behaviour and geometry, never pixel snapshots.

--- a/docs/live-dsl.md
+++ b/docs/live-dsl.md
@@ -50,7 +50,7 @@ Write `sse-swap "score-change"` — no error. The server compiles, the page rend
 
 Now put a swarm on it. Each agent arrives with partial context and must REDISCOVER the four conventions from source before touching anything. The post calls the result entropy: special cases and near-misses accumulating faster than any one agent can see. And the only net under them is the e2e suite — simulation, in the post's terms: expensive, late, and only as good as its scenario coverage. This is not hypothetical; olai's sidebar-rebuilds-chat bug was convention 3 misapplied, shipped green, and caught by a human.
 
-Frangibility says what the fix must feel like: an agent cannot learn by breaking your browser session, so the feedback has to arrive before anything runs. The cheapest such feedback in Racket is expansion failure with a srcloc — already this repo's agent interface (`#lang olai` is a closed grammar with one checker; css-expr makes stylesheets checked s-expressions; CLAUDE.md holds tests to srcloc fidelity). The cure below is the same one, applied to the wiring.
+Frangibility says what the fix must feel like: an agent cannot learn by breaking your browser session, so the feedback has to arrive before anything runs. The cheapest such feedback in Racket is expansion failure with a srcloc — already this repo's agent interface (`#lang olai` is a closed grammar with one checker; css-expr makes stylesheets checked s-expressions; [CLAUDE.md](../CLAUDE.md) holds tests to srcloc fidelity). The cure below is the same one, applied to the wiring.
 
 ## The toy, declared
 
@@ -129,6 +129,6 @@ Both die at expansion, srcloc first, before a server boots. That error message I
 
 ## And olai?
 
-Substitute names: `board` is `#ol-live`, `scores` is `outline-events` in web/watch.rkt, `player-link` is every sidebar, crumb, and permalink the renderer draws — and the chat panel is the second consumer of the same three forms, riding the same hub. serve.rkt requires both drawers; the module graph wires the rest.
+Substitute names: `board` is `#ol-live`, `scores` is `outline-events` in `web/watch.rkt`, `player-link` is every sidebar, crumb, and permalink the renderer draws — and the chat panel is the second consumer of the same three forms, riding the same hub. `serve.rkt` requires both drawers; the module graph wires the rest.
 
 The in-flight live-view PR ships the functional core. The DSL is a possible second PR, judged then by the same lenses: build it only if the declarations CHECK something a swarm actually trips on.

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -4,8 +4,7 @@ Two surface syntaxes share one expander (the validator).
 
 ## `#lang olai` — outline (default)
 
-Workflowy-shaped, quoteless titles. The reader translates to `(t ...)` forms;
-the expander does not know which surface you used.
+Workflowy-shaped, quoteless titles. The reader translates to `(t ...)` forms; the expander does not know which surface you used.
 
 ```racket
 #lang olai
@@ -23,7 +22,7 @@ olai roadmap #project
 ### Implemented
 
 | Feature | Rule |
-|--------|------|
+|---|---|
 | Title | Any non-blank line that is not `#lang`, metadata (`:`/`@`), a mirror, or an include — stored **verbatim** minus its sugar. Escape with `\` to keep a line that starts like one of those. |
 | Nesting | Exactly **2 spaces** per level. Tabs forbidden. Indent may increase by at most one level. |
 | Description | Indented continuation `: text` — colon **and space**; a bare `:` or `:text` is a reader error. Multiple `: ` lines join with `\n` into one `#:description`. |
@@ -42,17 +41,14 @@ olai roadmap #project
 
 ### Inline formatting (Markdown)
 
-Formatting is **interpretation at render time**, not data. The reader, expander,
-task struct, and CLI write path leave strings **verbatim**. Only the web view
-(`olai serve`) parses Markdown, via the `markdown` package → xexprs →
-sanitizer. `tree` / `check` / `agenda` JSON never do.
+Formatting is **interpretation at render time**, not data. The reader, expander, task struct, and CLI write path leave strings **verbatim**. Only the web view (`olai serve`) parses Markdown, via the `markdown` package → xexprs → sanitizer. `tree` / `check` / `agenda` JSON never do.
 
 | Surface | Markdown scope |
-|--------|----------------|
+|---|---|
 | **Title** | Inline only: bold, italic, code spans, links. Block syntax is text in a title — a leading `#tag`, `- `, `> ` or `1. ` renders verbatim, pill and all. |
 | **Notes** (`: ` lines, joined with `\n`) | Full document Markdown, including fenced code blocks. |
 
-**Ambiguity rules**
+#### Ambiguity rules
 
 - `#word` is a **tag** in the data, always: `task-tags` comes from a regexp over the verbatim title, so the JSON is right no matter what the line looks like.
 - Rendering agrees: a title is parsed **inline-only**, so a line-initial block marker is text. `#tag first` keeps its pill, `- not a list` is not a list, `> quoted` is not a blockquote. (Notes are the opposite — full document Markdown, blocks included.)
@@ -60,7 +56,7 @@ sanitizer. `tree` / `check` / `agenda` JSON never do.
 - Mirror sigil `*anchor` is **line-initial** on its own outline line, so it does not collide with inline `*italic*`.
 - Raw HTML in titles/notes is **not** trusted: unknown tags are stripped after parse (no `<script>` injection).
 
-**Designed, not implemented**
+#### Designed, not implemented
 
 - `@layout code` — whole node rendered as a code block
 - Strikethrough (`~~x~~`) — not in the default `markdown` package grammar we use; `~~x~~` renders literally. Do not invent it yet.
@@ -79,43 +75,23 @@ Unknown `@field` is a **reader error** today (names the known fields: `@date`, `
 
 ### Includes (file composition)
 
-`@include` / `(include "path")` is **require + splice**, not textual paste. The
-included file is a normal `#lang olai` module; its top-level tasks appear
-in place of the include line. Anchors/mirrors resolve across the whole tree;
-duplicate `^id` names both files. Each task records its defining file
-(`task-file`); writes (`done` / `move` / `add --parent ^anchor`) edit that
-file, not the root. Node identity (`key` in the JSON) is minted from that
-defining file too, so a node keys the same through any root that includes it,
-and two roots sharing a fragment agree about it. The file is named relative to
-the common directory of the loaded set, so loading a fragment as its own root
-re-bases that name and re-keys its nodes — see `docs/cli.md`.
+`@include` / `(include "path")` is **require + splice**, not textual paste. The included file is a normal `#lang olai` module; its top-level tasks appear in place of the include line. Anchors/mirrors resolve across the whole tree; duplicate `^id` names both files. Each task records its defining file (`task-file`); writes (`done` / `move` / `add --parent ^anchor`) edit that file, not the root. Node identity (`key` in the JSON) is minted from that defining file too, so a node keys the same through any root that includes it, and two roots sharing a fragment agree about it. The file is named relative to the common directory of the loaded set, so loading a fragment as its own root re-bases that name and re-keys its nodes — see [docs/cli.md](cli.md).
 
 ### Mirrors
 
-A mirror is the **same node**, not a copy: shared title/fields/children. One
-node, multiple parents (DAG). Scope is the **loaded tree**: `*id` reaches an
-`^id` in the same file, or in any fragment that file `@include`s. It cannot
-reach a file nobody included — that is an unknown-anchor error, not a link.
+A mirror is the **same node**, not a copy: shared title/fields/children. One node, multiple parents (DAG). Scope is the **loaded tree**: `*id` reaches an `^id` in the same file, or in any fragment that file `@include`s. It cannot reach a file nobody included — that is an unknown-anchor error, not a link.
 
-Validation happens at compile time when the file has no `@include` (the
-expander can see the whole tree), and right after the splice otherwise; the
-checks and the messages are the same either way:
+Validation happens at compile time when the file has no `@include` (the expander can see the whole tree), and right after the splice otherwise; the checks and the messages are the same either way:
 
-- Duplicate `^id` → error, naming the first declaration (line, or the other
-  file's name once fragments are involved).
+- Duplicate `^id` → error, naming the first declaration (line, or the other file's name once fragments are involved).
 - Unknown `*id` → error, listing the anchors that do exist.
-- Cycle (direct or via other anchors) → error with path, e.g.
-  `agent -> week -> agent`.
+- Cycle (direct or via other anchors) → error with path, e.g. `agent -> week -> agent`.
 
-JSON tree sites emit `{"mirror":"id"}` (never inline the subtree). An
-`anchors` object holds each anchored node once. Agenda counts a dated node
-once (defining breadcrumb). Web view: the defining site gets `id="anchor"`;
-mirror sites render with a ↗ link to `#anchor`.
+JSON tree sites emit `{"mirror":"id"}` (never inline the subtree). An `anchors` object holds each anchored node once. Agenda counts a dated node once (defining breadcrumb). Web view: the defining site gets `id="anchor"`; mirror sites render with a ↗ link to `#anchor`.
 
 ## `#lang olai/sexp` — s-expression core
 
-The underlying form the expander sees. Useful for tests and for agents that
-prefer sexps.
+The underlying form the expander sees. Useful for tests and for agents that prefer sexps.
 
 ```racket
 #lang olai/sexp
@@ -129,9 +105,4 @@ prefer sexps.
    (t "Shipped" #:done "2026-08-03"))
 ```
 
-Keywords `#:id`, `#:date`, `#:description`, `#:done` and `#:doing` are
-optional, any order, at most once each. `#:done` / `#:doing` may be bare or
-take an ISO date/datetime, and a node may carry at most one of the two.
-Children are `(t ...)`, `(mirror "anchor")`, or `(include "relative/path.rkt")`
-— closed grammar, same three forms allowed at top level. Module exports
-`tasks`, `anchors` (hash id → task), and `includes` (absolute paths spliced in).
+Keywords `#:id`, `#:date`, `#:description`, `#:done` and `#:doing` are optional, any order, at most once each. `#:done` / `#:doing` may be bare or take an ISO date/datetime, and a node may carry at most one of the two. Children are `(t ...)`, `(mirror "anchor")`, or `(include "relative/path.rkt")` — closed grammar, same three forms allowed at top level. Module exports `tasks`, `anchors` (hash id → task), and `includes` (absolute paths spliced in).


### PR DESCRIPTION
The VOICE rule was amended: the 90s hacker persona governs the ENGLISH, not the file format. This brings every `.md` in the repo up to modern Markdown. **No wording changed** — verified word-for-word by normalizing both revisions (strip markup, collapse whitespace) and diffing; the only word-level deltas are the intended link labels and fence tags.

## Files and transformation classes

| File | Applied |
|---|---|
| `README.md` | unwrapped 80-col prose; collapsed the hand-aligned `WHY` bullet columns into plain list items; code spans (`#lang`); `docs/syntax.md` / `docs/cli.md` / `docs/hacking.md` cross-references became real links |
| `docs/cli.md` | unwrapped 80-col prose and every wrapped list item; `console` fences retagged (`bash` for the command-only `olai tree` pair, `text` for the three transcripts where output dominates); `*Errors*` / `*Sessions*` / `*Write routing under @include*` italics became anchor links |
| `docs/syntax.md` | unwrapped prose; bold-line pseudo-headings `**Ambiguity rules**` and `**Designed, not implemented**` became real `####` headings; table separator rows normalized; `docs/cli.md` reference became a link |
| `docs/hacking.md` | unwrapped prose and list items; the untagged linklet-mismatch fence got a `text` tag; `README` / `docs/cli.md` references became links |
| `CLAUDE.md` (= `AGENTS.md`, a symlink) | formatting only, wording untouched per the brief: unwrapped prose, code spans for bare identifiers/filenames/modules, the two bare URLs (hickey-lowy, odu SKILL.md) became labelled links |
| `docs/live-dsl.md` | already converted in 871d932; re-checked against the same list — three bare identifiers got code spans, one `CLAUDE.md` reference became a link |

Not touched: `Roadmap.rkt`, `.rkt` sources, `.github/workflows/`, `site/`. There are no issue/PR templates and no e2e docs to sweep.

## Verification

- `just test` — 229 passed.
- Fence parity checked per file: no untagged openers remain, and there were no 4-space-indented code blocks to convert (every block was already fenced).

## Content notes (not fixed — this was a format sweep)

- `docs/syntax.md` "Not implemented (designed, deferred)" still lists **"Live push: the page loads the htmx SSE extension but the server opens no event stream yet"**, which `docs/cli.md` and `README.md` both contradict — `/events` ships. Left alone per the brief; worth a separate content pass.
- Same section lists **"Check-off from the web view"** as deferred, which is consistent with the rest, so no flag there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)