### PR TITLE
racket: adopt the racket-skills SKILL.md conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Read [README.md](README.md) and `docs/*.md` first (especially [docs/hacking.md](
 * Module boundaries ship with `contract-out` (flat, cheap checks — never a tree walk); blame + srcloc are part of the error contract, and have tests.
 * Markdown is render-time only (web view). Strings in the struct/JSON stay verbatim.
 * Code organization/review: [kolu.dev/blog/hickey-lowy](https://kolu.dev/blog/hickey-lowy/) — separate spatial (complected concepts, Hickey) and temporal (volatility mismatches, Lowy) passes; ship only when both lenses go quiet.
+* Racket style: [notjack.space/racket-skills `racket/SKILL.md`](https://tangled.org/notjack.space/racket-skills/blob/main/racket/SKILL.md). Read it before writing `.rkt`. Two standing exceptions, both because something else here is already contract: internal invariants keep `error` and its who: (message text ships to agents, and [olai/fail.rkt](olai/fail.rkt) already owns the who:/no-who: split), and `raco fmt` is not run over this tree (the alignment in the css-expr and theme tables is read as a table).
 
 ## LAYERING
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,11 @@ Read [README.md](README.md) and `docs/*.md` first (especially [docs/hacking.md](
 
 ## WORKFLOW
 
-* `just check` / `serve` / `test` / `ci` — recipes handle `PLTUSERHOME` + `raco link`. Racket comes from the nix dev shell (nixpkgs 9.2). Don't fight `raco setup`; `PLTUSERHOME` must be writable.
+* `just check` / `serve` / `test` — recipes handle `PLTUSERHOME` + `raco link`. Racket comes from the nix dev shell (nixpkgs 9.2). Don't fight `raco setup`; `PLTUSERHOME` must be writable.
 * `just test` runs `just build` first (`raco setup --pkgs olai`) so `compiled/*.zo` exist and stay coherent after edits. `just install` alone does not recompile. Linklet mismatch → `just clean && just build` (see [docs/hacking.md](docs/hacking.md)). Repo-specific facts agents rediscover otherwise live in [docs/hacking.md](docs/hacking.md) — read it before probing css-expr or the toolchain.
 * `just test` is the only test command you run. It is the fast set; CI runs everything else on the PR.
 * Branch + PR for every change (agents included); CI green before merge. Master rejects direct pushes.
-* CI = [juspay/odu `.apm/skills/odu/SKILL.md`](https://github.com/juspay/odu/blob/master/.apm/skills/odu/SKILL.md) run on both Linux and macOS.
+* CI = https://github.com/juspay/odu/blob/master/.apm/skills/odu/SKILL.md (read this in FULL) run on both Linux and macOS. You must run CI at the end of a PR, in order to satisfy "CI green"
 * Tests parse JSON output with `read-json`. Never string-match JSON.
 
 ## VOICE

--- a/live/info.rkt
+++ b/live/info.rkt
@@ -3,7 +3,9 @@
 (define collection "live")
 (define deps '("base" "web-server-lib"))
 (define build-deps '("rackunit-lib"))
-(define pkg-desc "Live views for Racket web apps: an SSE hub with reconnect catch-up, and an htmx+idiomorph client runtime")
+(define pkg-desc
+  (string-append "Live views for Racket web apps: an SSE hub with reconnect"
+                 " catch-up, and an htmx+idiomorph client runtime"))
 (define version "0.1")
 (define pkg-authors '(srid))
 (define license 'AGPL-3.0-or-later)

--- a/live/tests/client.rkt
+++ b/live/tests/client.rkt
@@ -8,24 +8,27 @@
 ;; those is a string that has to be the same string in both files, and nothing
 ;; but this suite would notice the day it stopped being.
 
-(require rackunit
-         racket/file
+(require racket/file
          racket/string
          live/client
          (only-in live/hub heartbeat-event))
 
-;; live/tests/frame.rkt owns the wire format; this file owns the markup. The
-;; one thing both ends of the cursor have to agree on is asserted in each.
+(module+ test
+  (require rackunit))
 
-(define lv (make-live-view #:region "app" #:event "changed" #:stream "/events"
-                           #:href "/today"))
+(module+ test
+  ;; live/tests/frame.rkt owns the wire format; this file owns the markup. The
+  ;; one thing both ends of the cursor have to agree on is asserted in each.
 
-;; -> the value of `key`, or #f. Attributes are xexpr pairs: (name "value").
-(define (attr attrs key)
-  (cond [(assq key attrs) => cadr] [else #f]))
+  (define lv (make-live-view #:region "app" #:event "changed" #:stream "/events"
+                             #:href "/today"))
 
-(define (script-source name)
-  (file->string (build-path (live-static-dir) name)))
+  ;; -> the value of `key`, or #f. Attributes are xexpr pairs: (name "value").
+  (define (attr attrs key)
+    (cond [(assq key attrs) => cadr] [else #f]))
+
+  (define (script-source name)
+    (file->string (build-path (live-static-dir) name))))
 
 (module+ test
   ;; ---- the three attribute sets --------------------------------------------

--- a/live/tests/frame.rkt
+++ b/live/tests/frame.rkt
@@ -3,8 +3,10 @@
 ;; The wire format, in isolation. Every case here is a sentence from the SSE
 ;; spec that a naive implementation gets wrong.
 
-(require rackunit
-         live/frame)
+(require live/frame)
+
+(module+ test
+  (require rackunit))
 
 (module+ test
   (test-case "one event is name, payload, blank line"

--- a/live/tests/hub.rkt
+++ b/live/tests/hub.rkt
@@ -3,28 +3,31 @@
 ;; The fan-out, and the catch-up seam. No server: a subscriber is a channel,
 ;; and everything below is a local hop.
 
-(require rackunit
-         net/url
+(require net/url
          racket/promise
          web-server/http
          live/frame
          live/hub)
 
-;; -> frame string | #f. Generous: these are all local channel hops.
-(define (take-frame s [timeout 5])
-  (sync/timeout timeout (subscriber-evt s)))
+(module+ test
+  (require rackunit))
 
-(define (say name data #:id [id #f]) (make-frame name data #:id id))
+(module+ test
+  ;; -> frame string | #f. Generous: these are all local channel hops.
+  (define (take-frame s [timeout 5])
+    (sync/timeout timeout (subscriber-evt s)))
 
-;; A GET on the stream: `url` may carry the cursor a page put there, `headers`
-;; the one a reconnecting EventSource sets.
-(define (request-with #:url [u "/events"] . headers)
-  (define parsed (string->url u))
-  (request #"GET" parsed headers
-           (delay (for/list ([q (in-list (url-query parsed))])
-                    (binding:form (string->bytes/utf-8 (symbol->string (car q)))
-                                  (string->bytes/utf-8 (or (cdr q) "")))))
-           #f "1.2.3.4" 80 "1.2.3.4"))
+  (define (say name data #:id [id #f]) (make-frame name data #:id id))
+
+  ;; A GET on the stream: `url` may carry the cursor a page put there, `headers`
+  ;; the one a reconnecting EventSource sets.
+  (define (request-with #:url [u "/events"] . headers)
+    (define parsed (string->url u))
+    (request #"GET" parsed headers
+             (delay (for/list ([q (in-list (url-query parsed))])
+                      (binding:form (string->bytes/utf-8 (symbol->string (car q)))
+                                    (string->bytes/utf-8 (or (cdr q) "")))))
+             #f "1.2.3.4" 80 "1.2.3.4")))
 
 (module+ test
   ;; ---- subscription --------------------------------------------------------

--- a/olai/acp.rkt
+++ b/olai/acp.rkt
@@ -54,6 +54,7 @@
 (require json
          racket/async-channel
          racket/contract
+         racket/match
          racket/path
          racket/string
          (only-in olai/fail user-fail)
@@ -349,7 +350,7 @@
 (define (read-config-model! cl opts)
   (define o (model-config opts))
   (when o
-    (define options (let ([os (hash-ref o 'options '())]) (if (list? os) os '())))
+    (define options (list-or-empty (hash-ref o 'options '())))
     (define labels (option-labels options))
     (define current (string-or-false (hash-ref o 'currentValue #f)))
     (emit! cl (acp-config-model (and current (or (hash-ref labels current #f) current))
@@ -400,7 +401,7 @@
 (define (list-sessions cl)
   (define r (request! cl "session/list"
                       (hash 'cwd (path->string (acp-client-cwd cl)))))
-  (define raw (let ([ss (hash-ref r 'sessions '())]) (if (list? ss) ss '())))
+  (define raw (list-or-empty (hash-ref r 'sessions '())))
   (define here (as-directory (acp-client-cwd cl)))
   (define mine
     (for/list ([s (in-list raw)]
@@ -573,8 +574,8 @@
   (define err (hash-ref js 'error #f))
   (define answer
     (if (hash? err)
-        (cons 'error (let ([m (hash-ref err 'message #f)])
-                       (if (string? m) m (jsexpr->string err))))
+        (cons 'error (or (string-or-false (hash-ref err 'message #f))
+                         (jsexpr->string err)))
         (cons 'ok (hash-ref js 'result (hash)))))
   (if ch
       (async-channel-put ch answer)
@@ -608,8 +609,7 @@
          (define kind (hash-ref o 'kind ""))
          (and (string? kind)
               (string-prefix? kind "allow")
-              (let ([oid (hash-ref o 'optionId #f)])
-                (and (string? oid) oid))))))
+              (string-or-false (hash-ref o 'optionId #f))))))
 
 ;; ---- incoming notifications ------------------------------------------------
 
@@ -681,7 +681,12 @@
     [(member kind ignored-update-kinds) (void)]
     [else (log-kind-once! cl (format "session/update ~a" kind))]))
 
+;; A field the agent sent with the wrong type is a misbehaving agent, not a
+;; reason to take the client down: read it as absent. Three shapes, because
+;; the protocol only ever promises a string, a list or an object.
 (define (string-or-false v) (and (string? v) v))
+(define (list-or-empty v) (if (list? v) v '()))
+(define (hash-or-empty v) (if (hash? v) v (hash)))
 
 ;; A content block, as much of it as a chat line can show.
 (define (content-text c)
@@ -740,8 +745,8 @@
   (define r (request! cl "initialize"
                       (hash 'protocolVersion protocol-version
                             'clientCapabilities client-capabilities)))
-  (define caps (let ([c (hash-ref r 'agentCapabilities (hash))]) (if (hash? c) c (hash))))
-  (define scaps (let ([c (hash-ref caps 'sessionCapabilities (hash))]) (if (hash? c) c (hash))))
+  (define caps (hash-or-empty (hash-ref r 'agentCapabilities (hash))))
+  (define scaps (hash-or-empty (hash-ref caps 'sessionCapabilities (hash))))
   (with-state cl
     (λ ()
       (set-acp-client-can-load?! cl (eq? (hash-ref caps 'loadSession #f) #t))
@@ -758,7 +763,9 @@
                                       (log-line cl (format "session/list failed: ~a"
                                                            (exn-message e)))
                                       #f)])
-           (let ([ss (list-sessions cl)]) (and (pair? ss) (car ss))))))
+           (match (list-sessions cl)
+             [(cons newest _) newest]
+             ['() #f]))))
   (cond
     [latest (load-session! cl
                            (hash-ref latest 'sessionId)

--- a/olai/calendar.rkt
+++ b/olai/calendar.rkt
@@ -4,6 +4,7 @@
 ;; Day nodes (bare ISO titles in Daily.rkt) are tracked separately for links.
 
 (require racket/list
+         racket/match
          racket/set
          racket/string
          racket/format
@@ -49,16 +50,14 @@
 
 ;; "2026-08" -> (values 2026 8) or (values #f #f)
 (define (parse-year-month s)
-  (cond
-    [(and (string? s)
-          (regexp-match #px"^([0-9]{4})-([0-9]{2})$" s))
-     => (λ (m)
-          (define y (string->number (cadr m)))
-          (define mo (string->number (caddr m)))
-          (if (and y mo (<= 1 mo 12))
-              (values y mo)
-              (values #f #f)))]
-    [else (values #f #f)]))
+  (match s
+    [(regexp #px"^([0-9]{4})-([0-9]{2})$" (list _ year month))
+     (define y (string->number year))
+     (define mo (string->number month))
+     (if (and y mo (<= 1 mo 12))
+         (values y mo)
+         (values #f #f))]
+    [_ (values #f #f)]))
 
 (define (format-year-month y m)
   (format "~a-~a" y (~r m #:min-width 2 #:pad-string "0")))

--- a/olai/capture.rkt
+++ b/olai/capture.rkt
@@ -35,20 +35,19 @@
     [(line-blank? k) 'blank]
     [(line-lang? k) 'lang]
     [(and (line-title? k) (even? ind))
-     (list 'title level (cadr k) (cadddr k))]
+     (list 'title level (title-text k) (title-anchor k))]
     [else (list 'other level content)]))
 
 ;; Returns (values insert-pos has-parent? task-line-1-based parent-indent)
 ;; parent-spec: #f | string title | (cons 'anchor id-string)
 (define (find-parent-insert text parent-spec)
   (define lines (string-split text "\n" #:trim? #f))
-  (define want-title
-    (cond
-      [(not parent-spec) "Inbox"]
-      [(string? parent-spec) parent-spec]
-      [else #f]))
-  (define want-anchor
-    (and (pair? parent-spec) (eq? (car parent-spec) 'anchor) (cdr parent-spec)))
+  (define-values (want-title want-anchor)
+    (match parent-spec
+      [#f (values "Inbox" #f)]
+      [(? string? title) (values title #f)]
+      [(cons 'anchor anchor) (values #f anchor)]
+      [_ (values #f #f)]))
 
   (define-values (parent-line parent-indent end-line)
     (let loop ([i 0] [pline #f] [pind 0] [seen? #f])
@@ -108,12 +107,10 @@
                         #:description [desc #f]
                         #:parent [parent #f])
   (define parent-spec
-    (cond
-      [(not parent) #f]
-      [(and (string? parent) (regexp-match #px"^\\^([A-Za-z0-9_-]+)$" parent))
-       => (λ (m) (cons 'anchor (cadr m)))]
-      [(string? parent) parent]
-      [else parent]))
+    (match parent
+      [#f #f]
+      [(regexp #px"^\\^([A-Za-z0-9_-]+)$" (list _ anchor)) (cons 'anchor anchor)]
+      [_ parent]))
   (define-values (pos has-parent? line-no parent-indent)
     (find-parent-insert text parent-spec))
   (define child-indent
@@ -123,13 +120,13 @@
   (define create-inbox?
     (and (not has-parent?) (not parent-spec)))
   (define block
-    (if has-parent?
-        (string-append (string-join body-lines "\n") "\n")
-        (if create-inbox?
-            (string-append "Inbox\n" (string-join body-lines "\n") "\n")
-            (if (pair? parent-spec)
-                (user-fail "no task with anchor ^~a" (cdr parent-spec))
-                (user-fail "no task titled ~s" parent-spec)))))
+    (cond
+      [has-parent? (string-append (string-join body-lines "\n") "\n")]
+      [create-inbox?
+       (string-append "Inbox\n" (string-join body-lines "\n") "\n")]
+      [(pair? parent-spec)
+       (user-fail "no task with anchor ^~a" (cdr parent-spec))]
+      [else (user-fail "no task titled ~s" parent-spec)]))
   (define prefix (substring text 0 pos))
   (define suffix (substring text pos))
   (define new-text
@@ -139,14 +136,18 @@
                        suffix)
         (string-append (if (string=? text "") "" (ensure-nl text))
                        block)))
-  (define actual-line
-    (if has-parent?
-        line-no
-        (let* ([base-text (if (string=? text "") "" (ensure-nl text))]
-               [lines (string-split base-text "\n" #:trim? #f)]
-               [line-count (if (and (pair? lines) (string=? (last lines) ""))
-                               (sub1 (length lines))
-                               (length lines))])
-          (+ line-count 2))))
-  (values new-text actual-line create-inbox?))
+  (values new-text
+          (if has-parent? line-no (appended-line-number text))
+          create-inbox?))
+
+;; Where a block appended to the end of `text` starts, 1-based: past every
+;; line the text already has, plus the "Inbox" line written above the task.
+(define (appended-line-number text)
+  (define base-text (if (string=? text "") "" (ensure-nl text)))
+  (define lines (string-split base-text "\n" #:trim? #f))
+  (define line-count
+    (if (and (pair? lines) (string=? (last lines) ""))
+        (sub1 (length lines))
+        (length lines)))
+  (+ line-count 2))
 

--- a/olai/cli.rkt
+++ b/olai/cli.rkt
@@ -108,52 +108,53 @@
                includes)]
         [(load-error msg src line col)
          (list 'error path msg src line col)])))
-  (define any-bad? (ormap (λ (r) (eq? (car r) 'error)) results))
-  (if (= (length paths) 1)
-      (match (car results)
-        [(list 'ok path n ac mc includes)
-         (write-json-stdout
-          (let ([h (ok-hash 'file (path->string path)
-                            'tasks n
-                            'anchors ac
-                            'mirrors mc)])
-            (if (null? includes)
-                h
-                (hash-set h 'includes
-                          (for/list ([p includes])
-                            (hash 'file p))))))]
-        [(list 'error path msg src line col)
-         (die exit-validation msg #:json? #t #:file src #:line line #:col col)])
-      (let ([files
-             (for/list ([r (in-list results)])
-               (match r
-                 [(list 'ok path n ac mc includes)
-                  (define h
-                    (hash 'file (path->string path)
-                          'ok #t
-                          'tasks n
-                          'anchors ac
-                          'mirrors mc))
-                  (if (null? includes)
-                      h
-                      (hash-set h 'includes
-                                (for/list ([p includes])
-                                  (hash 'file p))))]
-                 [(list 'error path msg src line col)
-                  (hash 'file (path->string path)
-                        'ok #f
-                        'error (hash 'file (nullish (and src
-                                                         (if (path? src)
-                                                             (path->string src)
-                                                             src)))
-                                     'line (nullish line)
-                                     'col (nullish col)
-                                     'message msg))]))])
+  (define any-bad?
+    (for/or ([r (in-list results)]) (eq? (first r) 'error)))
+  ;; The @include list rides along only when the file has one — an absent key
+  ;; and an empty list are not the same answer.
+  (define (with-includes h includes)
+    (if (null? includes)
+        h
+        (hash-set h 'includes
+                  (for/list ([p (in-list includes)]) (hash 'file p)))))
+  (cond
+    [(= (length paths) 1)
+     (match (first results)
+       [(list 'ok path n ac mc includes)
         (write-json-stdout
-         (hash 'version json-reply-version
-               'ok (not any-bad?)
-               'files files))
-        (when any-bad? (exit exit-validation)))))
+         (with-includes (ok-hash 'file (path->string path)
+                                 'tasks n
+                                 'anchors ac
+                                 'mirrors mc)
+                        includes))]
+       [(list 'error path msg src line col)
+        (die exit-validation msg #:json? #t #:file src #:line line #:col col)])]
+    [else
+     (define files
+       (for/list ([r (in-list results)])
+         (match r
+           [(list 'ok path n ac mc includes)
+            (with-includes (hash 'file (path->string path)
+                                 'ok #t
+                                 'tasks n
+                                 'anchors ac
+                                 'mirrors mc)
+                           includes)]
+           [(list 'error path msg src line col)
+            (hash 'file (path->string path)
+                  'ok #f
+                  'error (hash 'file (nullish (and src
+                                                   (if (path? src)
+                                                       (path->string src)
+                                                       src)))
+                               'line (nullish line)
+                               'col (nullish col)
+                               'message msg))])))
+     (write-json-stdout
+      (hash 'version json-reply-version
+            'ok (not any-bad?)
+            'files files))
+     (when any-bad? (exit exit-validation))]))
 
 (define (cmd-tree paths)
   (define entries

--- a/olai/daily.rkt
+++ b/olai/daily.rkt
@@ -4,6 +4,7 @@
 
 (require racket/file
          racket/list
+         racket/match
          racket/path
          racket/string
          racket/format
@@ -43,15 +44,23 @@
   (define k (classify-line content))
   (and (line-title? k)
        (even? ind)
-       (list ind (cadr k))))
+       (list ind (title-text k))))
 
-(define (find-title-line lines title indent)
-  (for/or ([i (in-range (length lines))])
-    (define info (scan-title-line (list-ref lines i)))
-    (and info
-         (= (car info) indent)
-         (equal? (cadr info) title)
-         i)))
+;; The year node of a monolithic Daily.rkt: a top-level 4-digit title.
+;; Takes a scan-title-line answer, gives back the year string or #f.
+(define (year-node-title info)
+  (match info
+    [(list 0 (and year (regexp #px"^[0-9]{4}$"))) year]
+    [_ #f]))
+
+;; The first line in [start, end) that is `title` at `indent`, or #f.
+(define (find-title-line lines title indent
+                         #:from [start 0]
+                         #:to [end (length lines)])
+  (for/or ([i (in-range start end)])
+    (match (scan-title-line (list-ref lines i))
+      [(list (== indent) (== title)) i]
+      [_ #f])))
 
 (define (section-end lines parent-idx parent-indent)
   (define child-indent (+ parent-indent 2))
@@ -60,13 +69,11 @@
       [(>= i (length lines)) i]
       [(blank-line? (list-ref lines i)) (loop (add1 i))]
       [else
-       (define info (scan-title-line (list-ref lines i)))
-       (cond
-         [(not info)
+       (match (scan-title-line (list-ref lines i))
+         [(list indent _) (if (< indent child-indent) i (loop (add1 i)))]
+         [#f
           (define-values (ind _) (line-indent+content (list-ref lines i)))
-          (if (< ind child-indent) i (loop (add1 i)))]
-         [(< (car info) child-indent) i]
-         [else (loop (add1 i))])])))
+          (if (< ind child-indent) i (loop (add1 i)))])])))
 
 (define (lines->text lines original)
   (define body (string-join lines "\n"))
@@ -153,44 +160,35 @@
   (define year-i (find-title-line root-lines* year-title 0))
   (unless year-i (error 'daily "internal: year node missing"))
 
+  (define year-end (section-end root-lines* year-i 0))
   (define mon-i
-    (let ([end (section-end root-lines* year-i 0)])
-      (for/or ([i (in-range (add1 year-i) end)])
-        (define info (scan-title-line (list-ref root-lines* i)))
-        (and info (= (car info) 2) (equal? (cadr info) mon-title) i))))
+    (find-title-line root-lines* mon-title 2 #:from (add1 year-i) #:to year-end))
 
   (define root-lines**
     (if mon-i
         root-lines*
-        (let ([end (section-end root-lines* year-i 0)])
-          (append (take root-lines* end)
-                  (list (string-append "  " mon-title))
-                  (drop root-lines* end)))))
+        (append (take root-lines* year-end)
+                (list (string-append "  " mon-title))
+                (drop root-lines* year-end))))
 
-  (define mon-i*
-    (or mon-i
-        (for/or ([i (in-range (length root-lines**))])
-          (define info (scan-title-line (list-ref root-lines** i)))
-          (and info (= (car info) 2) (equal? (cadr info) mon-title) i))))
+  (define mon-i* (or mon-i (find-title-line root-lines** mon-title 2)))
   (unless mon-i* (error 'daily "internal: month node missing"))
 
   (define include-line (string-append "    @include " rel))
+  (define mon-end (section-end root-lines** mon-i* 2))
   (define has-include?
-    (let ([end (section-end root-lines** mon-i* 2)])
-      (for/or ([i (in-range (add1 mon-i*) end)])
-        (regexp-match?
-         (pregexp (string-append "^\\s*@include\\s+" (regexp-quote rel) "\\s*$"))
-         (list-ref root-lines** i)))))
+    (for/or ([i (in-range (add1 mon-i*) mon-end)])
+      (regexp-match?
+       (pregexp (string-append "^\\s*@include\\s+" (regexp-quote rel) "\\s*$"))
+       (list-ref root-lines** i))))
 
-  (define added-include? #f)
+  (define added-include? (not has-include?))
   (define root-lines***
     (if has-include?
         root-lines**
-        (let ([end (section-end root-lines** mon-i* 2)])
-          (set! added-include? #t)
-          (append (take root-lines** end)
-                  (list include-line)
-                  (drop root-lines** end)))))
+        (append (take root-lines** mon-end)
+                (list include-line)
+                (drop root-lines** mon-end))))
 
   (define root-text* (lines->text root-lines*** root-text))
   (unless (equal? root-text* root-text)
@@ -232,39 +230,37 @@
     (set! day-buf '())
     (set! current-day #f))
 
+  ;; A line under a day node moves up two levels when the day becomes the
+  ;; fragment's top node.
+  (define (dedented s)
+    (define-values (ind content) (line-indent+content s))
+    (string-append (make-string (max 0 (- ind 4)) #\space) content))
+
   (for ([s (in-list lines)])
     (define info (scan-title-line s))
-    (cond
-      [(and info (zero? (car info)) (regexp-match? #px"^[0-9]{4}$" (cadr info)))
+    (match info
+      [(app year-node-title (? string? year))
        (flush-day!)
-       (set! current-year (string->number (cadr info)))
+       (set! current-year (string->number year))
        (set! current-month #f)]
-      [(and info (= (car info) 2) current-year)
+      [(list 2 month)
+       #:when current-year
        (flush-day!)
-       (define m
-         (for/or ([i (in-range 1 13)])
-           (and (equal? (month-name i) (cadr info)) i)))
-       (set! current-month m)]
-      [(and info (= (car info) 4) current-year current-month
-            (bare-iso-date-title? (cadr info)))
+       (set! current-month
+             (for/or ([i (in-range 1 13)])
+               (and (equal? (month-name i) month) i)))]
+      [(list 4 (? bare-iso-date-title? day))
+       #:when (and current-year current-month)
        (flush-day!)
-       (set! current-day (cadr info))
-       (set! day-buf (list (cadr info)))]
-      [(and current-day info)
-       (define-values (ind content) (line-indent+content s))
-       (define new-ind (max 0 (- ind 4)))
-       (set! day-buf
-             (cons (string-append (make-string new-ind #\space) content)
-                   day-buf))]
-      [(and current-day (not info) (not (blank-line? s)))
-       (define-values (ind content) (line-indent+content s))
-       (define new-ind (max 0 (- ind 4)))
-       (set! day-buf
-             (cons (string-append (make-string new-ind #\space) content)
-                   day-buf))]
-      [(and current-day (blank-line? s))
-       (set! day-buf (cons "" day-buf))]
-      [else (void)]))
+       (set! current-day day)
+       (set! day-buf (list day))]
+      [_
+       (cond
+         [(and current-day (or info (not (blank-line? s))))
+          (set! day-buf (cons (dedented s) day-buf))]
+         [(and current-day (blank-line? s))
+          (set! day-buf (cons "" day-buf))]
+         [else (void)])]))
   (flush-day!)
 
   (when (hash-empty? result)
@@ -285,17 +281,11 @@
     (display-to-file body frag #:exists 'truncate/replace)
     (dynamic-require `(file ,(path->string frag)) 'tasks))
 
+  ;; Everything above the first year node stays at the root, verbatim.
   (define header-lines
-    (let loop ([i 0] [acc '()])
-      (cond
-        [(>= i (length lines)) (reverse acc)]
-        [else
-         (define s (list-ref lines i))
-         (define info (scan-title-line s))
-         (cond
-           [(and info (zero? (car info)) (regexp-match? #px"^[0-9]{4}$" (cadr info)))
-            (reverse acc)]
-           [else (loop (add1 i) (cons s acc))])])))
+    (for/list ([s (in-list lines)]
+               #:break (year-node-title (scan-title-line s)))
+      s))
 
   (define years
     (sort (remove-duplicates

--- a/olai/dates.rkt
+++ b/olai/dates.rkt
@@ -9,7 +9,8 @@
 ;;   YYYY-MM-DD HH:MM[ :SS]   (space ok; normalized to T)
 ;; Optional trailing Z / offset when gregor accepts it.
 
-(require racket/string
+(require racket/match
+         racket/string
          (only-in gregor iso8601->date iso8601->datetime today ~t))
 
 (provide valid-iso-date-string?
@@ -21,20 +22,24 @@
 
 ;; "2026-08-04 14:30" -> "2026-08-04T14:30"
 (define (normalize-date-string s)
-  (cond
-    [(regexp-match #px"^([0-9]{4}-[0-9]{2}-[0-9]{2})[ ]+([0-9].*)$" s)
-     => (λ (m) (string-append (cadr m) "T" (caddr m)))]
-    [else s]))
+  (match s
+    [(regexp #px"^([0-9]{4}-[0-9]{2}-[0-9]{2})[ ]+([0-9].*)$" (list _ day time))
+     (string-append day "T" time)]
+    [_ s]))
+
+;; True when `parse` accepts the string rather than raising.
+(define (parses? parse s)
+  (with-handlers ([exn:fail? (λ (_) #f)])
+    (parse s)
+    #t))
 
 (define (valid-iso-date-string? s)
-  (and (string? s)
-       (let ([s (normalize-date-string s)])
-         (or (with-handlers ([exn:fail? (λ (_) #f)])
-               (iso8601->date s)
-               #t)
-             (with-handlers ([exn:fail? (λ (_) #f)])
-               (iso8601->datetime s)
-               #t)))))
+  (cond
+    [(string? s)
+     (define n (normalize-date-string s))
+     (or (parses? iso8601->date n)
+         (parses? iso8601->datetime n))]
+    [else #f]))
 
 ;; Calendar day for agenda buckets: first 10 chars of a normalized ISO string.
 (define (date-day-prefix s)

--- a/olai/ics.rkt
+++ b/olai/ics.rkt
@@ -5,6 +5,7 @@
 ;; via raco pkg catalog-show ics / icalendar); a thin writer is justified.
 
 (require racket/list
+         racket/match
          racket/path
          racket/string
          file/sha1
@@ -33,17 +34,13 @@
                   (cons (substring rest 0 75) acc))))))
 
 (define (dt-value iso)
-  (define n (normalize-date-string iso))
-  (cond
-    [(regexp-match #px"^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2})(?::([0-9]{2}))?" n)
-     => (λ (m)
-          (format "~a~a~aT~a~a~a"
-                  (cadr m) (caddr m) (cadddr m)
-                  (list-ref m 4) (list-ref m 5)
-                  (or (list-ref m 6) "00")))]
-    [(regexp-match #px"^([0-9]{4})-([0-9]{2})-([0-9]{2})$" n)
-     => (λ (m) (format "~a~a~a" (cadr m) (caddr m) (cadddr m)))]
-    [else n]))
+  (match (normalize-date-string iso)
+    [(regexp #px"^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2})(?::([0-9]{2}))?"
+             (list _ y m d hh mm ss))
+     (format "~a~a~aT~a~a~a" y m d hh mm (or ss "00"))]
+    [(regexp #px"^([0-9]{4})-([0-9]{2})-([0-9]{2})$" (list _ y m d))
+     (format "~a~a~a" y m d)]
+    [n n]))
 
 (define (uid-for path title date id)
   (define base
@@ -108,11 +105,11 @@
   (vcalendar
    (append*
     (for/list ([e (in-list file-entries)])
-      (define path (car e))
+      (match-define (cons path tasks) e)
       ;; ICS events are read outside the outline, so every breadcrumb is
       ;; file-rooted here, single file or not.
       (append*
-       (for/list ([it (in-list (collect-cal-items (cdr e)
+       (for/list ([it (in-list (collect-cal-items tasks
                                                   #:root (file-label path)))])
          (vevent (path-string path) it)))))))
 

--- a/olai/index.rkt
+++ b/olai/index.rkt
@@ -18,6 +18,7 @@
 
 (require racket/contract
          racket/list
+         racket/match
          (except-in olai/lang/expander #%module-begin)
          olai/lang/walk)
 
@@ -43,9 +44,9 @@
 (define (outline-index files-data)
   (define idx (make-hash))
   (for ([e (in-list files-data)])
-    (define file (car e))
+    (match-define (list file tasks) e)
     (fold-tasks
-     (cadr e)
+     tasks
      (λ (tk path acc)
        (define key (task-key tk))
        (unless (hash-has-key? idx key)

--- a/olai/lang/expander.rkt
+++ b/olai/lang/expander.rkt
@@ -308,8 +308,7 @@
        #:describe ir-loc
        #:fail (λ (who ir msg)
                 (raise-syntax-error who msg (and ir (ir-stx ir))))))
-    (void))
-  )
+    (void)))
 
 ;; ---- runtime include load + tree validation ------------------------------
 
@@ -499,6 +498,19 @@
       "expected (include \"relative/path.rkt\")"
       stx)]))
 
+;; The shape of `t`, spelled once for the two clauses that answer with it.
+(define-for-syntax t-shape
+  (string-append "expected (t \"title\" [#:id anchor] [#:date iso-date] "
+                 "[#:description \"...\"] [#:done [iso-date]] "
+                 "[#:doing [iso-date]] child ...)"))
+
+;; What a malformed `t` is blamed on: the title the source wrote, when it
+;; wrote one, else the whole form.
+(define-for-syntax (t-title-stx stx)
+  (match (syntax-e stx)
+    [(list-rest _ title _) title]
+    [_ stx]))
+
 (define-syntax (t stx)
   (syntax-parse stx
     [(_ title:str kw:t-kwargs child:child-form ...)
@@ -544,15 +556,10 @@
     [(_ title . _)
      (raise-syntax-error
       't
-      "expected (t \"title\" [#:id anchor] [#:date iso-date] [#:description \"...\"] [#:done [iso-date]] [#:doing [iso-date]] child ...); title must be a string literal"
+      (string-append t-shape "; title must be a string literal")
       stx
-      (let ([e (syntax-e stx)])
-        (if (and (pair? e) (pair? (cdr e))) (cadr e) stx)))]
-    [_
-     (raise-syntax-error
-      't
-      "expected (t \"title\" [#:id anchor] [#:date iso-date] [#:description \"...\"] [#:done [iso-date]] [#:doing [iso-date]] child ...)"
-      stx)]))
+      (t-title-stx stx))]
+    [_ (raise-syntax-error 't t-shape stx)]))
 
 (define-syntax (module-begin stx)
   (syntax-parse stx

--- a/olai/lang/line.rkt
+++ b/olai/lang/line.rkt
@@ -28,6 +28,7 @@
 ;;   (meta bad MESSAGE)
 
 (require racket/contract
+         racket/match
          racket/string)
 
 ;; The grammar is a boundary five modules read across, so it is contracted:
@@ -50,6 +51,9 @@
           [line-include? (-> classification/c boolean?)]
           [line-meta? (-> classification/c boolean?)]
           [meta-field (-> classification/c (or/c 'desc 'date 'done 'doing 'bad #f))]
+          [title-text (-> classification/c (or/c string? #f))]
+          [title-flag (-> classification/c (or/c 'done 'doing 'open #f))]
+          [title-anchor (-> classification/c (or/c string? #f))]
           [strip-checkbox-prefix (-> string? any)]
           [strip-trailing-anchor (-> string? any)]))
 
@@ -58,77 +62,75 @@
 
 ;; Leading spaces are structure; everything after them is the line's content.
 (define (line-indent+content s)
-  (define m (regexp-match #px"^( *)(.*)$" s))
-  (values (string-length (cadr m)) (caddr m)))
+  (match-define (list _ spaces content) (regexp-match #px"^( *)(.*)$" s))
+  (values (string-length spaces) content))
 
 ;; Title checkbox sugar: "[x] " / "[X] " → done, "[/] " → doing (the Obsidian
 ;; community spelling for in-progress; "[-] " is left unclaimed for a future
 ;; cancelled), "[ ] " → open (stripped). All #t-valued marks; the timestamped
 ;; form is the @field.
 (define (strip-checkbox-prefix title)
-  (cond
-    [(regexp-match #px"^\\[[xX]\\] (.*)$" title)
-     => (λ (m) (values (cadr m) 'done))]
-    [(regexp-match #px"^\\[/\\] (.*)$" title)
-     => (λ (m) (values (cadr m) 'doing))]
-    [(regexp-match #px"^\\[ \\] (.*)$" title)
-     => (λ (m) (values (cadr m) 'open))]
-    [else (values title #f)]))
+  (match title
+    [(regexp #px"^\\[[xX]\\] (.*)$" (list _ rest)) (values rest 'done)]
+    [(regexp #px"^\\[/\\] (.*)$" (list _ rest)) (values rest 'doing)]
+    [(regexp #px"^\\[ \\] (.*)$" (list _ rest)) (values rest 'open)]
+    [_ (values title #f)]))
 
 ;; Trailing ^anchor (not part of the verbatim title).
 ;; Returns (values title-without-anchor anchor-or-#f).
 (define (strip-trailing-anchor title)
-  (cond
-    [(regexp-match #px"^(.*\\S)\\s+\\^([A-Za-z0-9_-]+)\\s*$" title)
-     => (λ (m) (values (cadr m) (caddr m)))]
-    [(regexp-match #px"^\\^([A-Za-z0-9_-]+)\\s*$" title)
-     => (λ (m) (values "" (cadr m)))]
-    [else (values title #f)]))
+  (match title
+    [(regexp #px"^(.*\\S)\\s+\\^([A-Za-z0-9_-]+)\\s*$" (list _ text anchor))
+     (values text anchor)]
+    [(regexp #px"^\\^([A-Za-z0-9_-]+)\\s*$" (list _ anchor))
+     (values "" anchor)]
+    [_ (values title #f)]))
 
 ;; content: a line with its indentation already stripped.
 (define (classify-line content)
-  (cond
-    [(blank-line? content) '(blank)]
-    [(regexp-match? #px"^#lang\\s" content) '(lang)]
+  (match content
+    [(? blank-line?) '(blank)]
+    [(regexp #px"^#lang\\s") '(lang)]
     ;; Escape: title is the rest after `\`; no checkbox/mirror/anchor sugar.
-    [(regexp-match? #px"^\\\\" content)
+    [(regexp #px"^\\\\")
      (list 'title (substring content 1) #f #f)]
     ;; Mirror line: *anchor alone (line-initial *).
-    [(regexp-match #px"^\\*([A-Za-z0-9_-]+)\\s*$" content)
-     => (λ (m) (list 'mirror (cadr m)))]
-    [(regexp-match #px"^: (.*)$" content)
-     => (λ (m) (list 'meta 'desc (cadr m)))]
-    [(regexp-match? #px"^:($|[^ ].*)$" content)
+    [(regexp #px"^\\*([A-Za-z0-9_-]+)\\s*$" (list _ anchor))
+     (list 'mirror anchor)]
+    [(regexp #px"^: (.*)$" (list _ text))
+     (list 'meta 'desc text)]
+    [(regexp #px"^:($|[^ ].*)$")
      (list 'meta 'bad "description line must start with \": \" (colon + space)")]
-    [(regexp-match #px"^(@date[ \t]+)(\\S.*)$" content)
-     => (λ (m) (list 'meta 'date (string-trim (caddr m)) (string-length (cadr m))))]
-    [(regexp-match? #px"^@date\\s*$" content)
+    [(regexp #px"^(@date[ \t]+)(\\S.*)$" (list _ field value))
+     (list 'meta 'date (string-trim value) (string-length field))]
+    [(regexp #px"^@date\\s*$")
      (list 'meta 'bad
            "expected a date or datetime after @date (YYYY-MM-DD[THH:MM[:SS]])")]
-    [(regexp-match #px"^(@done[ \t]+)(\\S.*)$" content)
-     => (λ (m) (list 'meta 'done (string-trim (caddr m)) (string-length (cadr m))))]
-    [(regexp-match? #px"^@done\\s*$" content)
+    [(regexp #px"^(@done[ \t]+)(\\S.*)$" (list _ field value))
+     (list 'meta 'done (string-trim value) (string-length field))]
+    [(regexp #px"^@done\\s*$")
      (list 'meta 'done #t 0)]
     ;; @done's own regexps want whitespace after the name, so @doing cannot be
-    ;; read as one of them however this cond is ordered.
-    [(regexp-match #px"^(@doing[ \t]+)(\\S.*)$" content)
-     => (λ (m) (list 'meta 'doing (string-trim (caddr m)) (string-length (cadr m))))]
-    [(regexp-match? #px"^@doing\\s*$" content)
+    ;; read as one of them however this match is ordered.
+    [(regexp #px"^(@doing[ \t]+)(\\S.*)$" (list _ field value))
+     (list 'meta 'doing (string-trim value) (string-length field))]
+    [(regexp #px"^@doing\\s*$")
      (list 'meta 'doing #t 0)]
-    [(regexp-match #px"^@include[ \t]+(\\S.*)$" content)
-     => (λ (m) (list 'include (string-trim (cadr m))))]
-    [(regexp-match? #px"^@include\\s*$" content)
+    [(regexp #px"^@include[ \t]+(\\S.*)$" (list _ rel))
+     (list 'include (string-trim rel))]
+    [(regexp #px"^@include\\s*$")
      (list 'meta 'bad "expected a relative path after @include")]
-    [(regexp-match #px"^@(\\S+)" content)
-     => (λ (m)
-          (list 'meta 'bad
-                (format "unknown @~a; known fields: @date, @done, @doing, @include"
-                        (cadr m))))]
-    [else
+    [(regexp #px"^@(\\S+)" (list _ name))
+     (list 'meta 'bad
+           (format "unknown @~a; known fields: @date, @done, @doing, @include"
+                   name))]
+    [_
      (define-values (title0 flag) (strip-checkbox-prefix content))
      (define-values (title anchor) (strip-trailing-anchor title0))
      (list 'title title flag anchor)]))
 
+;; `car`, not `first`: every scan of a file runs these once per line, and the
+;; head of a classification is there by construction (classification/c).
 (define ((kind? sym) k) (eq? (car k) sym))
 
 (define line-blank? (kind? 'blank))
@@ -142,4 +144,20 @@
 
 ;; 'desc | 'date | 'done | 'doing | 'bad for a meta line, #f otherwise.
 (define (meta-field k)
-  (and (line-meta? k) (cadr k)))
+  (match k
+    [(list 'meta field _ ...) field]
+    [_ #f]))
+
+;; The three parts of a (title TEXT FLAG ANCHOR), #f when k is not a title.
+;; A title line without a checkbox or a ^anchor answers #f for those too, so
+;; ask line-title? first where the difference matters. These exist so that the
+;; modules that EDIT outline text — meta, capture, daily — do not each spell
+;; the position a part sits at; that is this file's job.
+(define (title-text k)
+  (match k [(list 'title text _ _) text] [_ #f]))
+
+(define (title-flag k)
+  (match k [(list 'title _ flag _) flag] [_ #f]))
+
+(define (title-anchor k)
+  (match k [(list 'title _ _ anchor) anchor] [_ #f]))

--- a/olai/lang/outline.rkt
+++ b/olai/lang/outline.rkt
@@ -24,7 +24,8 @@
 ;; id-info: #f or (list id-string line col)
 ;; mirror-anchor: #f or anchor string (when set, this node is a mirror leaf)
 ;; include-path: #f or relative path string (when set, this node is an include leaf)
-(struct node (title date-info done-info doing-info id-info descs children line col span src mirror-anchor include-path)
+(struct node (title date-info done-info doing-info id-info descs children
+              line col span src mirror-anchor include-path)
   #:mutable #:transparent)
 
 (define (reader-error src line col pos msg . args)
@@ -60,13 +61,13 @@
 (define (classify-content content src line col)
   ;; The reader is handed the body AFTER the #lang line, so a line that looks
   ;; like one here is an ordinary title.
+  (define classified (classify-line content))
   (define k
-    (let ([k (classify-line content)])
-      (if (line-lang? k) (list 'title content #f #f) k)))
+    (if (line-lang? classified) (list 'title content #f #f) classified))
   (match k
     [(list 'meta 'bad msg)
      (reader-error src line col #f "~a" msg)]
-    [(list 'title "" _flag (? string? anchor))
+    [(list 'title "" _ (? string? anchor))
      (reader-error src line col #f "title required before ^~a" anchor)]
     [_ k]))
 
@@ -96,6 +97,17 @@
          (list kw-stx)
          (list kw-stx (datum->syntax #f v (loc-vec src line col
                                                    (string-length v)))))]))
+
+;; descs is newest-first, so the OLDEST is the run's first line — the one the
+;; joined text is blamed on. Empty descs means the node wrote no `:` line.
+(define (description-part src descs)
+  (match (reverse descs)
+    ['() '()]
+    [(and texts (cons (list _ dline dcol) _))
+     (define joined (string-join (map car texts) "\n"))
+     (list (datum->syntax #f '#:description (loc-vec src dline dcol 1))
+           (datum->syntax #f joined
+                          (loc-vec src dline dcol (string-length joined))))]))
 
 (define (node-mirror? nd)
   (and (node-mirror-anchor nd) #t))
@@ -140,18 +152,7 @@
          [#f '()]))
      (define done-part (mark-part src '#:done (node-done-info nd)))
      (define doing-part (mark-part src '#:doing (node-doing-info nd)))
-     (define desc-part
-       (let ([ds (node-descs nd)])
-         (if (null? ds)
-             '()
-             (let* ([texts (map car (reverse ds))]
-                    [joined (string-join texts "\n")]
-                    [first (last ds)]
-                    [dline (cadr first)]
-                    [dcol (caddr first)])
-               (list (datum->syntax #f '#:description (loc-vec src dline dcol 1))
-                     (datum->syntax #f joined
-                                   (loc-vec src dline dcol (string-length joined))))))))
+     (define desc-part (description-part src (node-descs nd)))
      (define kids (map node->syntax (reverse (node-children nd))))
      (define form
        (cons (datum->syntax #f 't (loc-vec src line col span))
@@ -183,6 +184,30 @@
       (set! roots (cons nd roots)))
     (set! stack (append (take stack level) (list nd))))
 
+  ;; Every node kind runs the same two checks before it is pushed, and used to
+  ;; say so three times over: an indent may not skip a level, and a mirror or
+  ;; an include is a leaf.
+  (define (check-level! level n col)
+    (when (> level (current-depth))
+      (reader-error src n col #f
+                    (string-append "indent jumps more than one level "
+                                   "(from ~a to ~a); use 2 spaces per level")
+                    (current-depth) level))
+    (when (and (zero? (current-depth)) (positive? level))
+      (reader-error src n col #f
+                    (string-append "indent jumps more than one level "
+                                   "(from 0 to ~a); top-level tasks must "
+                                   "start at column 0")
+                    level)))
+
+  (define (check-leaf-parent! level n col)
+    (define parent (and (positive? level) (last-node-at (sub1 level))))
+    (when parent
+      (when (node-mirror? parent)
+        (reader-error src n col #f "mirror cannot have children"))
+      (when (node-include? parent)
+        (reader-error src n col #f "include cannot have children"))))
+
   (define (require-task-parent! level n col what)
     (when (zero? level)
       (reader-error src n col #f "~a with no title above" what))
@@ -207,54 +232,21 @@
        (define level (level-of ind src n col))
        (match kind
          [`(mirror ,anchor)
-          (when (> level (current-depth))
-            (reader-error src n col #f
-                          "indent jumps more than one level (from ~a to ~a); use 2 spaces per level"
-                          (current-depth) level))
-          (when (and (zero? (current-depth)) (positive? level))
-            (reader-error src n col #f
-                          "indent jumps more than one level (from 0 to ~a); top-level tasks must start at column 0"
-                          level))
-          (when (and (positive? level)
-                     (let ([p (last-node-at (sub1 level))])
-                       (and p (or (node-mirror? p) (node-include? p)))))
-            (reader-error src n col #f
-                          (if (node-mirror? (last-node-at (sub1 level)))
-                              "mirror cannot have children"
-                              "include cannot have children")))
+          (check-level! level n col)
+          (check-leaf-parent! level n col)
           (set! stack (take stack level))
           (define nd
             (node #f #f #f #f #f '() '() n col (string-length content) src anchor #f))
           (push-node! nd level)]
          [`(include ,path)
-          (when (> level (current-depth))
-            (reader-error src n col #f
-                          "indent jumps more than one level (from ~a to ~a); use 2 spaces per level"
-                          (current-depth) level))
-          (when (and (zero? (current-depth)) (positive? level))
-            (reader-error src n col #f
-                          "indent jumps more than one level (from 0 to ~a); top-level tasks must start at column 0"
-                          level))
-          (when (and (positive? level)
-                     (let ([p (last-node-at (sub1 level))])
-                       (and p (or (node-mirror? p) (node-include? p)))))
-            (reader-error src n col #f
-                          (if (node-mirror? (last-node-at (sub1 level)))
-                              "mirror cannot have children"
-                              "include cannot have children")))
+          (check-level! level n col)
+          (check-leaf-parent! level n col)
           (set! stack (take stack level))
           (define nd
             (node #f #f #f #f #f '() '() n col (string-length content) src #f path))
           (push-node! nd level)]
          [`(title ,title ,flag ,anchor)
-          (when (> level (current-depth))
-            (reader-error src n col #f
-                          "indent jumps more than one level (from ~a to ~a); use 2 spaces per level"
-                          (current-depth) level))
-          (when (and (zero? (current-depth)) (positive? level))
-            (reader-error src n col #f
-                          "indent jumps more than one level (from 0 to ~a); top-level tasks must start at column 0"
-                          level))
+          (check-level! level n col)
           (set! stack (take stack level))
           ;; the checkbox IS the node's mark, so `[x] X` plus `@done` below it
           ;; is a duplicate, exactly as two `@done` lines would be

--- a/olai/lang/tags.rkt
+++ b/olai/lang/tags.rkt
@@ -17,4 +17,4 @@
 ;; "Ship #lang work #lang" -> '("lang")
 (define (title-tags title)
   (remove-duplicates
-   (regexp-match* tag-rx title #:match-select cadr)))
+   (regexp-match* tag-rx title #:match-select second)))

--- a/olai/load.rkt
+++ b/olai/load.rkt
@@ -8,6 +8,7 @@
 
 (require racket/contract
          racket/list
+         racket/match
          racket/path
          racket/string
          file/sha1
@@ -90,15 +91,13 @@
          (values fallback-path #f #f))]
     [(exn:fail:read? e)
      (define locs (exn:fail:read-srclocs e))
-     (if (pair? locs)
-         (let ([loc (last locs)])
-           (cond
-             [(srcloc? loc)
-              (values (srcloc-source loc) (srcloc-line loc) (srcloc-column loc))]
-             [(list? loc)
-              (values (list-ref loc 0) (list-ref loc 1) (list-ref loc 2))]
-             [else (values fallback-path #f #f)]))
-         (values fallback-path #f #f))]
+     (cond
+       [(null? locs) (values fallback-path #f #f)]
+       [else
+        (match (last locs)
+          [(srcloc source line column _ _) (values source line column)]
+          [(list source line column _ ...) (values source line column)]
+          [_ (values fallback-path #f #f)])])]
     [else (values fallback-path #f #f)]))
 
 (define (exn-message* e)

--- a/olai/meta.rkt
+++ b/olai/meta.rkt
@@ -48,7 +48,7 @@
 
 ;; 'desc | 'date | 'done | 'doing | 'bad, or #f when the line is not metadata.
 (define (line-field s)
-  (define-values (_ind k) (scan s))
+  (define-values (_ k) (scan s))
   (meta-field k))
 
 ;; Lines that are metadata for the title at title-idx (same indent+2, until
@@ -80,7 +80,7 @@
 ;; classify-line per entry is not a thing to do twice for a two-state answer.
 (define (title-status k meta-idxs lines)
   (define marks
-    (cons (caddr k)
+    (cons (title-flag k)
           (for/list ([i (in-list meta-idxs)]) (line-field (list-ref lines i)))))
   (cond
     [(memq 'done marks) 'done]
@@ -98,25 +98,23 @@
      (and (line-title? k)
           (even? ind)
           (keep? k)
-          (let ([meta (metadata-indices lines i ind)])
-            (title-match (add1 i) i ind
-                         (title-status k meta lines)
-                         (cadr k)))))))
+          (title-match (add1 i) i ind
+                       (title-status k (metadata-indices lines i ind) lines)
+                       (title-text k))))))
 
 ;; Find all title lines whose effective title equals `title` exactly.
 (define (find-title-matches text title)
-  (find-title-lines text (λ (k) (equal? (cadr k) title))))
+  (find-title-lines text (λ (k) (equal? (title-text k) title))))
 
 ;; Find the title line declaring ^anchor (at most one if the file is valid).
 (define (find-anchor-matches text anchor)
-  (find-title-lines text (λ (k) (equal? (cadddr k) anchor))))
+  (find-title-lines text (λ (k) (equal? (title-anchor k) anchor))))
 
 ;; 'title | 'anchor
 (define (parse-title-or-anchor s)
-  (cond
-    [(regexp-match #px"^\\^([A-Za-z0-9_-]+)$" (string-trim s))
-     => (λ (m) (cons 'anchor (cadr m)))]
-    [else (cons 'title s)]))
+  (match (string-trim s)
+    [(regexp #px"^\\^([A-Za-z0-9_-]+)$" (list _ anchor)) (cons 'anchor anchor)]
+    [_ (cons 'title s)]))
 
 ;; How a spec is quoted in messages: ^anchors bare, titles quoted.
 (define (spec-label spec)

--- a/olai/ops.rkt
+++ b/olai/ops.rkt
@@ -177,12 +177,15 @@
 
 (define mark-state/c (or/c 'done 'doing))
 
-;; state -> (mark undo commit-verb undo-verb), where mark/undo are the text
-;; mutators olai/status owns. The commit verbs are what a `git log` reads
-;; like, which is the only reason they are not just the state's name.
+;; mark/undo are the text mutators olai/status owns. The verbs are what a
+;; `git log` reads like, which is the only reason they are not just the
+;; state's name.
+(struct mark-ops (mark undo verb undo-verb) #:transparent)
+
 (define marks
-  (hash 'done (list mark-done-in-text undo-done-in-text "done" "undone")
-        'doing (list mark-doing-in-text undo-doing-in-text "doing" "not-doing")))
+  (hash 'done (mark-ops mark-done-in-text undo-done-in-text "done" "undone")
+        'doing (mark-ops mark-doing-in-text undo-doing-in-text
+                         "doing" "not-doing")))
 
 ;; state: which mark this is, so a caller (and the CLI's JSON) need not be
 ;;        told twice
@@ -193,7 +196,7 @@
 (define (ops-mark! file state spec today
                    #:undo? [undo? #f]
                    #:commit? [commit? #t])
-  (define row (hash-ref marks state))
+  (define ops (hash-ref marks state))
   (define root-path (existing-file file))
   (define hit
     (as-validation root-path
@@ -207,9 +210,9 @@
      path
      (λ ()
        (if undo?
-           ((cadr row) original spec #:at at)
-           ((car row) original spec today #:at at)))))
-  (define verb (if undo? (cadddr row) (caddr row)))
+           ((mark-ops-undo ops) original spec #:at at)
+           ((mark-ops-mark ops) original spec today #:at at)))))
+  (define verb (if undo? (mark-ops-undo-verb ops) (mark-ops-verb ops)))
   (define committed?
     (write! path new-text #:commit (and commit? (format "~a: ~a" verb title))))
   (mark-result (path->string path) title line state

--- a/olai/store.rkt
+++ b/olai/store.rkt
@@ -25,6 +25,7 @@
 
 (require racket/contract
          racket/list
+         racket/match
          racket/path
          racket/port
          syntax/modread
@@ -166,7 +167,8 @@
 ;; #f. First match in file order, so the answer does not depend on hash order.
 (define (snapshot-day-key snap iso-day)
   (for/or ([e (in-list (snapshot-files-data snap))])
-    (fold-tasks (cadr e)
+    (match-define (list _ tasks) e)
+    (fold-tasks tasks
                 (λ (tk _path acc)
                   (or acc (and (equal? (task-title tk) iso-day) (task-key tk))))
                 #f)))

--- a/olai/tests/agenda.rkt
+++ b/olai/tests/agenda.rkt
@@ -1,14 +1,17 @@
 #lang racket/base
 
-(require rackunit
-         racket/list
+(require racket/list
          racket/path
          (except-in olai/lang/expander #%module-begin)
          olai/agenda)
 
-(define (tk title date desc kids #:done [done #f] #:doing [doing #f] #:id [id #f])
-  (make-task #:title title #:date date #:description desc #:done done
-             #:doing doing #:id id #:children kids #:key (or id title)))
+(module+ test
+  (require rackunit))
+
+(module+ test
+  (define (tk title date desc kids #:done [done #f] #:doing [doing #f] #:id [id #f])
+    (make-task #:title title #:date date #:description desc #:done done
+               #:doing doing #:id id #:children kids #:key (or id title))))
 
 (module+ test
   (define sample

--- a/olai/tests/calendar.rkt
+++ b/olai/tests/calendar.rkt
@@ -1,14 +1,17 @@
 #lang racket/base
 
-(require rackunit
-         racket/set
+(require racket/set
          (except-in olai/lang/expander #%module-begin)
          olai/calendar
          olai/dates)
 
-(define (tk title date desc kids #:done [done #f] #:doing [doing #f] #:id [id #f])
-  (make-task #:title title #:date date #:description desc #:done done
-             #:doing doing #:id id #:children kids #:key (or id title)))
+(module+ test
+  (require rackunit))
+
+(module+ test
+  (define (tk title date desc kids #:done [done #f] #:doing [doing #f] #:id [id #f])
+    (make-task #:title title #:date date #:description desc #:done done
+               #:doing doing #:id id #:children kids #:key (or id title))))
 
 (module+ test
   (test-case "collect keeps every state; mirrors once"

--- a/olai/tests/capture.rkt
+++ b/olai/tests/capture.rkt
@@ -1,8 +1,10 @@
 #lang racket/base
 
-(require rackunit
-         racket/string
+(require racket/string
          olai/capture)
+
+(module+ test
+  (require rackunit))
 
 (module+ test
   (test-case "format-capture-lines"

--- a/olai/tests/contracts.rkt
+++ b/olai/tests/contracts.rkt
@@ -7,8 +7,7 @@
 ;; jump to. That is the difference between "expected string?, given 42" and a
 ;; regexp failing four frames deep inside someone else's regexp.
 
-(require rackunit
-         racket/string
+(require racket/string
          (except-in olai/lang/expander #%module-begin)
          olai/index
          olai/lang/line
@@ -17,15 +16,19 @@
          olai/web/render
          olai/web/watch)
 
-(define here "tests/contracts.rkt")
+(module+ test
+  (require rackunit))
 
-;; The caller is blamed, and the module that owns the contract is named.
-(define ((blames owner) e)
-  (define msg (exn-message e))
-  (and (exn:fail:contract? e)
-       (string-contains? msg "blaming:")
-       (string-contains? msg here)
-       (string-contains? msg owner)))
+(module+ test
+  (define here "tests/contracts.rkt")
+
+  ;; The caller is blamed, and the module that owns the contract is named.
+  (define ((blames owner) e)
+    (define msg (exn-message e))
+    (and (exn:fail:contract? e)
+         (string-contains? msg "blaming:")
+         (string-contains? msg here)
+         (string-contains? msg owner))))
 
 (module+ test
   (test-case "lang/line: a classification is a string away, and says so"

--- a/olai/tests/edit.rkt
+++ b/olai/tests/edit.rkt
@@ -2,34 +2,37 @@
 
 ;; The shared write path. Temp dirs only, never personal data.
 
-(require rackunit
-         racket/file
+(require racket/file
          racket/list
          racket/path
          racket/string
          olai/edit
          olai/load)
 
-(define (with-temp-dir proc)
-  (define dir (make-temporary-file "sfedit~a" 'directory))
-  (dynamic-wind void (λ () (proc dir)) (λ () (delete-directory/files dir))))
+(module+ test
+  (require rackunit))
 
-(define (write-file! path text)
-  (make-parent-directory* path)
-  (display-to-file text path #:exists 'truncate/replace))
+(module+ test
+  (define (with-temp-dir proc)
+    (define dir (make-temporary-file "sfedit~a" 'directory))
+    (dynamic-wind void (λ () (proc dir)) (λ () (delete-directory/files dir))))
 
-(define (leftovers dir)
-  (filter (λ (p) (regexp-match? #px"sf-edit|sf-tmp" (path->string p)))
-          (directory-list dir)))
+  (define (write-file! path text)
+    (make-parent-directory* path)
+    (display-to-file text path #:exists 'truncate/replace))
 
-;; Collect the load-error instead of raising.
-(define (try-edit! path text)
-  (define err #f)
-  (define applied '())
-  (apply-outline-edit! path text
-                       #:on-invalid (λ (e) (set! err e))
-                       #:on-applied (λ (p) (set! applied (cons p applied))))
-  (values err (reverse applied)))
+  (define (leftovers dir)
+    (filter (λ (p) (regexp-match? #px"sf-edit|sf-tmp" (path->string p)))
+            (directory-list dir)))
+
+  ;; Collect the load-error instead of raising.
+  (define (try-edit! path text)
+    (define err #f)
+    (define applied '())
+    (apply-outline-edit! path text
+                         #:on-invalid (λ (e) (set! err e))
+                         #:on-applied (λ (p) (set! applied (cons p applied))))
+    (values err (reverse applied))))
 
 (module+ test
   (test-case "a valid edit is applied atomically and announced"

--- a/olai/tests/expander.rkt
+++ b/olai/tests/expander.rkt
@@ -1,32 +1,35 @@
 #lang racket/base
 
-(require rackunit
-         racket/file
+(require racket/file
          racket/string
          (except-in olai/lang/expander #%module-begin)
          olai/load)
 
-(define (eval-tasks src)
-  (define tmp (make-temporary-file "olai~a.rkt"))
-  (dynamic-wind
-   void
-   (λ ()
-     (display-to-file src tmp #:exists 'truncate)
-     (dynamic-require `(file ,(path->string tmp)) 'tasks))
-   (λ () (delete-file tmp))))
+(module+ test
+  (require rackunit))
 
-;; The same source through the load layer, which is what turns a syntax error
-;; into the file:line:col an agent reads. -> (values where message)
-(define (load-failure src [suffix "olai~a.rkt"])
-  (define tmp (make-temporary-file suffix))
-  (dynamic-wind
-   void
-   (λ ()
-     (display-to-file src tmp #:exists 'truncate)
-     (define r (try-load-outline tmp))
-     (check-true (load-error? r) (format "expected a load error, got ~a" r))
-     (values (or (load-error-where r) "") (load-error-message r)))
-   (λ () (delete-file tmp))))
+(module+ test
+  (define (eval-tasks src)
+    (define tmp (make-temporary-file "olai~a.rkt"))
+    (dynamic-wind
+     void
+     (λ ()
+       (display-to-file src tmp #:exists 'truncate)
+       (dynamic-require `(file ,(path->string tmp)) 'tasks))
+     (λ () (delete-file tmp))))
+
+  ;; The same source through the load layer, which is what turns a syntax error
+  ;; into the file:line:col an agent reads. -> (values where message)
+  (define (load-failure src [suffix "olai~a.rkt"])
+    (define tmp (make-temporary-file suffix))
+    (dynamic-wind
+     void
+     (λ ()
+       (display-to-file src tmp #:exists 'truncate)
+       (define r (try-load-outline tmp))
+       (check-true (load-error? r) (format "expected a load error, got ~a" r))
+       (values (or (load-error-where r) "") (load-error-message r)))
+     (λ () (delete-file tmp)))))
 
 (module+ test
   (test-case "empty module yields empty task list"

--- a/olai/tests/include.rkt
+++ b/olai/tests/include.rkt
@@ -1,7 +1,6 @@
 #lang racket/base
 
-(require rackunit
-         racket/file
+(require racket/file
          racket/path
          racket/string
          racket/port
@@ -14,21 +13,25 @@
          olai/status
          olai/daily)
 
-(define (write-outline dir name body)
-  (define p (build-path dir name))
-  (make-parent-directory* p)
-  (display-to-file body p #:exists 'truncate/replace)
-  p)
+(module+ test
+  (require rackunit))
 
-(define (make-parent-directory* path)
-  (define-values (base name dir?) (split-path path))
-  (when (path? base) (make-directory* base)))
+(module+ test
+  (define (write-outline dir name body)
+    (define p (build-path dir name))
+    (make-parent-directory* p)
+    (display-to-file body p #:exists 'truncate/replace)
+    p)
 
-(define (load-tasks path)
-  (dynamic-require `(file ,(path->string path)) 'tasks))
+  (define (make-parent-directory* path)
+    (define-values (base name dir?) (split-path path))
+    (when (path? base) (make-directory* base)))
 
-(define (load-includes path)
-  (dynamic-require `(file ,(path->string path)) 'includes))
+  (define (load-tasks path)
+    (dynamic-require `(file ,(path->string path)) 'tasks))
+
+  (define (load-includes path)
+    (dynamic-require `(file ,(path->string path)) 'includes)))
 
 (module+ test
   (test-case "include splices fragment top-level tasks"

--- a/olai/tests/index.rkt
+++ b/olai/tests/index.rkt
@@ -7,21 +7,24 @@
 ;; a test reads as "the node called X". Real keys come from the load layer; see
 ;; tests/store.rkt for those.
 
-(require rackunit
-         file/sha1
+(require file/sha1
          (except-in olai/lang/expander #%module-begin)
          (only-in olai/lang/walk resolve-mirrors)
          olai/index)
 
-(define (title-key title)
-  (string-append
-   "p" (substring (sha1 (open-input-bytes (string->bytes/utf-8 title))) 0 8)))
+(module+ test
+  (require rackunit))
 
-(define (tk title kids #:id [id #f])
-  (make-task #:title title #:id id #:children kids
-             #:key (or id (title-key title))))
+(module+ test
+  (define (title-key title)
+    (string-append
+     "p" (substring (sha1 (open-input-bytes (string->bytes/utf-8 title))) 0 8)))
 
-(define (files . entries) entries)
+  (define (tk title kids #:id [id #f])
+    (make-task #:title title #:id id #:children kids
+               #:key (or id (title-key title))))
+
+  (define (files . entries) entries))
 
 (module+ test
   (define fd

--- a/olai/tests/integration/acp.rkt
+++ b/olai/tests/integration/acp.rkt
@@ -9,88 +9,91 @@
 ;; Events are compared by name and payload, never by print form: they are
 ;; structs, and a test that matched their printing would be testing racket.
 
-(require rackunit
-         racket/async-channel
+(require racket/async-channel
          racket/string
          olai/acp
          olai/ops)
 
-(define fake-agent
-  (path->string
-   (collection-file-path "fake-acp-agent.rkt" "olai" "tests" "integration")))
+(module+ test
+  (require rackunit))
 
-;; A file that exists and is not an executable: the other way to get the
-;; agent's path wrong.
-(define example
-  (build-path (simplify-path (build-path (collection-file-path "info.rkt" "olai")
-                                         'up 'up))
-              "examples" "Example.rkt"))
+(module+ test
+  (define fake-agent
+    (path->string
+     (collection-file-path "fake-acp-agent.rkt" "olai" "tests" "integration")))
 
-;; -> (values client event-channel log-port). The subprocess is stopped on the
-;; way out whether the body finished or not.
-(define (with-client proc)
-  (define events (make-async-channel))
-  (define log (open-output-string))
-  (define cl (make-acp-client #:command fake-agent
-                              #:cwd (find-system-path 'temp-dir)
-                              #:on-event (λ (ev) (async-channel-put events ev))
-                              #:log-port log))
-  (dynamic-wind void (λ () (proc cl events log)) (λ () (acp-stop! cl))))
+  ;; A file that exists and is not an executable: the other way to get the
+  ;; agent's path wrong.
+  (define example
+    (build-path (simplify-path (build-path (collection-file-path "info.rkt" "olai")
+                                           'up 'up))
+                "examples" "Example.rkt"))
 
-;; What an event IS, in one word, so a sequence can be asserted as one value.
-(define (event-name ev)
-  (cond
-    [(acp-said? ev) 'said]
-    [(acp-user-said? ev) 'user-said]
-    [(acp-tool? ev) 'tool]
-    [(acp-tool-moved? ev) 'tool-moved]
-    [(acp-config-model? ev) 'config-model]
-    [(acp-live-model? ev) 'live-model]
-    [(acp-commands? ev) 'commands]
-    [(acp-session? ev) 'session]
-    [(acp-session-titled? ev) 'session-titled]
-    [(acp-session-over? ev) 'session-over]
-    [(acp-replay-started? ev) 'replay-started]
-    [(acp-replay-ended? ev) 'replay-ended]
-    [(acp-gone? ev) 'gone]
-    [(acp-trouble? ev) 'trouble]
-    [else 'unknown]))
+  ;; -> (values client event-channel log-port). The subprocess is stopped on the
+  ;; way out whether the body finished or not.
+  (define (with-client proc)
+    (define events (make-async-channel))
+    (define log (open-output-string))
+    (define cl (make-acp-client #:command fake-agent
+                                #:cwd (find-system-path 'temp-dir)
+                                #:on-event (λ (ev) (async-channel-put events ev))
+                                #:log-port log))
+    (dynamic-wind void (λ () (proc cl events log)) (λ () (acp-stop! cl))))
 
-(define (next-event events [timeout 30])
-  (sync/timeout timeout events))
-
-;; Every event up to and including the first one named `name` — the whole boot
-;; (or turn) as one value, so a test can assert the SEQUENCE rather than poll
-;; for parts.
-(define (events-through events name [timeout 30])
-  (let loop ([acc '()] [n 0])
+  ;; What an event IS, in one word, so a sequence can be asserted as one value.
+  (define (event-name ev)
     (cond
-      [(> n 20) (reverse acc)]
-      [else
-       (define ev (next-event events timeout))
-       (cond
-         [(not ev) (reverse acc)]
-         [(eq? (event-name ev) name) (reverse (cons ev acc))]
-         [else (loop (cons ev acc) (add1 n))])])))
+      [(acp-said? ev) 'said]
+      [(acp-user-said? ev) 'user-said]
+      [(acp-tool? ev) 'tool]
+      [(acp-tool-moved? ev) 'tool-moved]
+      [(acp-config-model? ev) 'config-model]
+      [(acp-live-model? ev) 'live-model]
+      [(acp-commands? ev) 'commands]
+      [(acp-session? ev) 'session]
+      [(acp-session-titled? ev) 'session-titled]
+      [(acp-session-over? ev) 'session-over]
+      [(acp-replay-started? ev) 'replay-started]
+      [(acp-replay-ended? ev) 'replay-ended]
+      [(acp-gone? ev) 'gone]
+      [(acp-trouble? ev) 'trouble]
+      [else 'unknown]))
 
-(define (event-names evs) (map event-name evs))
+  (define (next-event events [timeout 30])
+    (sync/timeout timeout events))
 
-(define (event-of evs name)
-  (for/or ([ev (in-list evs)]) (and (eq? (event-name ev) name) ev)))
+  ;; Every event up to and including the first one named `name` — the whole boot
+  ;; (or turn) as one value, so a test can assert the SEQUENCE rather than poll
+  ;; for parts.
+  (define (events-through events name [timeout 30])
+    (let loop ([acc '()] [n 0])
+      (cond
+        [(> n 20) (reverse acc)]
+        [else
+         (define ev (next-event events timeout))
+         (cond
+           [(not ev) (reverse acc)]
+           [(eq? (event-name ev) name) (reverse (cons ev acc))]
+           [else (loop (cons ev acc) (add1 n))])])))
 
-;; The fake agent keeps stored sessions only when it is told to, and `mode`
-;; says whose (see its header): the environment is what the subprocess
-;; inherits, so this is set around the whole of a test, agent and all.
-(define (with-stored-sessions thunk [mode #"1"])
-  (define env (current-environment-variables))
-  (dynamic-wind
-   (λ () (environment-variables-set! env #"OLAI_FAKE_ACP_STORED" mode))
-   thunk
-   (λ () (environment-variables-set! env #"OLAI_FAKE_ACP_STORED" #f))))
+  (define (event-names evs) (map event-name evs))
 
-;; What a boot says, once there is a session: which conversation, what it runs,
-;; what it offers, and the name the agent wrote for it.
-(define boot-events '(session-over session config-model commands session-titled))
+  (define (event-of evs name)
+    (for/or ([ev (in-list evs)]) (and (eq? (event-name ev) name) ev)))
+
+  ;; The fake agent keeps stored sessions only when it is told to, and `mode`
+  ;; says whose (see its header): the environment is what the subprocess
+  ;; inherits, so this is set around the whole of a test, agent and all.
+  (define (with-stored-sessions thunk [mode #"1"])
+    (define env (current-environment-variables))
+    (dynamic-wind
+     (λ () (environment-variables-set! env #"OLAI_FAKE_ACP_STORED" mode))
+     thunk
+     (λ () (environment-variables-set! env #"OLAI_FAKE_ACP_STORED" #f))))
+
+  ;; What a boot says, once there is a session: which conversation, what it runs,
+  ;; what it offers, and the name the agent wrote for it.
+  (define boot-events '(session-over session config-model commands session-titled)))
 
 (module+ test
   ;; ---- coming up -----------------------------------------------------------

--- a/olai/tests/integration/chat.rkt
+++ b/olai/tests/integration/chat.rkt
@@ -14,8 +14,7 @@
 ;; model that moved under a session, an agent that died — each of those is one
 ;; line of events and several of scripted agent.
 
-(require rackunit
-         json
+(require json
          net/http-client
          net/uri-codec
          racket/async-channel
@@ -30,294 +29,298 @@
          olai/web/markdown
          olai/web/serve)
 
-(define fake-agent
-  (path->string
-   (collection-file-path "fake-acp-agent.rkt" "olai" "tests" "integration")))
+(module+ test
+  (require rackunit))
 
-;; A file that exists and is not an executable: the other way to get the
-;; agent's path wrong.
-(define example
-  (build-path (simplify-path (build-path (collection-file-path "info.rkt" "olai")
-                                         'up 'up))
-              "examples" "Example.rkt"))
+(module+ test
+  (define fake-agent
+    (path->string
+     (collection-file-path "fake-acp-agent.rkt" "olai" "tests" "integration")))
 
-;; -> (values chat frame-channel log-port). The agent is stopped on the way
-;; out whether the body finished or not.
-(define (with-agent proc)
-  (define frames (make-async-channel))
-  (define log (open-output-string))
-  (define ag (make-chat #:command fake-agent
-                             #:cwd (find-system-path 'temp-dir)
-                             #:broadcast (λ (name data) (async-channel-put frames (cons name data)))
-                             #:log-port log))
-  (dynamic-wind void (λ () (proc ag frames log)) (λ () (chat-stop! ag))))
+  ;; A file that exists and is not an executable: the other way to get the
+  ;; agent's path wrong.
+  (define example
+    (build-path (simplify-path (build-path (collection-file-path "info.rkt" "olai")
+                                           'up 'up))
+                "examples" "Example.rkt"))
 
-;; Next frame as (cons event-name jsexpr), or #f. Generous: a subprocess boot
-;; is in here the first time.
-(define (next-frame frames [timeout 30])
-  (define f (sync/timeout timeout frames))
-  (and f (cons (car f) (string->jsexpr (cdr f)))))
+  ;; -> (values chat frame-channel log-port). The agent is stopped on the way
+  ;; out whether the body finished or not.
+  (define (with-agent proc)
+    (define frames (make-async-channel))
+    (define log (open-output-string))
+    (define ag (make-chat #:command fake-agent
+                               #:cwd (find-system-path 'temp-dir)
+                               #:broadcast (λ (name data) (async-channel-put frames (cons name data)))
+                               #:log-port log))
+    (dynamic-wind void (λ () (proc ag frames log)) (λ () (chat-stop! ag))))
 
-;; Every frame up to and including the first one of `type` — the whole turn as
-;; one value, so a test can assert the SEQUENCE rather than poll for parts.
-(define (frames-through frames type [timeout 30])
-  (let loop ([acc '()] [n 0])
-    (cond
-      [(> n 20) (reverse acc)]
-      [else
-       (define f (next-frame frames timeout))
-       (cond
-         [(not f) (reverse acc)]
-         [(equal? (hash-ref (cdr f) 'type #f) type) (reverse (cons f acc))]
-         [else (loop (cons f acc) (add1 n))])])))
+  ;; Next frame as (cons event-name jsexpr), or #f. Generous: a subprocess boot
+  ;; is in here the first time.
+  (define (next-frame frames [timeout 30])
+    (define f (sync/timeout timeout frames))
+    (and f (cons (car f) (string->jsexpr (cdr f)))))
 
-;; What a list of frames SAYS it is, in order. Two spellings because frames
-;; come two ways: named pairs off the broadcast channel, and bare jsexprs off
-;; a stream or a catch-up.
-(define (frame-types fs) (jsexpr-types (map cdr fs)))
+  ;; Every frame up to and including the first one of `type` — the whole turn as
+  ;; one value, so a test can assert the SEQUENCE rather than poll for parts.
+  (define (frames-through frames type [timeout 30])
+    (let loop ([acc '()] [n 0])
+      (cond
+        [(> n 20) (reverse acc)]
+        [else
+         (define f (next-frame frames timeout))
+         (cond
+           [(not f) (reverse acc)]
+           [(equal? (hash-ref (cdr f) 'type #f) type) (reverse (cons f acc))]
+           [else (loop (cons f acc) (add1 n))])])))
 
-(define (jsexpr-types fs)
-  (for/list ([f (in-list fs)]) (hash-ref f 'type #f)))
+  ;; What a list of frames SAYS it is, in order. Two spellings because frames
+  ;; come two ways: named pairs off the broadcast channel, and bare jsexprs off
+  ;; a stream or a catch-up.
+  (define (frame-types fs) (jsexpr-types (map cdr fs)))
 
-;; The frames of one type, in order — an assertion about WHAT a frame said
-;; rather than about where in the sequence it landed (the sequence has its own
-;; check, right above every one of these).
-(define (frames-of fs type)
-  (for/list ([f (in-list fs)]
-             #:when (equal? (hash-ref (cdr f) 'type #f) type))
-    (cdr f)))
+  (define (jsexpr-types fs)
+    (for/list ([f (in-list fs)]) (hash-ref f 'type #f)))
 
-(define (frame-of fs type)
-  (define hits (frames-of fs type))
-  (and (pair? hits) (car hits)))
+  ;; The frames of one type, in order — an assertion about WHAT a frame said
+  ;; rather than about where in the sequence it landed (the sequence has its own
+  ;; check, right above every one of these).
+  (define (frames-of fs type)
+    (for/list ([f (in-list fs)]
+               #:when (equal? (hash-ref (cdr f) 'type #f) type))
+      (cdr f)))
 
-;; What a session says about itself the moment it exists: which conversation
-;; (twice — the id as soon as there is one, the name when the agent has written
-;; one), which model it runs, which slash commands it offers. A bridge that
-;; boots lazily says all of it inside the first turn, which is the turn that
-;; booted it.
-(define boot-frames '("session" "model" "commands" "session"))
+  (define (frame-of fs type)
+    (define hits (frames-of fs type))
+    (and (pair? hits) (car hits)))
 
-;; A command list as pairs, and its key count beside it. A frame's hashes come
-;; back from read-json and the bridge's are its own, so the comparison is over
-;; content — and the count is how "and nothing else" is said.
-(define (command-pairs cs)
-  (for/list ([c (in-list cs)])
-    (list (hash-ref c 'name #f) (hash-ref c 'description #f) (hash-count c))))
+  ;; What a session says about itself the moment it exists: which conversation
+  ;; (twice — the id as soon as there is one, the name when the agent has written
+  ;; one), which model it runs, which slash commands it offers. A bridge that
+  ;; boots lazily says all of it inside the first turn, which is the turn that
+  ;; booted it.
+  (define boot-frames '("session" "model" "commands" "session"))
 
-;; A conversation with nothing behind it: the agent is never spawned, and the
-;; events a client would have delivered are handed over by hand.
-;; -> (proc chat frame-channel).
-(define (with-events proc)
-  (define frames (make-async-channel))
-  (define ch (make-chat #:command fake-agent
-                        #:cwd (find-system-path 'temp-dir)
-                        #:broadcast (λ (name data) (async-channel-put frames (cons name data)))
-                        #:log-port (open-output-string)))
-  (dynamic-wind void (λ () (proc ch frames)) (λ () (chat-stop! ch))))
+  ;; A command list as pairs, and its key count beside it. A frame's hashes come
+  ;; back from read-json and the bridge's are its own, so the comparison is over
+  ;; content — and the count is how "and nothing else" is said.
+  (define (command-pairs cs)
+    (for/list ([c (in-list cs)])
+      (list (hash-ref c 'name #f) (hash-ref c 'description #f) (hash-count c))))
 
-(define (feed! ch . events)
-  (for ([ev (in-list events)]) (chat-handle-event! ch ev)))
+  ;; A conversation with nothing behind it: the agent is never spawned, and the
+  ;; events a client would have delivered are handed over by hand.
+  ;; -> (proc chat frame-channel).
+  (define (with-events proc)
+    (define frames (make-async-channel))
+    (define ch (make-chat #:command fake-agent
+                          #:cwd (find-system-path 'temp-dir)
+                          #:broadcast (λ (name data) (async-channel-put frames (cons name data)))
+                          #:log-port (open-output-string)))
+    (dynamic-wind void (λ () (proc ch frames)) (λ () (chat-stop! ch))))
 
-;; Every frame there is, in order. Synchronous by construction: the events were
-;; handed over on this thread, so whatever they broadcast is already here.
-(define (drain frames)
-  (let loop ([acc '()])
-    (define f (async-channel-try-get frames))
-    (if f
-        (loop (cons (cons (car f) (string->jsexpr (cdr f))) acc))
-        (reverse acc))))
+  (define (feed! ch . events)
+    (for ([ev (in-list events)]) (chat-handle-event! ch ev)))
 
-(define (wait-idle ag [seconds 30])
-  (define deadline (+ (current-inexact-milliseconds) (* 1000.0 seconds)))
-  (let loop ()
-    (cond
-      [(not (chat-busy? ag)) #t]
-      [(>= (current-inexact-milliseconds) deadline) #f]
-      [else (sleep 0.02) (loop)])))
+  ;; Every frame there is, in order. Synchronous by construction: the events were
+  ;; handed over on this thread, so whatever they broadcast is already here.
+  (define (drain frames)
+    (let loop ([acc '()])
+      (define f (async-channel-try-get frames))
+      (if f
+          (loop (cons (cons (car f) (string->jsexpr (cdr f))) acc))
+          (reverse acc))))
 
-;; ---- a server with an agent in it ------------------------------------------
+  (define (wait-idle ag [seconds 30])
+    (define deadline (+ (current-inexact-milliseconds) (* 1000.0 seconds)))
+    (let loop ()
+      (cond
+        [(not (chat-busy? ag)) #t]
+        [(>= (current-inexact-milliseconds) deadline) #f]
+        [else (sleep 0.02) (loop)])))
 
-(define outline
-  (string-append "#lang olai\n" "Inbox\n" "  Buy milk\n"))
+  ;; ---- a server with an agent in it ------------------------------------------
 
-;; Boots the real server with the fake agent wired in: (proc port agent).
-;;
-;; The server boots the agent itself now, in the background, so the body runs
-;; only once that has finished: everything the boot says (the session, the
-;; model, the commands) is already out, and what a test then asserts on the
-;; stream is the turn it asked for. #:booted? #f is the other side of that —
-;; the window in which `serve` answers requests while the agent is still waking
-;; up, which is a test's business only when it is about that window.
-(define (with-server proc #:booted? [booted? #t])
-  (define dir (make-temporary-file "sfacp~a" 'directory))
-  (define f (build-path dir "Tasks.rkt"))
-  (display-to-file outline f #:exists 'truncate)
-  (define bound #f)
-  (define agent #f)
-  (define stop
-    (start-server #:port 0
-                  #:bind "127.0.0.1"
-                  #:files (list f)
-                  #:acp-command fake-agent
-                  #:on-listen (λ (p) (set! bound p))
-                  #:on-agent (λ (a) (set! agent a))))
-  (dynamic-wind
-   void
-   (λ ()
-     (when booted? (check-true (wait-booted agent) "the agent never booted"))
-     (proc bound agent))
-   (λ ()
-     (stop)
-     (delete-directory/files dir))))
+  (define outline
+    (string-append "#lang olai\n" "Inbox\n" "  Buy milk\n"))
 
-;; -> #t once the bridge has said everything a boot says (see `boot-frames`).
-;;
-;; The session id is the FIRST of those, not the last: it comes off the
-;; session/new RESULT, while the commands and the conversation's name are still
-;; a round trip away, on session/set_mode. Waiting for the id alone let those
-;; two land after the body opened /events and inside its assertions. So wait
-;; for all three — whichever way the session was got, the last frame of the
-;; boot is one of them (a new session names itself last, an adopted one already
-;; had its name and finishes on the commands).
-(define (wait-booted ag [seconds 30])
-  (define deadline (+ (current-inexact-milliseconds) (* 1000.0 seconds)))
-  (let loop ()
-    (cond
-      [(and (chat-session-id ag)
-            (pair? (chat-commands ag))
-            (chat-session-title ag))
-       #t]
-      [(>= (current-inexact-milliseconds) deadline) #f]
-      [else (sleep 0.02) (loop)])))
+  ;; Boots the real server with the fake agent wired in: (proc port agent).
+  ;;
+  ;; The server boots the agent itself now, in the background, so the body runs
+  ;; only once that has finished: everything the boot says (the session, the
+  ;; model, the commands) is already out, and what a test then asserts on the
+  ;; stream is the turn it asked for. #:booted? #f is the other side of that —
+  ;; the window in which `serve` answers requests while the agent is still waking
+  ;; up, which is a test's business only when it is about that window.
+  (define (with-server proc #:booted? [booted? #t])
+    (define dir (make-temporary-file "sfacp~a" 'directory))
+    (define f (build-path dir "Tasks.rkt"))
+    (display-to-file outline f #:exists 'truncate)
+    (define bound #f)
+    (define agent #f)
+    (define stop
+      (start-server #:port 0
+                    #:bind "127.0.0.1"
+                    #:files (list f)
+                    #:acp-command fake-agent
+                    #:on-listen (λ (p) (set! bound p))
+                    #:on-agent (λ (a) (set! agent a))))
+    (dynamic-wind
+     void
+     (λ ()
+       (when booted? (check-true (wait-booted agent) "the agent never booted"))
+       (proc bound agent))
+     (λ ()
+       (stop)
+       (delete-directory/files dir))))
 
-;; The fake agent keeps stored sessions only when it is told to (see its
-;; header): the environment is what the subprocess inherits, so this is set
-;; around the whole of a test, agent and all.
-(define (with-stored-sessions thunk)
-  (define env (current-environment-variables))
-  (dynamic-wind
-   (λ () (environment-variables-set! env #"OLAI_FAKE_ACP_STORED" #"1"))
-   thunk
-   (λ () (environment-variables-set! env #"OLAI_FAKE_ACP_STORED" #f))))
+  ;; -> #t once the bridge has said everything a boot says (see `boot-frames`).
+  ;;
+  ;; The session id is the FIRST of those, not the last: it comes off the
+  ;; session/new RESULT, while the commands and the conversation's name are still
+  ;; a round trip away, on session/set_mode. Waiting for the id alone let those
+  ;; two land after the body opened /events and inside its assertions. So wait
+  ;; for all three — whichever way the session was got, the last frame of the
+  ;; boot is one of them (a new session names itself last, an adopted one already
+  ;; had its name and finishes on the commands).
+  (define (wait-booted ag [seconds 30])
+    (define deadline (+ (current-inexact-milliseconds) (* 1000.0 seconds)))
+    (let loop ()
+      (cond
+        [(and (chat-session-id ag)
+              (pair? (chat-commands ag))
+              (chat-session-title ag))
+         #t]
+        [(>= (current-inexact-milliseconds) deadline) #f]
+        [else (sleep 0.02) (loop)])))
 
-;; /events never ends, so this keeps the port. Same shape as
-;; tests/integration/serve.rkt.
-;;
-;; A connection is told the conversation on the way in (web/chat's catch-up),
-;; and every test here opens one after the boot — so what a test is ABOUT
-;; starts after that, and this reads it off. #:caught-up-through is the last
-;; frame of the catch-up: the command list is the last thing a booted, empty
-;; conversation has to say, and a server that adopted a stored session ends on
-;; the replayed turn's `done`. #f keeps the whole stream, which is what the
-;; tests about the catch-up itself want.
-(define (open-events port #:caught-up-through [through "commands"])
-  (define-values (_status _headers in)
-    (http-sendrecv "127.0.0.1" "/events" #:port port #:method #"GET"))
-  (when through (events-through in through))
-  in)
+  ;; The fake agent keeps stored sessions only when it is told to (see its
+  ;; header): the environment is what the subprocess inherits, so this is set
+  ;; around the whole of a test, agent and all.
+  (define (with-stored-sessions thunk)
+    (define env (current-environment-variables))
+    (dynamic-wind
+     (λ () (environment-variables-set! env #"OLAI_FAKE_ACP_STORED" #"1"))
+     thunk
+     (λ () (environment-variables-set! env #"OLAI_FAKE_ACP_STORED" #f))))
 
-;; Next real event on the stream: -> (cons name data) | #f. The heartbeat is
-;; framing, not news — it is a named event (a client has to be able to notice
-;; it stopping, and a comment is invisible to one), and this is where it stops
-;; being anything a test about the conversation has to know.
-(define (next-event in #:timeout [timeout 30])
-  (define deadline (+ (current-inexact-milliseconds) (* 1000.0 timeout)))
-  (let loop ([name #f] [data '()])
-    (define left (/ (- deadline (current-inexact-milliseconds)) 1000.0))
-    (define line (and (positive? left)
-                      (sync/timeout left (read-line-evt in 'linefeed))))
-    (cond
-      [(or (not line) (eof-object? line)) #f]
-      [(string=? line "")
-       (cond
-         [(equal? name heartbeat-event) (loop #f '())]
-         [name (cons name (string-join (reverse data) "\n"))]
-         [else (loop #f '())])]
-      [(string-prefix? line "event: ") (loop (substring line 7) data)]
-      [(string-prefix? line "data: ") (loop name (cons (substring line 6) data))]
-      [else (loop name data)])))
+  ;; /events never ends, so this keeps the port. Same shape as
+  ;; tests/integration/serve.rkt.
+  ;;
+  ;; A connection is told the conversation on the way in (web/chat's catch-up),
+  ;; and every test here opens one after the boot — so what a test is ABOUT
+  ;; starts after that, and this reads it off. #:caught-up-through is the last
+  ;; frame of the catch-up: the command list is the last thing a booted, empty
+  ;; conversation has to say, and a server that adopted a stored session ends on
+  ;; the replayed turn's `done`. #f keeps the whole stream, which is what the
+  ;; tests about the catch-up itself want.
+  (define (open-events port #:caught-up-through [through "commands"])
+    (define-values (_status _headers in)
+      (http-sendrecv "127.0.0.1" "/events" #:port port #:method #"GET"))
+    (when through (events-through in through))
+    in)
 
-;; -> (values status-code body-string). A form post, the way the panel sends
-;; one; `fields` is an alist, url-encoded here rather than by hand.
-(define (POST port path [fields '()])
-  (define-values (status _headers in)
-    (http-sendrecv "127.0.0.1" path #:port port #:method #"POST"
-                   #:headers (list #"Content-Type: application/x-www-form-urlencoded")
-                   #:data (alist->form-urlencoded fields)))
-  (define body (port->string in))
-  (close-input-port in)
-  (values (string->number (cadr (string-split (bytes->string/utf-8 status) " ")))
-          body))
+  ;; Next real event on the stream: -> (cons name data) | #f. The heartbeat is
+  ;; framing, not news — it is a named event (a client has to be able to notice
+  ;; it stopping, and a comment is invisible to one), and this is where it stops
+  ;; being anything a test about the conversation has to know.
+  (define (next-event in #:timeout [timeout 30])
+    (define deadline (+ (current-inexact-milliseconds) (* 1000.0 timeout)))
+    (let loop ([name #f] [data '()])
+      (define left (/ (- deadline (current-inexact-milliseconds)) 1000.0))
+      (define line (and (positive? left)
+                        (sync/timeout left (read-line-evt in 'linefeed))))
+      (cond
+        [(or (not line) (eof-object? line)) #f]
+        [(string=? line "")
+         (cond
+           [(equal? name heartbeat-event) (loop #f '())]
+           [name (cons name (string-join (reverse data) "\n"))]
+           [else (loop #f '())])]
+        [(string-prefix? line "event: ") (loop (substring line 7) data)]
+        [(string-prefix? line "data: ") (loop name (cons (substring line 6) data))]
+        [else (loop name data)])))
 
-(define (GET port path)
-  (define-values (status _headers in)
-    (http-sendrecv "127.0.0.1" path #:port port #:method #"GET"))
-  (define body (port->string in))
-  (close-input-port in)
-  (values (string->number (cadr (string-split (bytes->string/utf-8 status) " ")))
-          body))
+  ;; -> (values status-code body-string). A form post, the way the panel sends
+  ;; one; `fields` is an alist, url-encoded here rather than by hand.
+  (define (POST port path [fields '()])
+    (define-values (status _headers in)
+      (http-sendrecv "127.0.0.1" path #:port port #:method #"POST"
+                     #:headers (list #"Content-Type: application/x-www-form-urlencoded")
+                     #:data (alist->form-urlencoded fields)))
+    (define body (port->string in))
+    (close-input-port in)
+    (values (string->number (cadr (string-split (bytes->string/utf-8 status) " ")))
+            body))
 
-;; Frames off a live /events connection, up to and including the first one of
-;; `type`. Same idea as frames-through, one layer out: over HTTP.
-(define (events-through in type)
-  (let loop ([acc '()] [n 0])
-    (cond
-      [(> n 20) (reverse acc)]
-      [else
-       (define ev (next-event in))
-       (cond
-         [(not ev) (reverse acc)]
-         [else
-          (define js (string->jsexpr (cdr ev)))
-          (if (equal? (hash-ref js 'type #f) type)
-              (reverse (cons js acc))
-              (loop (cons js acc) (add1 n)))])])))
+  (define (GET port path)
+    (define-values (status _headers in)
+      (http-sendrecv "127.0.0.1" path #:port port #:method #"GET"))
+    (define body (port->string in))
+    (close-input-port in)
+    (values (string->number (cadr (string-split (bytes->string/utf-8 status) " ")))
+            body))
 
-;; ---- the CLI ---------------------------------------------------------------
+  ;; Frames off a live /events connection, up to and including the first one of
+  ;; `type`. Same idea as frames-through, one layer out: over HTTP.
+  (define (events-through in type)
+    (let loop ([acc '()] [n 0])
+      (cond
+        [(> n 20) (reverse acc)]
+        [else
+         (define ev (next-event in))
+         (cond
+           [(not ev) (reverse acc)]
+           [else
+            (define js (string->jsexpr (cdr ev)))
+            (if (equal? (hash-ref js 'type #f) type)
+                (reverse (cons js acc))
+                (loop (cons js acc) (add1 n)))])])))
 
-;; `olai serve ARGS` with OLAI_ACP_AGENT set to `agent` — or removed
-;; from the environment entirely when it is #f. -> (values sp stdout stderr).
-(define (start-serve agent args)
-  (define env (environment-variables-copy (current-environment-variables)))
-  (environment-variables-set! env #"OLAI_ACP_AGENT"
-                              (and agent (string->bytes/utf-8 agent)))
-  (define-values (sp stdout stdin stderr)
-    (parameterize ([current-environment-variables env])
-      (apply subprocess #f #f #f (find-executable-path "racket")
-             "-l" "olai/cli" "--" "serve" args)))
-  (close-output-port stdin)
-  (values sp stdout stderr))
+  ;; ---- the CLI ---------------------------------------------------------------
 
-;; A serve that is expected to REFUSE: -> (values exit-code stderr).
-(define (run-serve agent [args (list (path->string example))])
-  (define-values (sp stdout stderr) (start-serve agent args))
-  (define _out (port->string stdout))
-  (define err (port->string stderr))
-  (close-input-port stdout)
-  (close-input-port stderr)
-  (subprocess-wait sp)
-  (values (subprocess-status sp) err))
+  ;; `olai serve ARGS` with OLAI_ACP_AGENT set to `agent` — or removed
+  ;; from the environment entirely when it is #f. -> (values sp stdout stderr).
+  (define (start-serve agent args)
+    (define env (environment-variables-copy (current-environment-variables)))
+    (environment-variables-set! env #"OLAI_ACP_AGENT"
+                                (and agent (string->bytes/utf-8 agent)))
+    (define-values (sp stdout stdin stderr)
+      (parameterize ([current-environment-variables env])
+        (apply subprocess #f #f #f (find-executable-path "racket")
+               "-l" "olai/cli" "--" "serve" args)))
+    (close-output-port stdin)
+    (values sp stdout stderr))
 
-;; A serve that is expected to COME UP: (proc port announcement). The port is
-;; read off the announcement line (--port 0 picks one), and the subprocess is
-;; taken down on the way out whether the body finished or not.
-(define (with-serve args proc)
-  (define-values (sp stdout stderr)
-    (start-serve fake-agent (append (list "--port" "0") args)))
-  (dynamic-wind
-   void
-   (λ ()
-     (define line (sync/timeout 60 (read-line-evt stdout 'any)))
-     (check-true (string? line) (format "serve said nothing: ~a" line))
-     (define m (regexp-match #rx"http://[^:]+:([0-9]+)" line))
-     (check-true (and m #t) (format "no url in ~s" line))
-     (proc (string->number (cadr m)) line))
-   (λ ()
-     (subprocess-kill sp #t)
-     (subprocess-wait sp)
-     (close-input-port stdout)
-     (close-input-port stderr))))
+  ;; A serve that is expected to REFUSE: -> (values exit-code stderr).
+  (define (run-serve agent [args (list (path->string example))])
+    (define-values (sp stdout stderr) (start-serve agent args))
+    (define _out (port->string stdout))
+    (define err (port->string stderr))
+    (close-input-port stdout)
+    (close-input-port stderr)
+    (subprocess-wait sp)
+    (values (subprocess-status sp) err))
+
+  ;; A serve that is expected to COME UP: (proc port announcement). The port is
+  ;; read off the announcement line (--port 0 picks one), and the subprocess is
+  ;; taken down on the way out whether the body finished or not.
+  (define (with-serve args proc)
+    (define-values (sp stdout stderr)
+      (start-serve fake-agent (append (list "--port" "0") args)))
+    (dynamic-wind
+     void
+     (λ ()
+       (define line (sync/timeout 60 (read-line-evt stdout 'any)))
+       (check-true (string? line) (format "serve said nothing: ~a" line))
+       (define m (regexp-match #rx"http://[^:]+:([0-9]+)" line))
+       (check-true (and m #t) (format "no url in ~s" line))
+       (proc (string->number (cadr m)) line))
+     (λ ()
+       (subprocess-kill sp #t)
+       (subprocess-wait sp)
+       (close-input-port stdout)
+       (close-input-port stderr)))))
 
 (module+ test
   ;; ---- a whole turn --------------------------------------------------------

--- a/olai/tests/integration/cli-add.rkt
+++ b/olai/tests/integration/cli-add.rkt
@@ -3,12 +3,14 @@
 ;; The capture path: `add`, what it leaves on disk, and what the write path
 ;; refuses. Real subprocess (cli-util.rkt), temp dirs only.
 
-(require rackunit
-         racket/file
+(require racket/file
          racket/port
          racket/string
          racket/system
          "cli-util.rkt")
+
+(module+ test
+  (require rackunit))
 
 (module+ test
   (test-case "add creates Inbox and preserves content"

--- a/olai/tests/integration/cli-doing.rkt
+++ b/olai/tests/integration/cli-doing.rkt
@@ -9,11 +9,13 @@
 ;; marks is a form the language rejects, so the op would fail rather than
 ;; write it.
 
-(require rackunit
-         json
+(require json
          racket/file
          racket/string
          "cli-util.rkt")
+
+(module+ test
+  (require rackunit))
 
 (module+ test
   (test-case "doing / undo round-trip with git commit"

--- a/olai/tests/integration/cli-done.rkt
+++ b/olai/tests/integration/cli-done.rkt
@@ -3,11 +3,13 @@
 ;; The `done` path: the round trip, and what a miss tells the user. Real
 ;; subprocess (cli-util.rkt), temp dirs only.
 
-(require rackunit
-         json
+(require json
          racket/file
          racket/string
          "cli-util.rkt")
+
+(module+ test
+  (require rackunit))
 
 (module+ test
   (test-case "done / undo round-trip with git commit"

--- a/olai/tests/integration/cli-multi.rkt
+++ b/olai/tests/integration/cli-multi.rkt
@@ -4,12 +4,14 @@
 ;; that writes across two of them at once. Real subprocess (cli-util.rkt),
 ;; temp dirs only.
 
-(require rackunit
-         racket/file
+(require racket/file
          racket/port
          racket/string
          racket/system
          "cli-util.rkt")
+
+(module+ test
+  (require rackunit))
 
 (module+ test
   (test-case "multi-file check: both ok + one-good-one-bad"

--- a/olai/tests/integration/cli-read.rkt
+++ b/olai/tests/integration/cli-read.rkt
@@ -3,10 +3,12 @@
 ;; Read-only commands over one file: check / tree / agenda, and the exit codes
 ;; a bad invocation earns. The CLI runs as a real subprocess (cli-util.rkt).
 
-(require rackunit
-         json
+(require json
          racket/file
          "cli-util.rkt")
+
+(module+ test
+  (require rackunit))
 
 (module+ test
   ;; There is no plain mode left to test: the reply is JSON with or without

--- a/olai/tests/integration/serve.rkt
+++ b/olai/tests/integration/serve.rkt
@@ -3,8 +3,7 @@
 ;; Web server routes. Boots the real server on an ephemeral port against a
 ;; temp outline; no personal data, no fixed ports.
 
-(require rackunit
-         json
+(require json
          net/http-client
          racket/file
          racket/path
@@ -15,110 +14,114 @@
          (only-in olai/web/live live-asset-prefix live-script-srcs outline-event)
          olai/web/serve)
 
-;; Sizes differ on every write below: the store's staleness probe is mtime +
-;; size, and a same-second same-size rewrite is invisible to it.
+(module+ test
+  (require rackunit))
 
-(define outline
-  (string-append
-   "#lang olai\n"
-   "Inbox\n"
-   "  Buy milk\n"
-   "    @date 2026-01-15\n"
-   "Ship the server ^serve\n"))
+(module+ test
+  ;; Sizes differ on every write below: the store's staleness probe is mtime +
+  ;; size, and a same-second same-size rewrite is invisible to it.
 
-;; Run body with the server up: (proc port outline-path). The path is handed
-;; back so a test can edit the outline underneath a running server. The temp
-;; dir goes whether or not the server came up, which is a case here.
-(define (with-server proc #:port [port 0] #:port-fallback? [fallback? #f])
-  (define dir (make-temporary-file "sfserve~a" 'directory))
-  (define f (build-path dir "Tasks.rkt"))
-  (display-to-file outline f #:exists 'truncate)
-  (dynamic-wind
-   void
-   (λ ()
-     (define bound #f)
-     (define stop
-       (start-server #:port port
-                     #:port-fallback? fallback?
-                     #:bind "127.0.0.1"
-                     #:files (list f)
-                     #:on-listen (λ (p) (set! bound p))))
-     (dynamic-wind void (λ () (proc bound f)) stop))
-   (λ () (delete-directory/files dir))))
+  (define outline
+    (string-append
+     "#lang olai\n"
+     "Inbox\n"
+     "  Buy milk\n"
+     "    @date 2026-01-15\n"
+     "Ship the server ^serve\n"))
 
-;; A port that is already bound, for the two "taken" cases: (proc port).
-(define (with-taken-port proc)
-  (define l (tcp-listen 0 4 #t "127.0.0.1"))
-  (define-values (_h port _rh _rp) (tcp-addresses l #t))
-  (dynamic-wind void (λ () (proc port)) (λ () (tcp-close l))))
+  ;; Run body with the server up: (proc port outline-path). The path is handed
+  ;; back so a test can edit the outline underneath a running server. The temp
+  ;; dir goes whether or not the server came up, which is a case here.
+  (define (with-server proc #:port [port 0] #:port-fallback? [fallback? #f])
+    (define dir (make-temporary-file "sfserve~a" 'directory))
+    (define f (build-path dir "Tasks.rkt"))
+    (display-to-file outline f #:exists 'truncate)
+    (dynamic-wind
+     void
+     (λ ()
+       (define bound #f)
+       (define stop
+         (start-server #:port port
+                       #:port-fallback? fallback?
+                       #:bind "127.0.0.1"
+                       #:files (list f)
+                       #:on-listen (λ (p) (set! bound p))))
+       (dynamic-wind void (λ () (proc bound f)) stop))
+     (λ () (delete-directory/files dir))))
 
-;; -> (values status-code headers body-string)
-(define (GET port path)
-  (define-values (status headers in)
-    (http-sendrecv "127.0.0.1" path #:port port #:method #"GET"))
-  (define body (port->string in))
-  (close-input-port in)
-  (values (string->number (cadr (string-split (bytes->string/utf-8 status) " ")))
-          (map bytes->string/utf-8 headers)
-          body))
+  ;; A port that is already bound, for the two "taken" cases: (proc port).
+  (define (with-taken-port proc)
+    (define l (tcp-listen 0 4 #t "127.0.0.1"))
+    (define-values (_h port _rh _rp) (tcp-addresses l #t))
+    (dynamic-wind void (λ () (proc port)) (λ () (tcp-close l))))
 
-(define (header-value headers name)
-  (for/or ([h (in-list headers)])
-    (and (string-prefix? (string-downcase h) (string-downcase name))
-         h)))
+  ;; -> (values status-code headers body-string)
+  (define (GET port path)
+    (define-values (status headers in)
+      (http-sendrecv "127.0.0.1" path #:port port #:method #"GET"))
+    (define body (port->string in))
+    (close-input-port in)
+    (values (string->number (cadr (string-split (bytes->string/utf-8 status) " ")))
+            (map bytes->string/utf-8 headers)
+            body))
 
-;; ---- the SSE stream --------------------------------------------------------
+  (define (header-value headers name)
+    (for/or ([h (in-list headers)])
+      (and (string-prefix? (string-downcase h) (string-downcase name))
+           h)))
 
-;; /events never ends, so this keeps the port: -> (values code headers in).
-;; net/http-client de-chunks for us, which is the only reason a test can read
-;; the stream a frame at a time.
-;;
-;; #:last-event-id is what a reconnecting EventSource sends: the id of the last
-;; frame it managed to dispatch before the connection went away. A test that
-;; passes one is a browser that has been asleep.
-(define (open-events port #:path [path "/events"] #:last-event-id [last-event-id #f])
-  (define-values (status headers in)
-    (http-sendrecv "127.0.0.1" path #:port port #:method #"GET"
-                   #:headers (if last-event-id
-                                 (list (string->bytes/utf-8
-                                        (string-append "Last-Event-ID: " last-event-id)))
-                                 '())))
-  (values (string->number (cadr (string-split (bytes->string/utf-8 status) " ")))
-          (map bytes->string/utf-8 headers)
-          in))
+  ;; ---- the SSE stream --------------------------------------------------------
 
-;; Next real event on the stream: -> (list name data id) | #f on timeout.
-;; Heartbeats are skipped — they are the transport keeping itself honest, not
-;; news about an outline. Waited on, never slept for.
-(define (next-event in #:timeout [timeout 20])
-  (define deadline (+ (current-inexact-milliseconds) (* 1000.0 timeout)))
-  (let loop ([name #f] [data '()] [id #f])
-    (define left (/ (- deadline (current-inexact-milliseconds)) 1000.0))
-    (define line (and (positive? left)
-                      (sync/timeout left (read-line-evt in 'linefeed))))
-    (cond
-      [(or (not line) (eof-object? line)) #f]
-      [(string=? line "")
-       (cond
-         [(equal? name heartbeat-event) (loop #f '() #f)]
-         [name (list name (string-join (reverse data) "\n") id)]
-         [else (loop #f '() #f)])]
-      [(string-prefix? line "event: ") (loop (substring line 7) data id)]
-      [(string-prefix? line "data: ") (loop name (cons (substring line 6) data) id)]
-      [(string-prefix? line "id: ") (loop name data (substring line 4))]
-      [else (loop name data id)])))
+  ;; /events never ends, so this keeps the port: -> (values code headers in).
+  ;; net/http-client de-chunks for us, which is the only reason a test can read
+  ;; the stream a frame at a time.
+  ;;
+  ;; #:last-event-id is what a reconnecting EventSource sends: the id of the last
+  ;; frame it managed to dispatch before the connection went away. A test that
+  ;; passes one is a browser that has been asleep.
+  (define (open-events port #:path [path "/events"] #:last-event-id [last-event-id #f])
+    (define-values (status headers in)
+      (http-sendrecv "127.0.0.1" path #:port port #:method #"GET"
+                     #:headers (if last-event-id
+                                   (list (string->bytes/utf-8
+                                          (string-append "Last-Event-ID: " last-event-id)))
+                                   '())))
+    (values (string->number (cadr (string-split (bytes->string/utf-8 status) " ")))
+            (map bytes->string/utf-8 headers)
+            in))
 
-;; The stream a PAGE would open: the URL is the one in its own markup, cursor
-;; and all. A test that rebuilt that URL itself would be testing its own
-;; arithmetic; this opens what the browser would.
-(define (open-events/page port page-body)
-  (define m (regexp-match #px"sse-connect=\"([^\"]+)\"" page-body))
-  (check-not-false m "the page carries no stream")
-  (open-events port #:path (cadr m)))
+  ;; Next real event on the stream: -> (list name data id) | #f on timeout.
+  ;; Heartbeats are skipped — they are the transport keeping itself honest, not
+  ;; news about an outline. Waited on, never slept for.
+  (define (next-event in #:timeout [timeout 20])
+    (define deadline (+ (current-inexact-milliseconds) (* 1000.0 timeout)))
+    (let loop ([name #f] [data '()] [id #f])
+      (define left (/ (- deadline (current-inexact-milliseconds)) 1000.0))
+      (define line (and (positive? left)
+                        (sync/timeout left (read-line-evt in 'linefeed))))
+      (cond
+        [(or (not line) (eof-object? line)) #f]
+        [(string=? line "")
+         (cond
+           [(equal? name heartbeat-event) (loop #f '() #f)]
+           [name (list name (string-join (reverse data) "\n") id)]
+           [else (loop #f '() #f)])]
+        [(string-prefix? line "event: ") (loop (substring line 7) data id)]
+        [(string-prefix? line "data: ") (loop name (cons (substring line 6) data) id)]
+        [(string-prefix? line "id: ") (loop name data (substring line 4))]
+        [else (loop name data id)])))
 
-(define (event-name ev) (car ev))
-(define (event-data ev) (cadr ev))
-(define (event-id ev) (caddr ev))
+  ;; The stream a PAGE would open: the URL is the one in its own markup, cursor
+  ;; and all. A test that rebuilt that URL itself would be testing its own
+  ;; arithmetic; this opens what the browser would.
+  (define (open-events/page port page-body)
+    (define m (regexp-match #px"sse-connect=\"([^\"]+)\"" page-body))
+    (check-not-false m "the page carries no stream")
+    (open-events port #:path (cadr m)))
+
+  (define (event-name ev) (car ev))
+  (define (event-data ev) (cadr ev))
+  (define (event-id ev) (caddr ev)))
 
 (module+ test
   ;; The port the CLI did not have to be told (its default): taken means take

--- a/olai/tests/json.rkt
+++ b/olai/tests/json.rkt
@@ -6,15 +6,18 @@
 ;; tests/integration/; this file is about the fields, and especially about a
 ;; field a reader is told is append-only.
 
-(require rackunit
-         json
+(require json
          (except-in olai/lang/expander #%module-begin)
          olai/agenda
          olai/json/model
          olai/json/reply)
 
-(define (tk title #:date [date #f] #:done [done #f] #:doing [doing #f])
-  (make-task #:title title #:date date #:done done #:doing doing #:key title))
+(module+ test
+  (require rackunit))
+
+(module+ test
+  (define (tk title #:date [date #f] #:done [done #f] #:doing [doing #f])
+    (make-task #:title title #:date date #:done done #:doing doing #:key title)))
 
 (module+ test
 

--- a/olai/tests/live.rkt
+++ b/olai/tests/live.rkt
@@ -6,21 +6,24 @@
 ;; module that reads one, and every case below is a client the outline moved
 ;; without.
 
-(require rackunit
-         racket/string
+(require racket/string
          live/frame
          (only-in live/hub live-boot-id)
          (only-in live/client live-view-region live-view-event live-view-stream
                   live-view-href live-view-cursor)
          olai/web/live)
 
-;; -> (list name data id) of the single owed frame, or #f for "nothing owed".
-(define (owed last-id rev)
-  (define fs (outline-catch-up last-id (outline-cursor rev)))
-  (and (pair? fs)
-       (list (frame-name (car fs)) (frame-data (car fs)) (frame-id (car fs)))))
+(module+ test
+  (require rackunit))
 
-(define (frame-of rev) (list outline-event (outline-cursor rev) (outline-cursor rev)))
+(module+ test
+  ;; -> (list name data id) of the single owed frame, or #f for "nothing owed".
+  (define (owed last-id rev)
+    (define fs (outline-catch-up last-id (outline-cursor rev)))
+    (and (pair? fs)
+         (list (frame-name (car fs)) (frame-data (car fs)) (frame-id (car fs)))))
+
+  (define (frame-of rev) (list outline-event (outline-cursor rev) (outline-cursor rev))))
 
 (module+ test
   ;; A revision counts from one per process, so it names a different outline

--- a/olai/tests/mirrors.rkt
+++ b/olai/tests/mirrors.rkt
@@ -1,7 +1,6 @@
 #lang racket/base
 
-(require rackunit
-         racket/file
+(require racket/file
          racket/list
          racket/hash
          racket/string
@@ -20,22 +19,26 @@
          olai/status
          olai/capture)
 
-;; Keys are minted by the load layer, not the module, so these go through it.
-(define (eval-mod src)
-  (define tmp (make-temporary-file "sf-mir~a.rkt"))
-  (dynamic-wind
-   void
-   (λ ()
-     (display-to-file src tmp #:exists 'truncate)
-     (define tasks (dynamic-require `(file ,(path->string tmp)) 'tasks))
-     (define anchors (dynamic-require `(file ,(path->string tmp)) 'anchors))
-     (define o (car (mint-outline-keys (list (outline tmp tasks anchors '())))))
-     (values (outline-tasks o) (outline-anchors o)))
-   (λ () (delete-file tmp))))
+(module+ test
+  (require rackunit))
 
-(define (eval-tasks src)
-  (define-values (t a) (eval-mod src))
-  t)
+(module+ test
+  ;; Keys are minted by the load layer, not the module, so these go through it.
+  (define (eval-mod src)
+    (define tmp (make-temporary-file "sf-mir~a.rkt"))
+    (dynamic-wind
+     void
+     (λ ()
+       (display-to-file src tmp #:exists 'truncate)
+       (define tasks (dynamic-require `(file ,(path->string tmp)) 'tasks))
+       (define anchors (dynamic-require `(file ,(path->string tmp)) 'anchors))
+       (define o (car (mint-outline-keys (list (outline tmp tasks anchors '())))))
+       (values (outline-tasks o) (outline-anchors o)))
+     (λ () (delete-file tmp))))
+
+  (define (eval-tasks src)
+    (define-values (t a) (eval-mod src))
+    t))
 
 (module+ test
   (test-case "sexp #:id and mirror resolve"

--- a/olai/tests/outline.rkt
+++ b/olai/tests/outline.rkt
@@ -1,23 +1,26 @@
 #lang racket/base
 
-(require rackunit
-         racket/file
+(require racket/file
          racket/list
          racket/string
          (except-in olai/lang/expander #%module-begin)
          olai/lang/outline)
 
-(define (eval-tasks src)
-  (define tmp (make-temporary-file "sf-outline~a.rkt"))
-  (dynamic-wind
-   void
-   (λ ()
-     (display-to-file src tmp #:exists 'truncate)
-     (dynamic-require `(file ,(path->string tmp)) 'tasks))
-   (λ () (delete-file tmp))))
+(module+ test
+  (require rackunit))
 
-(define (parse-string s)
-  (parse-outline-string 'test s))
+(module+ test
+  (define (eval-tasks src)
+    (define tmp (make-temporary-file "sf-outline~a.rkt"))
+    (dynamic-wind
+     void
+     (λ ()
+       (display-to-file src tmp #:exists 'truncate)
+       (dynamic-require `(file ,(path->string tmp)) 'tasks))
+     (λ () (delete-file tmp))))
+
+  (define (parse-string s)
+    (parse-outline-string 'test s)))
 
 (module+ test
   (test-case "empty outline"

--- a/olai/tests/render.rkt
+++ b/olai/tests/render.rkt
@@ -3,8 +3,7 @@
 ;; xexpr-level tests for the web renderers. No files, no server, no clocks:
 ;; `today` is always passed in.
 
-(require rackunit
-         json
+(require json
          racket/file
          racket/string
          xml
@@ -23,42 +22,46 @@
          olai/web/chat-panel
          olai/web/markdown)
 
-;; Hand-built tasks, so the key has to be minted here too. Keying off the
-;; title keeps these tests readable: two `tk` calls with the same title stand
-;; for the same node. Real keys come from the expander (see tests/expander).
-(define (title-key title)
-  (string-append
-   "p" (substring (sha1 (open-input-bytes (string->bytes/utf-8 title))) 0 8)))
+(module+ test
+  (require rackunit))
 
-(define (tk title date desc kids
-            #:tags [tags '()] #:done [done #f] #:doing [doing #f]
-            #:id [id #f] #:key [key #f])
-  (make-task #:title title #:date date #:description desc #:done done
-             #:doing doing #:id id #:tags tags #:children kids
-             #:key (or key id (title-key title))))
+(module+ test
+  ;; Hand-built tasks, so the key has to be minted here too. Keying off the
+  ;; title keeps these tests readable: two `tk` calls with the same title stand
+  ;; for the same node. Real keys come from the expander (see tests/expander).
+  (define (title-key title)
+    (string-append
+     "p" (substring (sha1 (open-input-bytes (string->bytes/utf-8 title))) 0 8)))
 
-(define (xstr x) (xexpr->string x))
+  (define (tk title date desc kids
+              #:tags [tags '()] #:done [done #f] #:doing [doing #f]
+              #:id [id #f] #:key [key #f])
+    (make-task #:title title #:date date #:description desc #:done done
+               #:doing doing #:id id #:tags tags #:children kids
+               #:key (or key id (title-key title))))
 
-;; The live view a served page is drawn with — the same value web/serve builds,
-;; so a test asserting markup is asserting the shipped markup. It is per-PAGE
-;; (it carries the page's own address), which is why this is a function.
-(define (live-at href) (outline-live-view "/events" #:href href #:cursor "boot.1"))
-(define the-live-view (live-at "/"))
+  (define (xstr x) (xexpr->string x))
 
-;; Where `needle` starts in `s`, for the assertions that are about ORDER.
-(define (string-index s needle)
-  (caar (regexp-match-positions (regexp (regexp-quote needle)) s)))
+  ;; The live view a served page is drawn with — the same value web/serve builds,
+  ;; so a test asserting markup is asserting the shipped markup. It is per-PAGE
+  ;; (it carries the page's own address), which is why this is a function.
+  (define (live-at href) (outline-live-view "/events" #:href href #:cursor "boot.1"))
+  (define the-live-view (live-at "/"))
 
-(define (xstr* xs) (string-join (map xstr xs) ""))
+  ;; Where `needle` starts in `s`, for the assertions that are about ORDER.
+  (define (string-index s needle)
+    (caar (regexp-match-positions (regexp (regexp-quote needle)) s)))
 
-(define (files . entries) entries)
+  (define (xstr* xs) (string-join (map xstr xs) ""))
 
-;; The sidebar over one trivial outline — what the prefs tests below read. The
-;; outline is not the subject there; the chrome around it is.
-(define (sidebar-html)
-  (xstr (render-sidebar (files (list "/tmp/Tasks.rkt" (list (tk "Inbox" #f #f '()))))
-                        #:home-href "/"
-                        #:today-href "/today")))
+  (define (files . entries) entries)
+
+  ;; The sidebar over one trivial outline — what the prefs tests below read. The
+  ;; outline is not the subject there; the chrome around it is.
+  (define (sidebar-html)
+    (xstr (render-sidebar (files (list "/tmp/Tasks.rkt" (list (tk "Inbox" #f #f '()))))
+                          #:home-href "/"
+                          #:today-href "/today"))))
 
 (module+ test
 

--- a/olai/tests/status.rkt
+++ b/olai/tests/status.rkt
@@ -1,8 +1,10 @@
 #lang racket/base
 
-(require rackunit
-         racket/string
+(require racket/string
          olai/status)
+
+(module+ test
+  (require rackunit))
 
 (module+ test
   (define sample

--- a/olai/tests/store.rkt
+++ b/olai/tests/store.rkt
@@ -3,8 +3,7 @@
 ;; The snapshot layer: reload on change (fresh namespace), transitive watch
 ;; set, last-good on a broken file. Temp dirs only, never personal data.
 
-(require rackunit
-         racket/file
+(require racket/file
          racket/list
          racket/path
          racket/string
@@ -12,18 +11,22 @@
          olai/load
          olai/store)
 
-(define (with-temp-dir proc)
-  (define dir (make-temporary-file "sfstore~a" 'directory))
-  (dynamic-wind void (λ () (proc dir)) (λ () (delete-directory/files dir))))
+(module+ test
+  (require rackunit))
 
-(define (write-file! path text)
-  (make-parent-directory* path)
-  (display-to-file text path #:exists 'truncate/replace))
+(module+ test
+  (define (with-temp-dir proc)
+    (define dir (make-temporary-file "sfstore~a" 'directory))
+    (dynamic-wind void (λ () (proc dir)) (λ () (delete-directory/files dir))))
 
-(define (titles snap)
-  (for*/list ([o (in-list (snapshot-outlines snap))]
-              [tk (in-list (outline-tasks o))])
-    (task-title tk)))
+  (define (write-file! path text)
+    (make-parent-directory* path)
+    (display-to-file text path #:exists 'truncate/replace))
+
+  (define (titles snap)
+    (for*/list ([o (in-list (snapshot-outlines snap))]
+                [tk (in-list (outline-tasks o))])
+      (task-title tk))))
 
 (module+ test
   (test-case "a store reloads a file that changed on disk"

--- a/olai/tests/style.rkt
+++ b/olai/tests/style.rkt
@@ -21,8 +21,7 @@
 ;; global registry theme.rkt does, and after it, which is what the ordering
 ;; tests read. Instantiation order is the cascade; that is the contract.
 
-(require rackunit
-         racket/file
+(require racket/file
          racket/list
          racket/runtime-path
          racket/set
@@ -50,6 +49,9 @@
          olai/index
          (only-in olai/lang/walk resolve-mirrors)
          (except-in olai/lang/expander #%module-begin))
+
+(module+ test
+  (require rackunit))
 
 ;; The skin's classes, captured BEFORE this module's fixtures register: a
 ;; module body runs in order, so this is every class olai/web/skin defines and

--- a/olai/tests/watch.rkt
+++ b/olai/tests/watch.rkt
@@ -5,9 +5,11 @@
 ;; connection that has been away is tested in tests/live.rkt; the wired-up
 ;; version of all three lives in tests/integration/serve.rkt.
 
-(require rackunit
-         gregor
+(require gregor
          olai/web/watch)
+
+(module+ test
+  (require rackunit))
 
 (module+ test
   (test-case "seconds-until-midnight is the distance to the next local one"

--- a/olai/web/chat.rkt
+++ b/olai/web/chat.rkt
@@ -551,10 +551,7 @@
     (λ ()
       (define tn (current-turn ch))
       (when tn
-        (define t (or (find-tool tn id)
-                      (let ([t (tool id title status)])
-                        (set-turn-tools! tn (cons t (turn-tools tn)))
-                        t)))
+        (define t (or (find-tool tn id) (add-tool! tn id title status)))
         (set-tool-title! t title)
         (set-tool-status! t status)
         (broadcast! ch (tool-jsexpr id title status))))))
@@ -580,6 +577,12 @@
 (define (find-tool tn id)
   (for/or ([t (in-list (turn-tools tn))])
     (and (equal? (tool-id t) id) t)))
+
+;; Newest-first, like the turn's other lists; the transcript reverses.
+(define (add-tool! tn id title status)
+  (define t (tool id title status))
+  (set-turn-tools! tn (cons t (turn-tools tn)))
+  t)
 
 ;; ---- replaying a loaded session ---------------------------------------------
 ;;

--- a/olai/web/markdown.rkt
+++ b/olai/web/markdown.rkt
@@ -29,11 +29,13 @@
 ;; ---- xexpr helpers --------------------------------------------------------
 
 (define (xexpr-tag x)
-  (and (list? x) (pair? x) (symbol? (car x)) (car x)))
+  (match x
+    [(cons (? symbol? tag) (? list?)) tag]
+    [_ #f]))
 
 (define (xexpr-attrs x)
   (match x
-    [(list _ (list (list (? symbol?) _) ...) _ ...) (cadr x)]
+    [(list _ (and attrs (list (list (? symbol?) _) ...)) _ ...) attrs]
     [_ '()]))
 
 (define (xexpr-kids x)
@@ -58,6 +60,12 @@
                            (blockquote . #t) (h1 . #t) (h2 . #t) (h3 . #t)
                            (h4 . #t) (h5 . #t) (h6 . #t) (hr . #t) (div . #t))))
 
+;; The value of an xexpr attribute, or `missing` when the tag does not wear it.
+(define (attr-value attrs name [missing #f])
+  (match (assq name attrs)
+    [(list-rest _ value _) value]
+    [_ missing]))
+
 (define (safe-href href)
   (and (string? href)
        (or (regexp-match? #px"^(https?|mailto):" href)
@@ -67,7 +75,7 @@
 (define (sanitize-attrs tag attrs)
   (case tag
     [(a)
-     (define href (safe-href (cond [(assq 'href attrs) => cadr] [else #f])))
+     (define href (safe-href (attr-value attrs 'href)))
      (if href `((href ,href)) '())]
     [else '()]))
 
@@ -258,7 +266,7 @@
          [(code) (make-xexpr 'code `((class ,ol-code)) kids)]
          [(pre) (make-xexpr 'pre `((class ,ol-pre)) kids)]
          [(a)
-          (define href (cond [(assq 'href attrs) => cadr] [else "#"]))
+          (define href (attr-value attrs 'href "#"))
           (make-xexpr 'a `((href ,href) (class ,ol-link)) kids)]
          [else (make-xexpr tag attrs kids)])]
       [(list? x) (map loop x)]

--- a/olai/web/render.rkt
+++ b/olai/web/render.rkt
@@ -619,16 +619,16 @@
         (day-pill-xexpr iso-day today done?)
         `(span ((class ,(classes ol-title (and done? is-done))))
                ,@(map style-md-xexpr (title->inline-xexprs title)))))
+  (define dot
+    `(span ((class ,(classes ol-bullet (and (pair? kids) has-children)))
+            (aria-hidden "true"))))
   (define bullet
-    (let ([dot `(span ((class ,(classes ol-bullet
-                                        (and (pair? kids) has-children)))
-                       (aria-hidden "true")))])
-      (if zoom-base
-          `(a ((class ,ol-bullet-link)
-               ,@(node-link-attributes live zoom-base key)
-               (title "zoom in"))
-              ,dot)
-          dot)))
+    (if zoom-base
+        `(a ((class ,ol-bullet-link)
+             ,@(node-link-attributes live zoom-base key)
+             (title "zoom in"))
+            ,dot)
+        dot))
   (node-shell
    #:key key
    #:element-id (node-element-id key #:site site)

--- a/olai/web/serve.rkt
+++ b/olai/web/serve.rkt
@@ -290,9 +290,11 @@
 ;; A form field, trimmed, or #f when it is missing or blank.
 (define (form-field req name)
   (define b (bindings-assq name (request-bindings/raw req)))
-  (and (binding:form? b)
-       (let ([s (string-trim (bytes->string/utf-8 (binding:form-value b)))])
-         (and (non-empty-string? s) s))))
+  (cond
+    [(binding:form? b)
+     (define s (string-trim (bytes->string/utf-8 (binding:form-value b))))
+     (and (non-empty-string? s) s)]
+    [else #f]))
 
 (define (no-agent-response)
   (text-response "no agent\n" #:code 503))


### PR DESCRIPTION
Adopts [notjack.space/racket-skills `racket/SKILL.md`](https://tangled.org/notjack.space/racket-skills/blob/main/racket/SKILL.md) across `olai/` and `live/`, and points CLAUDE.md at it so future agents read it as Racket style context.

Behaviour-preserving throughout: no CLI JSON fields added or moved, no event frames touched, no error message that a test pins reworded. `just test` 263, `just test-all` 377, `just e2e` 50 scenarios / 401 steps — all green.

## What SKILL.md prescribes

Idiomatic Racket as distinct from generic Scheme. The load-bearing items: `#lang racket/base` with explicit requires for library code; square brackets in `cond`/`match`/`let`/`for`/`parameterize` clauses; `define` in a body context rather than `let*`; the `for` family with explicit `in-list`/`in-range` sequence constructors rather than manual recursion or `map`+`lambda`; `match`/`match-define` for destructuring rather than `car`/`cdr` chains; `struct` with `#:transparent` rather than positional lists; closing parens never on their own line; kebab-case, `?` predicates, `!` mutators, `->` conversions; 102-column lines, no tabs; `syntax-parse` rather than `syntax-rules`/`syntax-case`; tests in `module+ test` submodules; `raise-arguments-error` rather than `error`; `raco fmt` and `resyntax` as tooling.

## Already compliant

Most of it. All 72 source files were already `#lang racket/base`; all 178 `for` clauses already used `in-list`/`in-range`/`in-hash`; every macro was already `syntax-parse`; every struct that wanted `#:transparent` had it; there was no `test-suite`, no `syntax-rules`, no tabs, no snake_case or camelCase, no paren-style violations outside here-strings (where Racket's `#<<EOF` terminator forces the closing paren onto its own line), and requires/provides were already ordered.

## What changed

**`match` for destructuring** — the repo's dominant `car`/`cdr` idiom was `(cond [(regexp-match rx s) => (λ (m) … (cadr m) …)])`, which `match`'s `regexp` pattern says directly. Converted in `lang/line.rkt` (14 sites), `dates.rkt`, `ics.rkt`, `calendar.rkt`, `capture.rkt`, `meta.rkt`, `daily.rkt`, `load.rkt`, `index.rkt`, `store.rkt`, `web/markdown.rkt`. Verified `match`'s `regexp` pattern fails rather than raises on a non-string, so the `(string? s)` guards it replaced were redundant.

**`define` over `let`** — ~20 single-binding `let`/`let*` forms in body context. Named `let` loops kept: that is idiomatic Racket iteration, not indentation.

**`struct` over positional list** — `ops.rkt`'s `marks` table was a 4-element list indexed with `car`/`cadr`/`caddr`/`cadddr`, with a comment above it explaining which slot was which. Now a `mark-ops` struct.

**Line width / paren style** — 7 lines over 102 columns, one genuine dangling `)`. Tree is now clean on both.

**Tests in `module+ test`** — `(require rackunit)` moved into its own `(module+ test (require rackunit))` block beside the other requires, and test-only helpers wrapped in `module+ test`, in 28 files. This is the one change with a large diff and no behaviour in it; it is what makes `raco cover`, `raco test` and binary code-stripping treat the helpers as test code.

## Helpers extracted

Applying the rules surfaced places where one rule was written more than once — the Hickey lens, in CLAUDE.md's terms:

- `lang/line.rkt` gained `title-text` / `title-flag` / `title-anchor`. `meta`, `capture` and `daily` each spelled `(cadr k)` / `(caddr k)` / `(cadddr k)` against the `(title TEXT FLAG ANCHOR)` grammar — the exact restatement that file's own header comment exists to prevent.
- `lang/outline.rkt` gained `check-level!` and `check-leaf-parent!`; the indent-jump rule was written three times, once per node kind, and adding a fourth kind meant copying it. Also `description-part`, replacing a `let*` chain that shadowed `first`.
- `acp.rkt` gained `list-or-empty` / `hash-or-empty` beside the existing `string-or-false`; "a field the agent sent with the wrong type reads as absent" sat inline at five read sites.
- `daily.rkt`: `find-title-line` took `#:from`/`#:to` and absorbed two hand-rolled ranged searches; `year-node-title` replaced two copies of the year-node rule; two identical `section-end` calls were hoisted; a `set!` flag became a derived `define`.
- `cli.rkt` `with-includes`, `dates.rkt` `parses?`, `markdown.rkt` `attr-value`, `capture.rkt` `appended-line-number`, `chat.rkt` `add-tool!`, `expander.rkt` `t-shape` (the two >102-col lines were the same message twice).

**Lowy lens**: each new helper sits with what changes at its rate — the grammar accessors in the module that owns the grammar, the protocol type-guards beside `string-or-false`, the indent rule apart from the node kinds precisely because those two change on different schedules.

## Deliberately not applied

- **`raise-arguments-error` instead of `error`.** SKILL.md calls this one "lightly discouraged". Here it collides with CLAUDE.md: replies and errors are JSON that agents read, and `olai/fail.rkt` already owns this axis with a documented split — user-facing failures go through `user-fail` (no `who:`), internal invariants keep `error` and its `who:` because there the function name is the point. Three messages are pinned by tests. Converting would reword agent-visible strings for a soft style preference. Noted in CLAUDE.md as a standing exception instead.
- **`raco fmt` over the tree.** It would reflow the hand-aligned css-expr and theme tables, which are read as tables, and produce an unreviewable diff. Also noted in CLAUDE.md.
- **Regrouping test cases under one `test-case` per function.** SKILL.md prescribes a nested tree named after the function under test. This is presentation-only, would reindent several thousand lines of otherwise-untouched test code, and buys grouping in tool output. Left for a separate change if wanted.
- **`olai/tests/style.rkt` helpers left at module level.** Its fixtures are documented as module-level on purpose: they register into the same global registry `theme.rkt` does, and after it, which is what the ordering tests read. CLAUDE.md makes instantiation order the CSS cascade, so this is contract. The `rackunit` require still moved.
- **`first`/`rest` over `car`/`cdr` generally.** Applied where the value is a list and the site is cold. Kept `car` where the value is a pair rather than a list, and in `lang/line.rkt`'s `kind?` predicates, which run once per line of every file parsed — `first` adds an O(n) `list?` check for no gain there. SKILL.md concedes this one ("though the latter work").

## Tooling

Installed `resyntax` (SKILL.md's recommended analyzer) and ran it over both collections. It reported no actionable suggestions on the refactored code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
