### PR TITLE
web: markdown fidelity — painted fences, pictures, footnotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ compiled/
 /live/static/htmx.min.js
 /live/static/sse.js
 /live/static/idiomorph.min.js
+
+# olai's own vendored asset, on the same terms: highlight.js, pinned (npins)
+# and built by nix/highlight-js.nix. A DIRECTORY this time — everything under
+# it is upstream's, so there is no name here to get wrong.
+/olai/web/static/hljs/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Inbox #capture
     @doc docs/agent-work.md
 ```
 
-Titles and notes are Markdown at **render** time (web view only); stored strings stay raw. Check off with `[x] ` OR `@done` — one node, one of them (or `olai done TITLE`). `[/] ` / `@doing` is the state in between, same rules (`olai doing TITLE`); done clears it. A node that is not a line gets `@doc`: it expands into that file — `.md` or `.scrbl`, greppable, diffable, still yours. Full rules: [docs/syntax.md](docs/syntax.md).
+Titles and notes are Markdown at **render** time (web view only); stored strings stay raw. A fenced block keeps its language and is highlighted in the browser, `![](shot.png)` draws the file beside the outline, and footnotes work. Check off with `[x] ` OR `@done` — one node, one of them (or `olai done TITLE`). `[/] ` / `@doing` is the state in between, same rules (`olai doing TITLE`); done clears it. A node that is not a line gets `@doc`: it expands into that file — `.md` or `.scrbl`, greppable, diffable, still yours. Full rules: [docs/syntax.md](docs/syntax.md).
 
 Under the hood every outline becomes s-expressions. Same expander:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -252,7 +252,8 @@ Routes:
 | `GET /api/agenda` | byte-identical to `olai agenda` |
 | `GET /static/app.css` | the skin, `text/css`, `Cache-Control: no-cache`. Generated from the Racket modules that draw the page — `olai/web/skin` composes them — not a file on disk. This route is the only way to get those bytes; there is no `css` command |
 | `GET /static/manifest.webmanifest` | web app manifest (`application/manifest+json`); name, icons, `display: standalone`, default theme colours |
-| `GET /static/*` | files under `olai/web/static/` — olai's own assets: icons, `collapse.js`, `prefs.js`, `chat.js`, `pwa.js` |
+| `GET /static/*` | files under `olai/web/static/` — olai's own assets: icons, `collapse.js`, `prefs.js`, `chat.js`, `pwa.js`, `highlight-init.js`, and the vendored highlighter under `hljs/` |
+| `GET /media/*` | pictures under the directory being served — what a note's `![](shot.png)` asks for. Same rules as `/static/`: a path that climbs out is a `404`, and so is a miss. Only picture extensions are served (`png`, `jpe?g`, `gif`, `webp`, `avif`, `bmp`, `ico`); an `.svg` is a document that can script, and the outline's own files are not pictures |
 | `GET /live/*` | files under the `live` collection's `static/` — the live-view client runtime this app ships and never edits: htmx, its SSE extension, idiomorph, and the health watchdog ([live/README.md](../live/README.md)) |
 | anything else | `404`, terse `text/plain` |
 
@@ -261,6 +262,14 @@ A node's permalink is `/n/<key>` (`key` as in `tree` JSON): every bullet in the 
 Within a page, anchored nodes and bare-ISO day nodes also keep a plain `#<anchor>` / `#<YYYY-MM-DD>` target, so links people wrote by hand still resolve, and every node carries `id="n-<key>"`.
 
 Paths that climb out of `static/` are 404, not files.
+
+**Markdown** is render-time only: the strings in the struct and in every JSON reply stay verbatim. A title is INLINE (block syntax in one is just characters — a leading `#tag` is a tag, not an `<h1>`); a note, an agent's finished turn and a `@doc` document are full Markdown. What comes out is sanitized against an allowlist — anything not on it is dropped, attributes included — and three things ride through it:
+
+* **Fenced code** keeps its language: the fence's first word, if it is a bare language name, becomes `class="language-<lang>"` on the `<code>`, and the browser paints it with highlight.js. That bundle is vendored (pinned in `npins/sources.json`, built by `nix/highlight-js.nix`, served from `/static/hljs/`) — never a CDN, and never a hand-committed blob. The colours are the skin's, so they follow the theme you picked; `racket` and `rkt` read as Scheme. A word that is not a language hljs has is a block left as plain text.
+* **Images** are files beside the outline: a RELATIVE `src` naming a picture becomes `/media/<path>`, and nothing else is drawn at all — no `http(s):`, no `data:`, no `//host`, no absolute path, no `..`, and no format the route will not serve (the list is `olai/web/markdown`'s, and the route is built from the same one). A picture is a note's, a document's or an agent turn's; a title stays one line and draws none.
+* **Footnotes** (`text[^1]` + `[^1]: …`) work, both ways. The ids are re-minted per piece of Markdown — the parser's own are never trusted onto the page — so the same note draws the same ids on every render and two notes on one page cannot collide.
+
+No tables, no strikethrough, no task lists: that is the `markdown` package's ceiling, and the parser is not ours to replace.
 
 **Prefs** are a sidebar section, one row per preference — client state, stored in `localStorage` under `olai.<pref>`, never sent to the server (same standing as the collapse state) and therefore per browser. The first row is `theme`: one chip per theme in `olai/web/theme`'s table, and nothing else. The sheet carries all of them, so picking one is a value on `<html data-theme>` and nothing else — no round trip, no re-render. A page that has picked nothing reads in the default theme (the sheet's bare `:root`) and that chip is the lit one; the OS's `prefers-color-scheme` is never consulted, and a stored theme the sheet no longer carries is forgotten on sight. A tiny inline script in `<head>` restores stored prefs before the first paint (`static/prefs.js` is the picker); each theme declares its own `color-scheme`, so scrollbars and form controls follow. `<meta name="theme-color">` starts as the default theme's paper and is rewritten from `--paper` by `static/pwa.js` whenever a chip flips, so the browser chrome tracks the page.
 

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -19,6 +19,8 @@ So `just install` links `live` before `olai`, and `just build` is `raco setup --
 * `git status` stays clean: the three are gitignored by name (`live/static/live.js` is ours and tracked). An upgrade that renames an artifact shows up as untracked rather than silently replacing anything.
 * Upgrading is `npins update htmx` — a revision and a hash in the diff, not a minified blob. Then `just test && just e2e`.
 
+`olai/web/static/hljs/` is the same arrangement one directory over: highlight.js and the two grammars the common bundle leaves out (`scheme`, for `racket`; `nix`), pinned as `highlight-js` and picked out of the checkout by `nix/highlight-js.nix`. The same `just vendor` stages them, the whole directory is gitignored (nothing in it is ours — `static/highlight-init.js` is, and is tracked), and `nix/olai.nix` installs them into the package the same way `live` arrives from its own derivation. Which files, and what they are called once they land, is that nix file's table; the list the page pulls in is `highlight-scripts` in `olai/web/markdown.rkt`, and `olai/tests/render.rkt` fails if the two disagree.
+
 ## Toolchain
 
 * Racket comes from `nix develop` (nixpkgs 9.2). `just` recipes set `PLTUSERHOME` to `$PWD/.plt-user` so user packages and the two links live in the worktree, not `~`. That directory must be writable.

--- a/e2e/features/highlight.feature
+++ b/e2e/features/highlight.feature
@@ -1,0 +1,26 @@
+Feature: fenced code is painted
+
+  A fence names a language and the server says so on the <code> element; the
+  colours are the browser's, from a highlighter this server ships itself
+  (never a CDN). Nothing the racket tests can see: they stop at the markup, and
+  the spans are written after it.
+
+  The second scenario is the one that matters. A live update MORPHS the
+  server's markup back over the DOM, so every painted block is plain text again
+  the moment anything changes — which is why the pass runs on settle and not
+  once at load.
+
+  Scenario: a fenced block is painted on first render
+    When I open the home page
+    And I zoom into "Ship the server"
+    Then the document on this page reads "listening"
+    And the code block on this page is painted
+
+  Scenario: it is painted again after the document is rewritten
+    When I open the home page
+    And I zoom into "Ship the server"
+    And I mark this page load
+    And I rewrite the document with a fenced block
+    Then the document on this page reads "Rewritten under the server"
+    And the code block on this page is painted
+    And the page has not reloaded

--- a/e2e/fixtures/notes/serve.md
+++ b/e2e/fixtures/notes/serve.md
@@ -8,3 +8,12 @@ see what a `@doc` node looks like in the two places it is drawn.
 - A heading, so the zoomed page has a block to find.
 - A list, so it has more than a paragraph.
 - Nothing a step matches by accident: every phrase here is its own.
+
+## A fence
+
+Fenced code, so a scenario can see it painted:
+
+```racket
+(define (serve port)
+  (displayln "listening"))
+```

--- a/e2e/steps/highlight_steps.js
+++ b/e2e/steps/highlight_steps.js
@@ -1,0 +1,34 @@
+// Fenced code, painted in the browser.
+//
+// What the server sends is <code class="ol-code language-racket"> and the code
+// as text (olai/web/markdown); what a step here asks about is what
+// highlight.js made of it — the class it writes on the element it painted, and
+// at least one token span inside. Asserting behaviour, not colours: which
+// token wears which of the palette's colours is the skin's business, and a
+// screenshot would be the wrong test for it.
+
+import assert from "node:assert/strict";
+import { Then, When } from "@cucumber/cucumber";
+
+Then("the code block on this page is painted", async function () {
+  const code = this.page
+    .locator("#ol-outline .ol-doc-body pre > code.language-racket")
+    .first();
+  await code.waitFor({ state: "visible" });
+  // hljs marks what it painted; the spans are the paint itself
+  await this.page
+    .locator("#ol-outline .ol-doc-body pre > code.hljs > span[class^='hljs-']")
+    .first()
+    .waitFor({ state: "visible" });
+  assert.match(await code.innerText(), /displayln|listening/);
+});
+
+// The same document, moved under an open page: a different fence, so what the
+// step above finds is what this write put there and not what the page loaded
+// with. Sized differently from the fixture's, like every edit in this suite.
+When("I rewrite the document with a fenced block", async function () {
+  await this.rewriteDoc(
+    "# Rewritten under the server\n\n" +
+      "```racket\n(define (again) (displayln \"listening again\"))\n```\n",
+  );
+});

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,11 @@
               # `just` stages it into live/static/ where the collection's own
               # define-runtime-path expects it; the files are gitignored.
               export OLAI_LIVE_ASSETS="${self.packages.${system}.live}/static"
+              # olai's own vendored asset, on the same terms: the highlighter
+              # the web view paints a fenced code block with
+              # (nix/highlight-js.nix). `just` stages it into
+              # olai/web/static/hljs/.
+              export OLAI_HLJS_ASSETS="${self.packages.${system}.highlight-js}"
             '';
           };
         in
@@ -87,6 +92,11 @@
           # live/default.nix, next to the collection it is about.
           live = pkgs.callPackage ./live { inherit sources; };
 
+          # The web view's other vendored asset: highlight.js, picked out of
+          # the pinned cdn-release checkout. Which files and what they are
+          # called lives in nix/highlight-js.nix, beside the choice.
+          highlightJs = pkgs.callPackage ./nix/highlight-js.nix { inherit sources; };
+
           # The framework's worked example, as its own artifact: it consumes
           # `live` and is not part of it. Its nix, its just module and its
           # test all live in that directory — this line is the mount.
@@ -96,13 +106,14 @@
           # default) lives in nix/olai.nix; src is a flake-level decision.
           olai = pkgs.callPackage ./nix/olai.nix {
             inherit (racketDepsPkg) racketPkgs racketDeps;
-            inherit acpAgent live;
+            inherit acpAgent live highlightJs;
             src = ./.;
           };
         in
         {
           default = olai;
           inherit olai live counters;
+          highlight-js = highlightJs;
           racket-deps = racketDepsPkg.racketDeps;
           acp-agent = acpAgent;
           # cucumber + playwright for the browser journeys (e2e/default.nix).

--- a/justfile
+++ b/justfile
@@ -37,11 +37,15 @@ default:
 vendor:
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ -z "${OLAI_LIVE_ASSETS:-}" ]; then
-      echo "vendor: OLAI_LIVE_ASSETS unset — run inside \`nix develop\`" >&2
+    if [ -z "${OLAI_LIVE_ASSETS:-}" ] || [ -z "${OLAI_HLJS_ASSETS:-}" ]; then
+      echo "vendor: OLAI_LIVE_ASSETS / OLAI_HLJS_ASSETS unset — run inside \`nix develop\`" >&2
       exit 1
     fi
     install -m 0644 "$OLAI_LIVE_ASSETS"/* {{justfile_directory()}}/live/static/
+    # olai's own vendored asset (nix/highlight-js.nix): a directory of its
+    # own, gitignored whole, so nothing here is ever mistaken for ours.
+    install -d {{justfile_directory()}}/olai/web/static/hljs
+    install -m 0644 "$OLAI_HLJS_ASSETS"/* {{justfile_directory()}}/olai/web/static/hljs/
 
 # Deps + raco link ./live and ./olai (cheap; does not recompile — use `just build`)
 install: vendor

--- a/nix/highlight-js.nix
+++ b/nix/highlight-js.nix
@@ -1,0 +1,56 @@
+# highlight.js, staged as the files the web view serves.
+#
+# Same discipline as the browser runtime under live/static/ (live/default.nix):
+# a vendored artifact is a PIN and a hash in npins/sources.json, never a
+# minified blob in the diff. `npins update highlight-js` is the upgrade, and
+# what it upgrades is visible as a revision.
+#
+# The pin is highlightjs/cdn-release rather than the highlight.js source repo:
+# upstream builds the bundle there, tag by tag, so there is nothing to build
+# here — only to choose. The choice is the table below.
+{ lib, stdenvNoCC, sources }:
+
+let
+  # Which files, out of the checkout. They keep their own names, and those
+  # names are `highlight-scripts` in olai/web/markdown.rkt — that list and this
+  # one are the two halves of one fact, and olai/tests/render.rkt fails if they
+  # disagree.
+  #
+  # The bundle carries the COMMON languages (bash, json, js, sql, …). The two
+  # beside it are the ones an olai outline is actually written in and the
+  # common set leaves out; each language is its own file, so this is the whole
+  # cost of having them.
+  assets = [
+    "build/highlight.min.js"
+    # racket / rkt ride on this one — highlight.js has no Racket grammar, and
+    # the alias is registered in static/highlight-init.js
+    "build/languages/scheme.min.js"
+    "build/languages/nix.min.js"
+  ];
+in
+stdenvNoCC.mkDerivation {
+  pname = "highlight-js";
+  version = sources.highlight-js.version;
+
+  src = sources.highlight-js;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # …and upstream's licence beside them, because that is what shipping
+    # somebody else's bytes asks of us.
+    install -m 0444 -Dt $out \
+      ${lib.concatMapStringsSep " " (p: ''"$src/${p}"'') assets} \
+      "$src/LICENSE"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "highlight.js browser bundle, as olai serves it";
+    license = licenses.bsd3;
+  };
+}

--- a/nix/olai.nix
+++ b/nix/olai.nix
@@ -16,6 +16,10 @@
 # the live-view collection with its vendored browser runtime already staged
 # (live/default.nix) — a drop-in for $src/live
 , live
+# the highlighter the web view paints fenced code with, as the files it is
+# served as (nix/highlight-js.nix). Pinned upstream rather than committed, so
+# it is not in $src either
+, highlightJs
 }:
 
 stdenv.mkDerivation {
@@ -54,6 +58,13 @@ stdenv.mkDerivation {
     cp -a "${live}" ./live-pkg
     cp -a "$src/olai" ./olai-pkg
     chmod -R u+w ./live-pkg ./olai-pkg
+
+    # …and the highlighter under olai's own static/, for the same reason: the
+    # bytes are a pin, not a file in the repo, so they join the collection
+    # here rather than coming along with $src. `just vendor` stages the same
+    # files into the same place for a working tree.
+    mkdir -p ./olai-pkg/web/static/hljs
+    install -m 0644 "${highlightJs}"/* ./olai-pkg/web/static/hljs/
 
     # Offline install of npins-vendored deps (order matters).
     # --deps force: markdown wants package name "parsack"; we ship

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -98,6 +98,22 @@
       "hash": "sha256-4TIeinXk7ak7sbT2lwfWYdwIwFD9S7whBrR2KEajW30=",
       "frozen": true
     },
+    "highlight-js": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "highlightjs",
+        "repo": "cdn-release"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": false,
+      "version": "11.11.1",
+      "revision": "91724c0adaf7bea7e5c5c85e4ea1d672f6c0ed23",
+      "url": "https://api.github.com/repos/highlightjs/cdn-release/tarball/refs/tags/11.11.1",
+      "hash": "sha256-dZsMdL6MhxuugtSfUBkeNXmD2pn5ZvFAqWFXH0MfF/4="
+    },
     "htmx": {
       "type": "GitRelease",
       "repository": {

--- a/olai/tests/classes.golden
+++ b/olai/tests/classes.golden
@@ -70,6 +70,8 @@ ol-error-detail
 ol-error-where
 ol-file
 ol-file-title
+ol-footnotes
+ol-image
 ol-line
 ol-link
 ol-main

--- a/olai/tests/integration/serve.rkt
+++ b/olai/tests/integration/serve.rkt
@@ -356,6 +356,84 @@
          (check-equal? code 404 (format "~a -> ~a" p body))
          (check-false (string-contains? body "#lang") body)))))
 
+  ;; ---- pictures --------------------------------------------------------------
+  ;;
+  ;; A note draws `![](shot.png)` and the page asks for /media/shot.png: the
+  ;; file beside the outline, served same-origin by the one route that reaches
+  ;; that directory — and reaches nothing above it, and nothing in it that is
+  ;; not a picture.
+
+  ;; A file under the outline's own directory; `rel` may name a subdirectory.
+  (define (write-media! outline-file rel [content "not really a png\n"])
+    (define p (build-path (path-only outline-file) rel))
+    (make-parent-directory* p)
+    (display-to-file content p #:exists 'truncate))
+
+  (test-case "GET /media/<file> serves a picture beside the outline"
+    (with-server
+     (λ (port f)
+       (write-media! f "shot.png")
+       (write-media! f "images/deep.png")
+       ;; the page asks for exactly what the route answers: the note is the
+       ;; source of the URL, not this test
+       (display-to-file (string-append outline "  : a shot ![shot](shot.png)\n")
+                        f #:exists 'truncate)
+       (define-values (_pc _ph page) (GET port "/"))
+       (check-true (string-contains? page "src=\"/media/shot.png\"") page)
+       (define-values (code headers body) (GET port "/media/shot.png"))
+       (check-equal? code 200 body)
+       (check-true (string-contains? (or (header-value headers "content-type:") "")
+                                     "image/png")
+                   (format "~a" headers))
+       (check-true (string-contains? body "not really a png") body)
+       ;; a subdirectory of the outline's is still the outline's
+       (define-values (dcode _dh dbody) (GET port "/media/images/deep.png"))
+       (check-equal? dcode 200 dbody))))
+
+  (test-case "a media miss is a 404, not an error page"
+    (with-server
+     (λ (port f)
+       (define-values (code headers body) (GET port "/media/nothing-here.png"))
+       (check-equal? code 404 body)
+       (check-true (string-contains? (or (header-value headers "content-type:") "")
+                                     "text/plain")
+                   (format "~a" headers))
+       (check-true (string-contains? body "404") body))))
+
+  (test-case "media path traversal is rejected"
+    (with-server
+     (λ (port f)
+       ;; a real file, one level above the outline's directory: what a
+       ;; traversal would be reaching for
+       (define above (build-path (path-only f) 'up "outside.png"))
+       (display-to-file "outside\n" above #:exists 'truncate)
+       (for ([p (in-list '("/media/../outside.png"
+                           "/media/../../outside.png"
+                           "/media/images/../../outside.png"
+                           "/media/%2e%2e/outside.png"
+                           "/media/..%2Foutside.png"))])
+         (define-values (code _h body) (GET port p))
+         (check-equal? code 404 (format "~a -> ~a" p body))
+         (check-false (string-contains? body "outside") (format "~a -> ~a" p body)))
+       (delete-file (simple-form-path above)))))
+
+  ;; The route hands bytes to a browser with no reading of them, so what it
+  ;; will serve is a list of picture formats — an .svg is a document that can
+  ;; script, and the outline's own files are not pictures at all.
+  (test-case "media serves pictures and nothing else"
+    (with-server
+     (λ (port f)
+       (for ([rel (in-list '("diagram.svg" "notes.md" "secrets.env"))])
+         (write-media! f rel "keep out\n")
+         (define-values (code _h body) (GET port (string-append "/media/" rel)))
+         (check-equal? code 404 (format "~a -> ~a" rel body))
+         (check-false (string-contains? body "keep out") body))
+       ;; including the outline itself, which is the one file that is
+       ;; certainly there
+       (define-values (code _h body) (GET port "/media/Tasks.rkt"))
+       (check-equal? code 404 body)
+       (check-false (string-contains? body "#lang") body))))
+
   ;; This server has no agent (the CLI refuses to start one that way; see
   ;; tests/integration/acp.rkt for the wired-up chat routes). Everything chat
   ;; says so rather than pretending: no panel on the page, 503 on the routes.

--- a/olai/tests/render.rkt
+++ b/olai/tests/render.rkt
@@ -5,6 +5,7 @@
 
 (require json
          racket/file
+         racket/list
          racket/string
          xml
          file/sha1
@@ -342,6 +343,168 @@
     (define n (xstr* (note->xexprs "- one\n- two\n")))
     (check-true (string-contains? n "<ul") n)
     (check-true (string-contains? n "one") n))
+
+  ;; ---- fenced code: the language, and only the language -------------------
+  ;;
+  ;; The parser hands the fence's info string over as class="brush: …" on the
+  ;; <pre>. It is the one place a note carries a word straight from its author
+  ;; into an attribute, so what survives is the FIRST word, on the <code>, and
+  ;; only when it is a bare language name.
+
+  (test-case "a fence names its language on the code element"
+    (define n (xstr* (note->xexprs "```racket\n(define x 1)\n```\n")))
+    (check-true (string-contains? n "<pre class=\"ol-pre\"") n)
+    (check-true (string-contains? n "class=\"ol-code language-racket\"") n)
+    (check-true (string-contains? n "(define x 1)") n)
+    ;; a fence with no info string says nothing about a language
+    (define plain (xstr* (note->xexprs "```\nblock\n```\n")))
+    (check-true (string-contains? plain "class=\"ol-code\"") plain)
+    (check-false (string-contains? plain "language-") plain))
+
+  (test-case "an info string cannot smuggle markup through the fence"
+    (define n (xstr* (note->xexprs "```js onload=\"alert(1)\" evil\ncode\n```\n")))
+    ;; the first word is the language; the rest of the line is gone
+    (check-true (string-contains? n "class=\"ol-code language-js\"") n)
+    (check-false (string-contains? n "onload") n)
+    (check-false (string-contains? n "alert(1)") n)
+    ;; and a first word that is not a language name is no class at all
+    (for ([info (in-list '("\"><script>alert(1)</script>"
+                           "-leading-dash"
+                           "语言"))])
+      (define s (xstr* (note->xexprs (string-append "```" info "\ncode\n```\n"))))
+      (check-false (string-contains? s "language-") s)
+      (check-false (string-contains? s "<script") s))
+    ;; nor is a language name longer than any language has ever been
+    (define long (xstr* (note->xexprs
+                         (string-append "```" (make-string 64 #\a) "\ncode\n```\n"))))
+    (check-false (string-contains? long "language-") long))
+
+  ;; ---- pictures ------------------------------------------------------------
+  ;;
+  ;; An image's src is a path inside the outline's own directory, rewritten to
+  ;; the one route that serves it. Everything else is not a picture this view
+  ;; draws — not a remote one, not an inline one, and not one that climbs.
+
+  (test-case "a relative image is served from the outline's directory"
+    (define n (xstr* (note->xexprs "![a shot](images/pic.png)")))
+    (check-true (string-contains? n "<img") n)
+    (check-true (string-contains? n "src=\"/media/images/pic.png\"") n)
+    (check-true (string-contains? n "alt=\"a shot\"") n)
+    (check-true (string-contains? n "class=\"ol-image\"") n))
+
+  (test-case "an image that is not a file beside the outline is not drawn"
+    (for ([src (in-list '("https://evil.example/a.png"
+                          "http://evil.example/a.png"
+                          "//evil.example/a.png"
+                          "data:text/html;base64,PHNjcmlwdD4="
+                          "javascript:alert(1)"
+                          "JavaScript:alert(1)"
+                          "/etc/passwd"
+                          "../../secret.png"
+                          "images/../../secret.png"
+                          "a.png?x=1"
+                          ;; not a picture: the route will not serve these, so
+                          ;; drawing one would be drawing a broken icon
+                          "diagram.svg"
+                          "Tasks.rkt"
+                          "notes"))])
+      (define n (xstr* (note->xexprs (format "![x](~a)" src))))
+      (check-false (string-contains? n "<img") (format "~a -> ~a" src n))
+      (check-false (string-contains? n "javascript") (format "~a -> ~a" src n))
+      (check-false (string-contains? n "data:") (format "~a -> ~a" src n)))
+    ;; The sanitizer is the border, so it is asked directly too — an xexpr can
+    ;; hold what a Markdown source cannot express (the parser eats a backslash
+    ;; before it ever gets here).
+    (for ([src (in-list '("..\\secret.png" "\\\\host\\share\\a.png" ""))])
+      (check-equal? (sanitize-xexpr `(p (img ((src ,src) (alt "x"))))) '(p) src))
+    ;; and a src that survives is always under the route, never verbatim
+    (check-false (string-contains? (xstr (sanitize-xexpr '(img ((src "a.png")))))
+                                   "\"a.png\"")))
+
+  ;; A title is one line of an outline row, and a picture is not one line.
+  (test-case "a title draws no picture"
+    (define s (xstr* (title->inline-xexprs "hi ![x](a.png) there")))
+    (check-false (string-contains? s "<img") s)
+    (check-true (string-contains? s "hi") s))
+
+  ;; ---- footnotes -----------------------------------------------------------
+  ;;
+  ;; The parser wires a footnote by id, and mints those ids itself. The
+  ;; structure survives; the names do not — the number is all that is read out
+  ;; of an upstream id, and both ends are spelled from a prefix this view chose.
+
+  (define (attr-values s name)
+    (regexp-match* (pregexp (string-append name "=\"([^\"]*)\"")) s #:match-select cadr))
+
+  (test-case "a footnote survives, and both ends point at each other"
+    (define n (xstr* (note->xexprs "text[^1] and more[^2]\n\n[^1]: first\n\n[^2]: second\n")))
+    (check-true (string-contains? n "<sup") n)
+    (check-true (string-contains? n "ol-footnotes") n)
+    (check-true (string-contains? n "first") n)
+    ;; every id is one this module minted, and no id the parser made
+    (define ids (attr-values n "id"))
+    (check-equal? (length ids) 4 n)
+    (for ([id (in-list ids)])
+      (check-true (regexp-match? #px"^fn[0-9a-f]{8}-(fn|fnref)-[0-9]+$" id) id))
+    ;; and every jump link lands on one of them
+    (define jumps
+      (for/list ([h (in-list (attr-values n "href"))]
+                 #:when (string-prefix? h "#"))
+        (substring h 1)))
+    (check-equal? (length jumps) 4 n)
+    (for ([j (in-list jumps)])
+      (check-not-false (member j ids) (format "~a is a link to nothing" j))))
+
+  (test-case "two notes on a page number their footnotes apart"
+    (define a (xstr* (note->xexprs "a[^1]\n\n[^1]: first\n")))
+    (define b (xstr* (note->xexprs "b[^1]\n\n[^1]: second\n")))
+    (check-equal? (length (remove-duplicates (append (attr-values a "id")
+                                                     (attr-values b "id"))))
+                  4 (string-append a b))
+    ;; and the same note twice is the same markup: an id that moved between
+    ;; renders is markup a live update would have to replace rather than morph
+    (check-equal? (xstr* (note->xexprs "a[^1]\n\n[^1]: first\n")) a))
+
+  (test-case "a forged footnote id never reaches the page"
+    (define s
+      (xstr (sanitize-xexpr
+             '(div ((class "footnotes"))
+                   (ol ()
+                       (li ((id "x\"><script>alert(1)</script>-footnote-1-definition"))
+                           (a ((href "#evil") (name "javascript:alert(1)")) "back")
+                           (a ((href "#g1-footnote-1-return")
+                               (name "g1-footnote-2-return"))
+                              "↩")))))))
+    (check-false (string-contains? s "<script") s)
+    (check-false (string-contains? s "javascript:") s)
+    (check-false (string-contains? s "g1-") s)
+    ;; an id that is not a footnote's NAME is not a footnote's id: the <li>
+    ;; keeps nothing at all
+    (check-false (string-contains? s "<li id") s)
+    ;; a well-formed one is re-minted, both ends of it
+    (check-true (string-contains? s "href=\"#fnref-1\"") s)
+    (check-true (string-contains? s "id=\"fnref-2\"") s)
+    ;; an href that is not a footnote's is still just an href
+    (check-true (string-contains? s "href=\"#evil\"") s))
+
+  ;; ---- the scripts a rendered page pulls in --------------------------------
+
+  ;; Three of them are vendored — highlight.js and two of its grammars, pinned
+  ;; upstream and staged by nix (nix/highlight-js.nix), never committed — so a
+  ;; checkout that skipped `just vendor` fails HERE, the way live/tests/client
+  ;; fails for the browser runtime, rather than in a browser with no colour.
+  (test-case "every script the page links is a file under static/"
+    (for ([name (in-list web-scripts)])
+      (check-true (file-exists? (build-path (web-static-dir) name)) name))
+    (define page (xstr (render-page '(div))))
+    (for ([name (in-list web-scripts)])
+      (check-true (string-contains? page (string-append "src=\"/static/" name "\""))
+                  name))
+    ;; the bundle before the grammars that register into it, and ours after both
+    (check-true (< (string-index page "hljs/highlight.min.js")
+                   (string-index page "hljs/scheme.min.js")))
+    (check-true (< (string-index page "hljs/scheme.min.js")
+                   (string-index page "highlight-init.js"))))
 
   ;; ---- outline ------------------------------------------------------------
 

--- a/olai/tests/style.rkt
+++ b/olai/tests/style.rkt
@@ -183,9 +183,14 @@
                            #:children (list (mirror-ref "no-such-anchor" #f))))
           (hash)))
     #:today example-today)
-   ;; Markdown at render time: the anchor and the code a note (or a finished
-   ;; turn) makes are the classes the demo outlines never happen to contain.
-   (note->xexprs "see [the manual](https://example.com), `inline`\n\n```\nblock\n```\n")
+   ;; Markdown at render time: the anchor, the code, the picture and the
+   ;; footnotes a note (or a finished turn) makes are the classes the demo
+   ;; outlines never happen to contain.
+   (note->xexprs (string-append
+                  "see [the manual](https://example.com), `inline`\n\n"
+                  "```\nblock\n```\n\n"
+                  "![a screenshot](shot.png)\n\n"
+                  "a claim[^1]\n\n[^1]: and what it rests on\n"))
    ;; The panel is chrome: what a conversation looks like is chat.js's markup,
    ;; and the classes it spells are read off the script (scripted-classes).
    (render-chat-panel
@@ -229,7 +234,11 @@
 ;; are its own vocabulary, and the skin styles them from the binding — and
 ;; scanning a minified bundle for class-shaped names would find noise, not a
 ;; border.
-(define script-names '("chat.js" "collapse.js" "prefs.js" "pwa.js"))
+;; (highlight-init.js is ours too; the bundle it drives is not, and neither
+;; are the language files beside it — they are vendored under static/hljs/,
+;; and scanning a minified grammar for class-shaped names would find noise.)
+(define script-names
+  '("chat.js" "collapse.js" "prefs.js" "pwa.js" "highlight-init.js"))
 
 (define scripted-classes
   (for/fold ([acc (set)]) ([js (in-list script-names)])

--- a/olai/web/markdown.rkt
+++ b/olai/web/markdown.rkt
@@ -11,6 +11,9 @@
 (require racket/contract
          racket/list
          racket/match
+         racket/string
+         ;; a name for a note, derived from the note (see footnote-prefix)
+         (only-in file/sha1 sha1)
          (only-in markdown parse-markdown)
          (only-in xml xexpr->string)
          ;; the tag grammar has one owner; this module only draws the pills
@@ -24,7 +27,15 @@
          title->inline-xexprs
          note->xexprs
          style-md-xexpr
-         (contract-out [note->html-string (-> string? string?)]))
+         (contract-out [note->html-string (-> string? string?)]
+                       ;; where the pictures a note draws come from — the URL
+                       ;; they are asked for at, and the formats this module
+                       ;; will write a src for at all — and what paints the
+                       ;; code it fences. What this module puts on a page that
+                       ;; something else has to serve
+                       [media-prefix string?]
+                       [media-extensions (listof string?)]
+                       [highlight-scripts (listof string?)]))
 
 ;; ---- xexpr helpers --------------------------------------------------------
 
@@ -51,14 +62,21 @@
 
 ;; ---- sanitize (no raw HTML injection) -------------------------------------
 
-(define allowed-inline
+;; Two tables, and what divides them is not block versus inline: it is what a
+;; TITLE gets. A title is one line of an outline row, so the second table is
+;; the set a title does not get — the blocks, and `img`, which is inline in
+;; HTML and still not one line.
+(define allowed-anywhere
   (make-hasheq '((em . #t) (strong . #t) (code . #t) (a . #t) (del . #t)
-                           (span . #t) (br . #t))))
+                           (span . #t) (br . #t)
+                           ;; a footnote's reference marker
+                           (sup . #t))))
 
-(define allowed-block
+(define allowed-in-body
   (make-hasheq '((p . #t) (pre . #t) (ul . #t) (ol . #t) (li . #t)
                            (blockquote . #t) (h1 . #t) (h2 . #t) (h3 . #t)
-                           (h4 . #t) (h5 . #t) (h6 . #t) (hr . #t) (div . #t))))
+                           (h4 . #t) (h5 . #t) (h6 . #t) (hr . #t) (div . #t)
+                           (img . #t))))
 
 ;; The value of an xexpr attribute, or `missing` when the tag does not wear it.
 (define (attr-value attrs name [missing #f])
@@ -66,18 +84,190 @@
     [(list-rest _ value _) value]
     [_ missing]))
 
+;; Same, but only when it is a string — everything below reads attributes with
+;; a regexp, and an xexpr is a data structure a caller writes by hand.
+(define (attr-string attrs name)
+  (define v (attr-value attrs name))
+  (and (string? v) v))
+
 (define (safe-href href)
   (and (string? href)
        (or (regexp-match? #px"^(https?|mailto):" href)
            (regexp-match? #px"^#" href))
        href))
 
-(define (sanitize-attrs tag attrs)
+;; ---- pictures --------------------------------------------------------------
+
+;; Where a picture in a note comes from. The ROUTE is the server's to mount
+;; (olai/web/serve); the prefix is this module's, because this is the module
+;; that writes the src — the same split /static/ has with web/render.
+(define media-prefix "/media/")
+
+;; And what a picture IS, which is a shorter list than what a file can be: the
+;; route hands these bytes to a browser with no reading of them, so an .svg —
+;; a document, which can script — is not one. Said here, next to the src this
+;; module writes, and the route is built from the same list (olai/web/serve).
+(define media-extensions
+  '("png" "jpg" "jpeg" "gif" "webp" "avif" "bmp" "ico"))
+
+(define media-extension-rx
+  (pregexp (string-append "(?i:\\.(" (string-join media-extensions "|") "))$")))
+
+;; An image's src is a path INSIDE the outline directory, and nothing else: no
+;; scheme (http, data:, javascript:), no protocol-relative //host, no absolute
+;; path, and no segment that climbs. What is left is served by one route off
+;; the directory being served — so a picture in a note is a file beside the
+;; outline, and a picture anywhere else is not drawn at all rather than
+;; fetched from wherever it says.
+;;
+;; A backslash is rejected wherever it appears, which is also what makes a
+;; leading one (a UNC path) one of the rejected shapes.
+(define (media-href src)
+  (and (non-empty-string? src)
+       (not (regexp-match? #px"^[A-Za-z][A-Za-z0-9+.-]*:" src)) ; a scheme
+       (not (regexp-match? #px"^/" src))                ; absolute, or //host
+       (not (regexp-match? #px"\\\\" src))              ; the other separator
+       (not (regexp-match? #px"(^|/)\\.\\.(/|$)" src))  ; climbing
+       (not (regexp-match? #px"[?#]" src))              ; a query is not a file
+       (not (regexp-match? #px"[[:cntrl:]]" src))
+       (regexp-match? media-extension-rx src)
+       (string-append media-prefix src)))
+
+;; ---- footnotes -------------------------------------------------------------
+;;
+;; The parser emits working footnotes: a <sup> marker per reference, and an
+;; <ol> of definitions each with a ↩ back to it, wired together by id. It mints
+;; those ids itself, from a gensym per parse — and none of that is ours to
+;; trust onto the page, because an id is also just markup somebody can write.
+;;
+;; So the STRUCTURE survives and the NAMES do not. The only thing read out of
+;; an upstream id is the footnote's number and which end of the pair it is;
+;; both ends are then spelled here, from a prefix this module chose. A forged
+;; id in a note is at worst a jump link to the wrong footnote of that same
+;; note, and never a name of somebody else's choosing landing on the page.
+
+;; "…-footnote-3-definition" -> (cons "3" "definition"), else #f. Anchored at
+;; both ends: an id is the whole attribute, never a substring of one.
+(define footnote-id-rx
+  #px"^[A-Za-z0-9_-]*footnote-([0-9]{1,4})-(definition|return)$")
+
+(define (footnote-parts s)
+  (define m (and (string? s) (regexp-match footnote-id-rx s)))
+  (and m (cons (cadr m) (caddr m))))
+
+;; The href a footnote link carries is the same name with a # on it.
+(define (footnote-href-parts href)
+  (and (string? href)
+       (string-prefix? href "#")
+       (footnote-parts (substring href 1))))
+
+(define (footnote-name prefix parts)
+  (string-append prefix
+                 (if (equal? (cdr parts) "definition") "fn-" "fnref-")
+                 (car parts)))
+
+;; A page is many parses — every title, every note, every document — and each
+;; numbers its footnotes from 1, so the prefix is what keeps two of them from
+;; minting one id. It is the text's own hash: the same note draws the same ids
+;; on every render (a live update MORPHS the markup, and an id that moved would
+;; be markup that has to be replaced instead), and two notes collide only by
+;; being the same note twice.
+;;
+;; Which does happen, and is the known limit: a mirrored node is one note drawn
+;; at two SITES on one page, so both copies mint the same ids and the ↩ from
+;; either lands on the first. Cosmetic, and the alternative is this module
+;; being told a node's identity — which it does not otherwise know, and which a
+;; chat turn does not have at all.
+(define (footnote-prefix text)
+  (string-append "fn" (substring (sha1 (open-input-string text)) 0 8) "-"))
+
+;; The one class that crosses from the parser's markup into ours, and a lookup
+;; rather than a value carried through: it is how the parser marks the block of
+;; definitions, and how style-md-xexpr finds the block to paint.
+(define footnotes-class "footnotes")
+
+;; ---- fenced code -----------------------------------------------------------
+
+;; The highlighter, as the files a page pulls in, IN LOAD ORDER: the bundle,
+;; then the languages that register into it, then ours. The three under hljs/
+;; are vendored — pinned upstream and staged by nix, never committed
+;; (nix/highlight-js.nix) — and they are named here because this is the module
+;; that draws what they paint. Where they are MOUNTED is web/render's.
+(define highlight-scripts
+  '("hljs/highlight.min.js" "hljs/scheme.min.js" "hljs/nix.min.js"
+    "highlight-init.js"))
+
+;; The fence's language, put where a highlighter reads it.
+;;
+;; The parser hangs the info string on the <pre> as class="brush: LANG …" —
+;; SyntaxHighlighter's spelling, from 2009. HTML's convention, which is also
+;; highlight.js's, is class="language-LANG" on the <code> inside, and it is
+;; the truer statement: the language is a fact about the code, not about the
+;; box around it.
+;;
+;; Only the FIRST word is read, and only when it is a bare language name. The
+;; rest of an info string is anything at all — a fence is the one place a note
+;; carries a word straight from its author into an attribute — so anything
+;; else is a fence with no language rather than a fence with a class.
+(define brush-rx #px"^brush: *([A-Za-z0-9][A-Za-z0-9+#._-]{0,31})(?: |$)")
+
+(define (fence-language attrs)
+  (define m (regexp-match brush-rx (or (attr-string attrs 'class) "")))
+  (and m (cadr m)))
+
+(define (label-code-language attrs kids)
+  (define lang (fence-language attrs))
+  (if lang
+      (for/list ([k (in-list kids)])
+        (if (eq? (xexpr-tag k) 'code)
+            (make-xexpr 'code
+                        `((class ,(string-append "language-" lang)))
+                        (xexpr-kids k))
+            k))
+      kids))
+
+;; What an element keeps. `prefix` is the footnote namespace this piece of
+;; markdown mints its ids in (see footnote-prefix).
+(define (sanitize-attrs tag attrs prefix)
   (case tag
     [(a)
-     (define href (safe-href (attr-value attrs 'href)))
-     (if href `((href ,href)) '())]
+     (define raw (attr-value attrs 'href))
+     (define jump (footnote-href-parts raw))
+     (define href (if jump
+                      (string-append "#" (footnote-name prefix jump))
+                      (safe-href raw)))
+     ;; the reference's own anchor, which the definition's ↩ points back at:
+     ;; <a name=…> is what the parser writes and `id` is what a page reads, so
+     ;; it is re-minted as one
+     (define anchor (footnote-parts (attr-value attrs 'name)))
+     (append (if href `((href ,href)) '())
+             (if anchor `((id ,(footnote-name prefix anchor))) '()))]
+    [(li)
+     (define fn (footnote-parts (attr-value attrs 'id)))
+     (if fn `((id ,(footnote-name prefix fn))) '())]
+    [(div)
+     (if (equal? (attr-string attrs 'class) footnotes-class)
+         `((class ,footnotes-class))
+         '())]
     [else '()]))
+
+;; One sanitized element — or nothing at all. Two tags decide something about
+;; themselves that an attribute list cannot say, so they are answered here
+;; rather than in the table above: an <img> IS its src, and one this view will
+;; not serve is a broken icon rather than a picture; a <pre> puts its fence's
+;; language on the child that carries the code.
+(define (sanitize-element tag attrs kids prefix)
+  (case tag
+    [(img)
+     (define src (media-href (attr-value attrs 'src)))
+     (define alt (attr-string attrs 'alt))
+     (if src
+         (list (make-xexpr 'img (cons `(src ,src) (if alt `((alt ,alt)) '())) kids))
+         '())]
+    [(pre)
+     (list (make-xexpr tag (sanitize-attrs tag attrs prefix)
+                       (label-code-language attrs kids)))]
+    [else (list (make-xexpr tag (sanitize-attrs tag attrs prefix) kids))]))
 
 ;; The markdown package emits smart punctuation as bare entity symbols
 ;; (mdash, ndash, rsquo, …). We want VERBATIM ASCII for those — ISO dates
@@ -123,10 +313,13 @@
       ""))
 
 ;; Returns a list of sanitized pieces (may flatten forbidden wrappers).
-(define (sanitize-pieces x #:inline-only? [inline-only? #f])
+;; `#:footnotes` is the namespace this markdown's footnote ids are minted in;
+;; the default is one namespace for everything, which is what a caller with a
+;; single piece of markup in its hands (a test, a fragment) wants.
+(define (sanitize-pieces x #:inline-only? [inline-only? #f] #:footnotes [prefix ""])
   (define (allowed? tag)
-    (or (hash-ref allowed-inline tag #f)
-        (and (not inline-only?) (hash-ref allowed-block tag #f))))
+    (or (hash-ref allowed-anywhere tag #f)
+        (and (not inline-only?) (hash-ref allowed-in-body tag #f))))
   (let loop ([x x])
     (cond
       [(string? x) (list x)]
@@ -138,14 +331,14 @@
        (define kids (xexpr-kids x))
        (define skids (append* (map loop kids)))
        (if (allowed? tag)
-           (list (make-xexpr tag (sanitize-attrs tag attrs) skids))
+           (sanitize-element tag attrs skids prefix)
            skids)] ; strip unknown tag (e.g. script), keep text kids
       [(list? x)
        (append* (map loop x))]
       [else '()])))
 
-(define (sanitize-xexpr x #:inline-only? [inline-only? #f])
-  (define pieces (sanitize-pieces x #:inline-only? inline-only?))
+(define (sanitize-xexpr x #:inline-only? [inline-only? #f] #:footnotes [prefix ""])
+  (define pieces (sanitize-pieces x #:inline-only? inline-only? #:footnotes prefix))
   (match pieces
     [(list one) one]
     [many many]))
@@ -253,6 +446,53 @@
   ;; a block already has the box; the code inside it does not need a second
   [(& ,(sel ol-code)) #:background none #:border 0 #:padding 0])
 
+;; A picture fits the column it is in, and never widens it.
+(define-style ol-image
+  #:display block
+  #:max-width 100%
+  #:height auto
+  #:margin (0.375rem 0)
+  #:border-radius ,radius)
+
+;; Footnotes, at the foot. The rule above them is what says the list under a
+;; note is not part of what the note said.
+(define-style ol-footnotes
+  #:margin-top 0.5rem
+  #:padding-top 0.375rem
+  #:border-top (1px solid ,line)
+  #:font-size 0.8125rem
+  #:color ,dim
+  [(& ol) #:margin 0 #:padding-left 1.25rem]
+  [(& p) #:margin (0.125rem 0)])
+
+;; ---- fenced code, painted --------------------------------------------------
+;;
+;; highlight.js writes the spans; the palette is ours. These are ITS class
+;; names — hljs-*, none of the skin's three prefixes — so this is a fragment
+;; rather than a define-style: nothing here DEFINES a class, it paints someone
+;; else's, the same standing web/render's rules for the framework's two
+;; stream-state classes have.
+;;
+;; And it is why nothing vendors a highlight.js stylesheet: one of those is one
+;; fixed palette in a file, and a page here reads in whichever theme its reader
+;; picked. Eight rules against the tokens is the whole cost.
+(register-fragment!
+ (css-expr
+  [,(sel "hljs-comment") ,(sel "hljs-quote") #:color ,dim #:font-style italic]
+  [,(sel "hljs-keyword") ,(sel "hljs-selector-tag") ,(sel "hljs-deletion")
+   #:color ,rose-fg]
+  [,(sel "hljs-string") ,(sel "hljs-regexp") ,(sel "hljs-addition")
+   #:color ,green]
+  [,(sel "hljs-number") ,(sel "hljs-literal") ,(sel "hljs-symbol")
+   ,(sel "hljs-bullet") ,(sel "hljs-meta")
+   #:color ,amber-fg]
+  [,(sel "hljs-title") ,(sel "hljs-name") ,(sel "hljs-section")
+   ,(sel "hljs-attr") ,(sel "hljs-attribute") ,(sel "hljs-variable")
+   ,(sel "hljs-built_in") ,(sel "hljs-type")
+   #:color ,blue-fg]
+  [,(sel "hljs-emphasis") #:font-style italic]
+  [,(sel "hljs-strong") #:font-weight 600]))
+
 ;; Attach the classes above; nothing else decides what a piece looks like.
 (define (style-md-xexpr x)
   (let loop ([x x])
@@ -263,17 +503,36 @@
        (define attrs (xexpr-attrs x))
        (define kids (map loop (xexpr-kids x)))
        (case tag
-         [(code) (make-xexpr 'code `((class ,ol-code)) kids)]
+         ;; a fenced block's language rides along — the sanitizer minted that
+         ;; class and the highlighter reads it (highlight-init.js) — and an
+         ;; inline `span` keeps sharing the one constant, which is nearly
+         ;; every <code> on a page
+         [(code)
+          (define lang (attr-string attrs 'class))
+          (make-xexpr 'code
+                      `((class ,(if lang (classes ol-code lang) ol-code)))
+                      kids)]
          [(pre) (make-xexpr 'pre `((class ,ol-pre)) kids)]
+         [(img) (make-xexpr 'img `((class ,ol-image) ,@attrs) kids)]
+         [(div)
+          (if (equal? (attr-string attrs 'class) footnotes-class)
+              (make-xexpr 'div `((class ,ol-footnotes)) kids)
+              (make-xexpr 'div attrs kids))]
          [(a)
           (define href (attr-value attrs 'href "#"))
-          (make-xexpr 'a `((href ,href) (class ,ol-link)) kids)]
+          ;; the id is the footnote anchor's, and the only other attribute the
+          ;; sanitizer ever mints on a link
+          (define id (attr-string attrs 'id))
+          (make-xexpr 'a
+                      `((href ,href) (class ,ol-link) ,@(if id `((id ,id)) '()))
+                      kids)]
          [else (make-xexpr tag attrs kids)])]
       [(list? x) (map loop x)]
       [else x])))
 
 (define (note->xexprs note)
-  (map style-md-xexpr (sanitize-pieces (parse-markdown note))))
+  (map style-md-xexpr
+       (sanitize-pieces (parse-markdown note) #:footnotes (footnote-prefix note))))
 
 ;; The same treatment, as one HTML string — for the callers that hand HTML to
 ;; a browser instead of an xexpr to a renderer (the `done` chat frame carries

--- a/olai/web/render.rkt
+++ b/olai/web/render.rkt
@@ -167,8 +167,14 @@
 ;; olai's own scripts. The client runtime (htmx, its SSE extension, idiomorph
 ;; and the health watchdog) is the framework's, mounted at its own prefix and
 ;; listed by it — see olai/web/live. These come after, and lean on it.
+;;
+;; The highlighter is under this prefix and not in this list: which files paint
+;; a fenced code block is the business of the module that draws one
+;; (web/markdown), the same way the framework's runtime is live/client's. All
+;; that is decided here is that they are mounted with the rest of /static/.
 (define web-scripts
-  '("collapse.js" "prefs.js" "chat.js" "pwa.js"))
+  (append '("collapse.js" "prefs.js" "chat.js" "pwa.js")
+          highlight-scripts))
 
 (define (static-href name) (string-append web-static-prefix name))
 

--- a/olai/web/serve.rkt
+++ b/olai/web/serve.rkt
@@ -20,6 +20,8 @@
 ;;   GET  /api/agenda   byte-identical to `olai agenda --json`
 ;;   GET  /static/app.css  the generated stylesheet (olai/web/skin)
 ;;   GET  /static/*     files from web/static/ (icons, scripts, manifest)
+;;   GET  /media/*      pictures from the outlines' own directory, and only
+;;                      those: what a note's `![](shot.png)` asks for
 ;;   anything else      404, terse text/plain
 ;;
 ;; No auth: the network is the auth (Tailscale / Caddy in front of it).
@@ -89,6 +91,9 @@
          ;; lands, from the module that owns them
          (only-in olai/web/theme theme-color-scheme theme-default-paper)
          olai/web/render
+         ;; where the pictures a note draws are asked for; the module that
+         ;; writes the src owns the prefix, this one mounts it
+         (only-in olai/web/markdown media-prefix media-extensions)
          (only-in olai/web/chat-panel render-chat-panel)
          olai/web/watch)
 
@@ -540,9 +545,10 @@
 
 ;; /<prefix>/foo.js -> that directory's foo.js. make-url->path refuses anything
 ;; that climbs out of the base ("/static/../..") — we turn that into a plain
-;; 404 instead of an error page. Two directories are mounted this way and they
-;; have different owners: /static/ is olai's own assets, /live/ is the
-;; framework's client runtime, which this app ships and never edits.
+;; 404 instead of an error page. Three directories are mounted this way and
+;; they have different owners: /static/ is olai's own assets, /live/ is the
+;; framework's client runtime, which this app ships and never edits, and
+;; /media/ is the user's own — the directory the outlines are in.
 ;; make-url->path is built ONCE per mount, not once per request: it is the
 ;; per-directory part, and the λ below is the per-request part.
 (define (dir-url->path dir)
@@ -555,20 +561,39 @@
 (define static-url->path (dir-url->path (web-static-dir)))
 (define live-url->path (dir-url->path (live-static-dir)))
 
-;; One MIME table for both mounts; building it walks a file, so it is built
+;; One MIME table for every mount; building it walks a file, so it is built
 ;; once rather than per request.
 (define the-mime-type (delay (make-path->mime-type mime-types-path)))
 
-(define (static-files-dispatcher prefix url->path)
-  (filter:make (regexp (string-append "^" (regexp-quote prefix)))
+;; A directory, mounted: what matches `rx` is served out of it, anything else
+;; is somebody else's request. One helper, so the three mounts cannot come to
+;; differ in what a directory means (no indices, one MIME table).
+(define (files-dispatcher rx url->path)
+  (filter:make rx
                (files:make #:url->path url->path
                            #:path->mime-type (λ (p) ((force the-mime-type) p))
                            #:indices '())))
 
+(define (prefix-rx prefix) (regexp (string-append "^" (regexp-quote prefix))))
+
+;; The pictures a note draws: the directory the OUTLINES are in, so
+;; `![](shot.png)` in a note is the file beside them.
+;;
+;; Three things bound it, and the route is only one of them. web/markdown will
+;; not write a src that is not a relative path to a picture; a request that
+;; arrives anyway meets the same make-url->path that refuses to climb out of
+;; /static/; and what is left is this filter — the same list of formats, from
+;; the same module, because this route hands bytes to a browser with no reading
+;; of them and a document that can script is not a picture. Anything else under
+;; the prefix falls through to the 404 a missing file gets.
+(define media-file-rx
+  (regexp (string-append "^" (regexp-quote media-prefix)
+                         "(?i:.*\\.(" (string-join media-extensions "|") "))$")))
+
 ;; The stylesheet the page links is generated, not a file (olai/web/skin owns
 ;; the URL). It wins that path ahead of the static directory, which no longer
 ;; holds an app.css to serve.
-(define (make-dispatcher st hub agent)
+(define (make-dispatcher st hub agent media-dir)
   (sequencer:make
    (filter:make (regexp (string-append "^" (regexp-quote stylesheet-href) "$"))
                 (lift:make (λ (req) (css-response))))
@@ -576,8 +601,9 @@
    ;; does not know
    (filter:make #rx"^/static/manifest\\.webmanifest$"
                 (lift:make (λ (_req) (manifest-response))))
-   (static-files-dispatcher web-static-prefix static-url->path)
-   (static-files-dispatcher live-asset-prefix live-url->path)
+   (files-dispatcher (prefix-rx web-static-prefix) static-url->path)
+   (files-dispatcher (prefix-rx live-asset-prefix) live-url->path)
+   (files-dispatcher media-file-rx (dir-url->path media-dir))
    (lift:make (make-router st hub agent))))
 
 ;; ---- server ---------------------------------------------------------------
@@ -630,22 +656,26 @@
                       #:on-agent [on-agent void])
   (define st (make-store files))
   (define hub (make-hub))
+  ;; Where the outlines LIVE: the deepest directory that holds them all (the
+  ;; same base node keys are minted against). It is the whole extent of what
+  ;; /media/ can reach, which is why it is derived from the FILES and from
+  ;; nothing that can be pointed elsewhere.
+  (define outline-dir (roots-base files))
   ;; The agent's working directory: the one it was given, else the outlines'
-  ;; own — one file means its directory, several mean the deepest one that
-  ;; holds them all (the same base node keys are minted against). It is worth
-  ;; naming rather than deriving: an agent's stored sessions are keyed by it,
-  ;; so a cwd that moves when the file set moves is a conversation history that
-  ;; moves with it. Nothing is spawned here; construction stays cheap.
+  ;; own. It is worth naming rather than deriving: an agent's stored sessions
+  ;; are keyed by it, so a cwd that moves when the file set moves is a
+  ;; conversation history that moves with it. Nothing is spawned here;
+  ;; construction stays cheap.
   (define agent
     (and acp-command
          (make-chat #:command acp-command
-                    #:cwd (or agent-cwd (roots-base files))
+                    #:cwd (or agent-cwd outline-dir)
                     ;; the conversation speaks (name, payload) and has never
                     ;; heard of the transport; this is where that becomes wire
                     #:broadcast (λ (name data)
                                   (hub-broadcast! hub (make-frame name data))))))
   (define-values (stop bound)
-    (listen (make-dispatcher st hub agent) port bind port-fallback?))
+    (listen (make-dispatcher st hub agent outline-dir) port bind port-fallback?))
   ;; Only once there is a listener: a watcher with nobody to tell is a
   ;; thread that reloads outlines for its own amusement.
   ;;

--- a/olai/web/static/chat.js
+++ b/olai/web/static/chat.js
@@ -302,7 +302,15 @@
       toolLine(f.id,f.title,f.status);
     }
     else if(f.type==='done'){
-      if(agentEl&&typeof f.html==='string')agentEl.innerHTML=f.html;
+      if(agentEl&&typeof f.html==='string'){
+        agentEl.innerHTML=f.html;
+        // Markup arrived without a swap, so nothing on the page would
+        // otherwise hear about it: an htmx settle is what every other pass
+        // over new markup listens for, and this is the one moment there is no
+        // htmx in it. Announced, not called: who cares is theirs to say
+        // (static/highlight-init.js is the one who does).
+        agentEl.dispatchEvent(new CustomEvent('olai:drawn',{bubbles:true}));
+      }
       if(f.stopReason&&f.stopReason!=='end_turn')
         append(line('ol-chat-note',f.stopReason));
       endTurn();

--- a/olai/web/static/highlight-init.js
+++ b/olai/web/static/highlight-init.js
@@ -1,0 +1,48 @@
+// Fenced code, painted. highlight.js (vendored beside this file, under hljs/)
+// knows the languages and writes the spans; this only says WHICH elements and
+// WHEN, and the colours are the skin's (olai/web/markdown).
+//
+// The language is a class the SERVER put on the <code> — language-<name>, out
+// of the fence's info string and through the sanitizer — so nothing here reads
+// anything a note's author wrote. A word that is not a language hljs has is a
+// block left as plain text: highlighting is a look, and guessing at one is
+// worse than not having it.
+(function(){
+  if(!window.hljs)return;
+
+  // highlight.js has no Racket grammar and Scheme is close enough to read by.
+  // The language file may not be there (a checkout that skipped `just
+  // vendor`), and registering an alias for a language hljs does not have
+  // throws.
+  if(hljs.getLanguage('scheme'))
+    hljs.registerAliases(['racket','rkt'],{languageName:'scheme'});
+
+  var LANG=/(?:^| )language-([^ ]+)/;
+
+  function paint(){
+    document.querySelectorAll('pre > code[class*="language-"]').forEach(function(el){
+      // hljs writes this itself, and highlighting twice is how a block ends
+      // up with spans inside spans
+      if(el.dataset.highlighted)return;
+      var m=LANG.exec(el.className);
+      if(!m||!hljs.getLanguage(m[1]))return;
+      hljs.highlightElement(el);
+    });
+  }
+
+  // afterSETTLE, for the same reason collapse.js says: a swap replaces the
+  // element an event would name, and the settle phase is when the server's
+  // markup is finally the DOM's. An outline reloaded under the page and a link
+  // followed both arrive that way, and a morph restores the plain text this
+  // puts the spans back over.
+  document.addEventListener('htmx:afterSettle',paint);
+
+  // The one thing that does not: a finished turn is HTML in a FRAME, drawn by
+  // chat.js, and no swap happens at all — so it announces it, and this listens
+  // for the announcement rather than being called by name. The day the panel
+  // is a live surface too (docs/brainstorming/live-dsl.md), the line above
+  // covers it and this one goes away with the announcement.
+  document.addEventListener('olai:drawn',paint);
+
+  paint();
+})();


### PR DESCRIPTION
Three things the `markdown` package already produced and the sanitizer threw away: a fence's language, images, and footnotes. The parser is unchanged — its ceiling (no tables, no strikethrough, no task lists) stands. What changed is what survives the allowlist, and what the page does with it.

The sanitizer is a security boundary, so every new allowance ships with hostile-input tests.

## 1. Fenced code keeps its language

**Allowlist:** `<pre>` gains no attribute of its own. Instead, when its `class="brush: LANG …"` (the parser's spelling) starts with a bare language name, the FIRST word — `[A-Za-z0-9][A-Za-z0-9+#._-]{0,31}` — becomes `class="language-LANG"` on the `<code>` inside. HTML's convention, and highlight.js's. Everything else in an info string is dropped: a fence is the one place a note carries a word straight from its author toward an attribute.

**The highlighter is vendored via nix, not committed.** `npins` pins `highlightjs/cdn-release`; `nix/highlight-js.nix` picks `highlight.min.js` plus the `scheme` and `nix` grammars (the common bundle's languages plus the two an olai outline is written in — `racket`/`rkt` alias onto `scheme`); `just vendor` stages them into `olai/web/static/hljs/`, gitignored whole; `nix/olai.nix` installs them into the package the way `live` already arrives from its own derivation. Same shape as the htmx/idiomorph runtime under `live/static/`. An upgrade is `npins update highlight-js` — a revision and a hash in the diff.

**The colours are the skin's.** A vendored hljs stylesheet is one fixed palette in a file, and a page here reads in whichever theme its reader picked, so the tokens are eight css-expr rules against the palette. Registered as a fragment rather than a `define-style`: `hljs-*` are not classes this program defines (the standing `render.rkt` already gives the framework's stream-state classes).

**When it paints:** `htmx:afterSettle`, like `collapse.js` — a morph puts the server's plain text back over every painted block, so first render is not enough. A finished chat turn is the one case with no swap at all (`chat.js` sets `innerHTML` from a frame), so it announces `olai:drawn` and the pass listens; when the panel becomes a live surface, the announcement goes away and the settle listener already covers it. A word hljs has no grammar for is left as plain text.

## 2. Images

**Allowlist:** `img` with `src` and `alt`, in the table a TITLE does not get — a title is one line of an outline row, and a picture is not one line.

**`src` is rewritten, never passed through.** Accepted: a relative path naming a picture. Rejected, with the element dropped rather than drawn broken: any scheme (`http(s):`, `data:`, `javascript:`), `//host`, an absolute path, any `..` segment, any backslash, a query, control characters, and any extension outside `media-extensions`. What survives becomes `/media/<path>`.

**The route** serves that off the directory the outlines are in — derived from the files, not from `#:agent-cwd`, which is a knob that could be pointed elsewhere. Bounded three ways: `web/markdown` will not write a bad src; `make-url->path` refuses a path that climbs out (the same call `/static/` has always made, so `%2e%2e` and friends are covered); and the dispatcher's filter is built from the same `media-extensions` list, so a document that can script (an `.svg`) is neither linked nor served. A miss is the ordinary 404, not an error page.

## 3. Footnotes

**Allowlist:** `sup`, plus the anchor pair — re-minted, never trusted. The only thing read out of an upstream id is the footnote's NUMBER and which end of the pair it is; both ends are then spelled from a prefix this module chose (the note's own hash, so ids are stable across renders — a live update morphs markup, and an id that moved is markup that has to be replaced). `<a name=…>` becomes an `id`. The footnotes block keeps its own look.

A forged `id="…footnote-1-definition"` in a note is at worst a jump to the wrong footnote of that same note. Known limit, stated in the source: a mirrored node is one note drawn at two sites, so both copies mint the same ids.

## Security tests

| what | where |
|---|---|
| info string carrying `onload="alert(1)"`, `"><script>`, a leading dash, non-ASCII, 64 chars | `olai/tests/render.rkt` |
| `javascript:` / `data:` / `http(s):` / `//host` / absolute / `..` / query / backslash / `.svg` / `.rkt` srcs | `olai/tests/render.rkt` |
| forged footnote id with markup in it; every id ours, every jump landing on one; two notes not colliding | `olai/tests/render.rkt` |
| `/media/` traversal in five spellings incl. `%2e%2e`; `.svg`, `.md`, `.env` and the outline's own `.rkt` refused; a miss is a 404 | `olai/tests/integration/serve.rkt` |
| a block painted on first render, and painted again after a live update morphs the markup back | `e2e/features/highlight.feature` |

## Checks

`just test` (307), `just test-integration` (118), `just e2e` (56 scenarios), `nix build .#olai` and the smoke check, all green locally.
