### PR TITLE
chat: tool calls fold — one line each, unfold on demand

### DIFF
--- a/e2e/features/chat.feature
+++ b/e2e/features/chat.feature
@@ -79,3 +79,63 @@ Feature: the agent panel
     And the page has not reloaded
     And the chat panel is open
     And the last turn reads "hello world"
+
+  # Tool calls are machine chatter: they arrive folded, one compact line each,
+  # and unfold when asked. Folding is the browser's, like the outline's
+  # collapse — the transcript keeps every call in full either way, and no
+  # frame on the wire knows a line is shut.
+  Scenario: a tool call arrives folded and unfolds when I ask
+    When I open the home page
+    And I press the agent toggle
+    And I send "what is in the outline" to the agent
+    Then the last turn ran the tool "read Tasks.rkt"
+    And the last turn's tool call is folded
+    When I unfold the last turn's tool call
+    Then the last turn's tool call is unfolded
+    And the last turn ran the tool "read Tasks.rkt"
+
+  # What folding is FOR. A real agent's tool titles are shell commands and
+  # absolute paths, and they used to wrap into paragraphs that buried the
+  # answer above them. Folded, a title with more to say than the line has room
+  # for is cut off at the line; unfolded, all of it is there. LONGTOOL is what
+  # asks the fake agent for one of those (olai/tests/integration).
+  Scenario: a title too long for its line is cut off until I unfold it
+    When I open the home page
+    And I press the agent toggle
+    And I send "LONGTOOL what did you run" to the agent
+    Then the last turn's tool call is folded
+    And the tool call's title is cut off
+    When I unfold the last turn's tool call
+    Then the last turn's tool call is unfolded
+    And unfolding put the whole title on screen
+
+  # Only the chatter folds. What the agent SAID is what the panel is for, and
+  # there is nothing in it to press.
+  Scenario: the agent's own words never fold
+    When I open the home page
+    And I press the agent toggle
+    And I send "what is in the outline" to the agent
+    Then the last turn reads "hello world"
+    And the agent's words have nothing to unfold
+
+  # A line you unfolded must not shut under you. Two things move the panel
+  # after it: the outline's live re-swap beneath it, and another turn arriving
+  # in it — and the fold is keyed by the call's own id, so even the transcript
+  # being rebuilt around it brings it back open.
+  Scenario: an unfolded tool call stays unfolded while the panel keeps moving
+    When I open the home page
+    And I press the agent toggle
+    And I send "what is in the outline" to the agent
+    Then the last turn ran the tool "read Tasks.rkt"
+    When I unfold the last turn's tool call
+    And I add the title "Renew the passport" to the outline
+    Then I see the title "Renew the passport"
+    And the first turn's tool call is unfolded
+    When I send "anything else" to the agent
+    Then the chat panel is idle
+    And the first turn's tool call is unfolded
+    # Same id, same line: that is the frame vocabulary's own rule (web/chat),
+    # and the fake agent reuses one. So the line drawn into the new turn is a
+    # new element that comes up OPEN — which is the keyed re-apply a rebuilt
+    # transcript rides on, with nothing to rebuild it here but a second turn.
+    And the last turn's tool call is unfolded

--- a/e2e/steps/chat_steps.js
+++ b/e2e/steps/chat_steps.js
@@ -137,7 +137,7 @@ Then("the chat is not titled {string}", async function (title) {
 // Nothing was replayed into it: this conversation is new, not one adopted from
 // somewhere else.
 Then("the transcript is empty", async function () {
-  assert.equal(await this.page.locator("#ol-chat-body .ol-chat-turn").count(), 0);
+  assert.equal(await this.page.locator(TURNS).count(), 0);
 });
 
 // ---- geometry -------------------------------------------------------------
@@ -272,8 +272,10 @@ async function sheet(page) {
 
 /** The turn being drawn. A turn owns its user bubble, the agent's text and its
  *  tool lines, so everything asserted about one is looked up inside it. */
+const TURNS = "#ol-chat-body .ol-chat-turn";
+
 function lastTurn(page) {
-  return page.locator("#ol-chat-body .ol-chat-turn").last();
+  return page.locator(TURNS).last();
 }
 
 Then("the last turn quotes me {string}", async function (text) {
@@ -297,4 +299,78 @@ Then("the last turn ran the tool {string}", async function (title) {
     .locator(".ol-chat-tool .ol-chat-tool-title", { hasText: title })
     .first()
     .waitFor({ state: "visible" });
+});
+
+// ---- folding the chatter ----------------------------------------------------
+//
+// A tool call is a disclosure, and the fake agent runs exactly one per turn,
+// so "the turn's tool call" is unambiguous. The button's aria-expanded IS the
+// fold — there is no class saying it a second time — so the state goes in the
+// SELECTOR, which is what makes these wait for it rather than read whatever is
+// there when they look.
+
+/** A turn's tool call: any of them, or the one in a given ARIA state. */
+function toolCall(turn, expanded) {
+  const state = expanded === undefined ? "" : `[aria-expanded="${expanded}"]`;
+  return turn.locator(`.ol-chat-tool${state}`).first();
+}
+
+function firstTurn(page) {
+  return page.locator(TURNS).first();
+}
+
+When("I unfold the last turn's tool call", async function () {
+  const tool = toolCall(lastTurn(this.page), "false");
+  // What the fold is holding down, read before the click: after it there is
+  // nothing left to compare against.
+  this.foldedToolBox = await tool.boundingBox();
+  await tool.click();
+});
+
+Then("the last turn's tool call is folded", async function () {
+  await toolCall(lastTurn(this.page), "false").waitFor({ state: "visible" });
+});
+
+Then("the last turn's tool call is unfolded", async function () {
+  await toolCall(lastTurn(this.page), "true").waitFor({ state: "visible" });
+});
+
+Then("the first turn's tool call is unfolded", async function () {
+  await toolCall(firstTurn(this.page), "true").waitFor({ state: "visible" });
+});
+
+// The clamp, as the browser laid it out rather than as the sheet claims it:
+// a title with more to say than the line has room for is cut off, and the
+// element knows it.
+Then("the tool call's title is cut off", async function () {
+  assert.ok(await clipped(this.page), "the title fits its line — nothing is held back");
+});
+
+// The other half: the whole title is out, and the line grew to hold it.
+Then("unfolding put the whole title on screen", async function () {
+  const tool = toolCall(lastTurn(this.page), "true");
+  const box = await tool.boundingBox();
+  assert.ok(
+    box.height > this.foldedToolBox.height,
+    `the tool call is still ${box.height}px tall — the title never left its one line`,
+  );
+  assert.equal(await clipped(this.page), false, "the title is still cut off");
+});
+
+async function clipped(page) {
+  return await toolCall(lastTurn(page))
+    .locator(".ol-chat-tool-title")
+    .evaluate((el) => el.scrollWidth > el.clientWidth);
+}
+
+// The prose the panel is actually for. Nothing in it is pressable, and its
+// text is there to read rather than to ask for.
+Then("the agent's words have nothing to unfold", async function () {
+  const said = lastTurn(this.page).locator(".ol-chat-msg.is-agent");
+  await said.waitFor({ state: "visible" });
+  assert.equal(
+    await said.locator("button, [aria-expanded]").count(),
+    0,
+    "the agent's own words carry a fold",
+  );
 });

--- a/olai/tests/classes.golden
+++ b/olai/tests/classes.golden
@@ -44,6 +44,7 @@ ol-chat-spop
 ol-chat-stop
 ol-chat-title
 ol-chat-tool
+ol-chat-tool-fold
 ol-chat-tool-glyph
 ol-chat-tool-title
 ol-chat-turn

--- a/olai/tests/integration/fake-acp-agent.rkt
+++ b/olai/tests/integration/fake-acp-agent.rkt
@@ -242,6 +242,16 @@
                  'toolCallId "call-replay"
                  'status "completed")))
 
+;; What the one tool call is called. Short by default, because that is what a
+;; test asserting a title wants to read — and, on LONGTOOL, the other thing a
+;; real agent hands a panel: a shell command no line has room for. A folded
+;; tool call is one line whatever it was called, and only a long one shows it.
+(define (tool-title text)
+  (if (string-contains? text "LONGTOOL")
+      (string-append "bash find . -name '*.rkt' -newer Roadmap.rkt "
+                     "| xargs grep -n 'tool_call' | sort -u | head -40")
+      "read Tasks.rkt"))
+
 ;; Sleep in slices so a cancel lands promptly. -> #t if it ran to the end.
 (define (dawdle seconds)
   (let loop ([left seconds])
@@ -304,7 +314,7 @@
      (chunk! "world")
      (update! (hash 'sessionUpdate "tool_call"
                     'toolCallId "call-1"
-                    'title "read Tasks.rkt"
+                    'title (tool-title text)
                     'kind "read"
                     'status "pending"))
      (update! (hash 'sessionUpdate "tool_call_update"

--- a/olai/web/chat-panel.rkt
+++ b/olai/web/chat-panel.rkt
@@ -285,19 +285,76 @@
   #:font-family ,mono
   #:font-size ,micro-size)
 
-;; one line per tool call, updated in place by id
+;; ---- one tool call ----------------------------------------------------------
+;;
+;; One line, and the line is a BUTTON. What you came to the panel for is what
+;; the agent SAID, and a turn that ran a dozen tools used to bury it under a
+;; dozen wrapped paragraphs of machine chatter. So a call comes up FOLDED: the
+;; title clamped to its line, whatever the agent called it, until you ask for
+;; the rest of it. A frame carries a title, a status and an id (web/chat), so
+;; the title is what there is to unfold — which is why the button's own label
+;; is what its aria-expanded is about, and there is no region to name.
+;;
+;; VIEW state, exactly like the outline's collapse: the transcript keeps every
+;; call in full whatever a browser is showing, no frame changes shape, and
+;; nothing on the wire knows a line is folded. static/chat.js writes it, and
+;; updates the line in place by id — same id, same line.
 (define-style ol-chat-tool
   #:display flex
   #:align-items baseline
   #:gap 0.375rem
+  ;; everything a button brings with it, undone: this is a line of the
+  ;; transcript that happens to be pressable, not a control of the chrome
+  #:width 100%
+  #:padding 0
+  #:border 0
+  #:background none
+  #:text-align left
+  #:cursor pointer
   #:font-family ,mono
   #:font-size 0.75rem
   #:color ,dim
   [(attribute & (= data-status ,tool-failed)) #:color ,rose-fg])
 
-(define-style ol-chat-tool-title #:overflow-wrap anywhere)
+;; The outline's disclosure triangle at the panel's scale — render.rkt's
+;; .ol-toggle is the original, and a second idiom for one gesture would be a
+;; second thing to learn. Pointing right while folded, a quarter turn open.
+;;
+;; What it does NOT copy is hiding until hover: the outline's triangle marks a
+;; node you CAN fold, and every line here is one and starts folded, so a
+;; triangle that appeared on hover would be an affordance a touch screen never
+;; finds. Quieter than its line instead — and by opacity, not by a colour,
+;; because a failed call paints the whole line and the triangle is part of it.
+(define-style ol-chat-tool-fold
+  #:flex none
+  #:font-size 0.625rem
+  #:line-height 1
+  #:opacity 0.55
+  #:transition (transform 120ms ease) (opacity 120ms ease)
+  [((: ,(sel ol-chat-tool) hover) &)
+   ((: ,(sel ol-chat-tool) focus-visible) &)
+   #:opacity 1]
+  [((attribute ,(sel ol-chat-tool) (= aria-expanded "true")) &)
+   #:opacity 1
+   #:transform (apply rotate 90deg)]
+  [@ media (#:prefers-reduced-motion reduce) #:transition none])
+
+;; Folded, ONE line whatever the agent called it: a shell command or an
+;; absolute path used to wrap into a paragraph, and a paragraph of chatter is
+;; the thing being fixed. Unfolded, the whole of it, spelled the way the agent
+;; spelled it.
+(define-style ol-chat-tool-title
+  #:flex (1 1 auto)
+  #:min-width 0
+  #:overflow hidden
+  #:text-overflow ellipsis
+  #:white-space nowrap
+  [((attribute ,(sel ol-chat-tool) (= aria-expanded "true")) &)
+   #:white-space pre-wrap
+   #:overflow-wrap anywhere])
 
 (define-style ol-chat-tool-glyph
+  #:flex none
   [((attribute ,(sel ol-chat-tool) (= data-status ,tool-completed)) &) #:color ,green]
   ;; a call still in flight spins; a finished one is a mark
   [((attribute ,(sel ol-chat-tool) (= data-status ,tool-pending)) &)

--- a/olai/web/static/chat.js
+++ b/olai/web/static/chat.js
@@ -88,12 +88,14 @@
     if(stick)body.scrollTop=body.scrollHeight;
   }
 
-  function line(cls,text){
-    var d=document.createElement('div');
+  function make(tag,cls,text){
+    var d=document.createElement(tag);
     d.className=cls;
     if(text!==undefined)d.textContent=text;
     return d;
   }
+
+  function line(cls,text){return make('div',cls,text)}
 
   // A turn owns its user bubble, the agent's text, and its tool lines, so a
   // tool id is only ever looked up inside the turn it belongs to.
@@ -110,20 +112,65 @@
 
   var GLYPH={completed:'✓',failed:'✗'};
 
+  // ---- tool calls, folded ------------------------------------------------
+  //
+  // A tool call is chatter, and it comes up folded: the line is a button, and
+  // the title is clamped to it until you ask for the rest (web/chat-panel
+  // draws all of that). Only tool calls — what the agent SAID is what the
+  // panel is for, and prose never folds.
+  //
+  // Which calls are open is the PAGE's, not localStorage's: unfolding one is a
+  // reading act, not a preference, so a reload comes back to a quiet panel.
+  // Keyed by the call's own id, which is what carries a fold through a
+  // REBUILD — a reconnect replays the whole conversation into an emptied body
+  // (web/chat's catch-up), so the line you were reading is a new element by
+  // the time you look back at it, under the same id. Same idea as collapse.js's
+  // afterSettle pass, at the one moment a chat line is drawn: there is no htmx
+  // swap to hook here, because the panel sits outside the region the outline's
+  // events re-swap and is never swapped itself.
+  var unfolded={};
+
+  // The one place a fold is written, and it has one spelling: the button's own
+  // ARIA state. What expands is the button's own label, so there is no region
+  // to name and no class to keep in step with it.
+  function setFold(el,open){
+    el.setAttribute('aria-expanded',open?'true':'false');
+  }
+
+  function toggleFold(el){
+    var id=el.getAttribute('data-tool-id');
+    if(unfolded[id])delete unfolded[id];else unfolded[id]=true;
+    setFold(el,!!unfolded[id]);
+  }
+
+  // The shape of a line, once. The triangle and the glyph are hidden from
+  // assistive tech, which leaves the button's name as the title — what the
+  // line IS.
+  function makeToolLine(id){
+    var el=make('button','ol-chat-tool');
+    el.type='button';
+    el.setAttribute('data-tool-id',id);
+    el.appendChild(quiet(make('span','ol-chat-tool-fold','▸')));
+    el.appendChild(quiet(make('span','ol-chat-tool-glyph')));
+    el.appendChild(make('span','ol-chat-tool-title'));
+    // folded, unless this same call was open before the body was rebuilt
+    setFold(el,!!unfolded[id]);
+    return el;
+  }
+
+  // One line per tool call, updated in place by id — same id, same line.
   function toolLine(id,title,status){
     var sel='[data-tool-id="'+(window.CSS&&CSS.escape?CSS.escape(id):id)+'"]';
     var el=turn?turn.querySelector(sel):null;
-    if(!el){
-      el=line('ol-chat-tool');
-      el.setAttribute('data-tool-id',id);
-      el.appendChild(line('ol-chat-tool-glyph'));
-      el.appendChild(line('ol-chat-tool-title'));
-      append(el);
-    }
+    if(!el)append(el=makeToolLine(id));
     el.setAttribute('data-status',status);
     el.querySelector('.ol-chat-tool-glyph').textContent=GLYPH[status]||'⚙';
     el.querySelector('.ol-chat-tool-title').textContent=title;
   }
+
+  // Decoration, to a screen reader: a mark and a triangle that say what the
+  // words beside them already say.
+  function quiet(el){el.setAttribute('aria-hidden','true');return el}
 
   // ---- slash commands ----------------------------------------------------
   //
@@ -439,6 +486,14 @@
         return;
       }
       post(t.getAttribute('data-post'));
+    });
+
+    // The transcript's one control of its own, and its own listener for it:
+    // the handler above is the chrome's, and threading a fold through it would
+    // buy an ordering invariant kept in prose. collapse.js is the same shape.
+    document.addEventListener('click',function(e){
+      var tool=e.target.closest('.ol-chat-tool');
+      if(tool)toggleFold(tool);
     });
 
     form.addEventListener('submit',function(e){


### PR DESCRIPTION
Roadmap item **tool-output folding**: ACP tool-call frames collapse by default in the chat panel; a toggle unfolds any of them.

A turn that ran a dozen tools buried what the agent said under a dozen wrapped paragraphs of chatter. Now every tool call is exactly one line.

## What folds

Tool-call lines, and only those. The line **is** the button: a `▸` disclosure triangle (the outline's, `render.rkt`'s `.ol-toggle`), the status glyph, and the title clamped to the line with an ellipsis. Unfolded, the title is the whole of it, wrapped, spelled the way the agent spelled it.

A tool frame carries `id`, `title`, `status` and nothing else (`web/chat`), so the title is what there is to unfold — which is why the button's own label is what its `aria-expanded` is about, and there is no manufactured detail region to name. The day a frame carries real output, the seam is the same line.

## What never folds

Agent prose. Also untouched: the user's bubble, error lines, separators, the `stopReason` note — each is one short line with nothing behind it, and a "chatter frames fold" abstraction would have exactly one member with a payload.

## How unfold state survives updates

The fold has **one** spelling in the DOM: `aria-expanded` on the button. Which calls are open is a page-lifetime map in `chat.js`, keyed by the call's own id, and it is applied at the one moment a line is drawn.

That covers every way the panel moves under a reader:

- another frame for the same call — the line is updated in place by id, the fold is not touched;
- another turn arriving — a new element, the old one untouched;
- the transcript being **rebuilt** — a reconnect replays the whole conversation into an emptied body (`chat-catch-up`), and a line comes back open under the same id. Same idea as `collapse.js`'s `afterSettle` re-apply; there is no htmx swap to hook, because the panel sits outside the region the outline's events re-swap;
- the outline's live re-swap beneath the panel — nothing to do, and now covered by a scenario.

Page-lifetime rather than `localStorage`: unfolding a line is a reading act, not a preference, so a reload comes back to a quiet panel. (The outline's collapse persists because a fold there is how you keep your outline.)

## Accessibility

Real `<button type=button>` with `aria-expanded`. The triangle and the status glyph are `aria-hidden`, which leaves the button's accessible name as the title — what the line is. `prefers-reduced-motion` drops the rotation's transition.

## Not touched

`olai/acp.rkt`, the frame vocabulary, `live/`, `Roadmap.rkt`, `docs/brainstorming/`. No new dependencies. CSS is css-expr in the module that draws it (`web/chat-panel.rkt`); one new class, `ol-chat-tool-fold`.

## Tests

`chat.feature` gains four scenarios: a call arrives folded and unfolds; a title too long for its line is cut off until unfolded (asserted as geometry — `scrollWidth > clientWidth`, and the line growing); the agent's words have nothing to unfold; an unfolded call survives an outline re-swap and a second turn. The fake agent grows a `LONGTOOL` prompt (its existing keyword idiom) so a scenario can watch the clamp actually clamp.

`just test` 298 passed · `just test-integration` 114 passed · `just e2e` 58 scenarios passed.

## Known boundary

`mobile.feature`'s "every chat control is at least 44 pixels tall" measures `#ol-chat button`, and a tool line is now one. No phone scenario renders a transcript, so it stays green — but a 44px minimum on folded chatter would make it taller than the prose it is hiding from, so sheet mode deliberately does not claim it. Whoever writes the first phone scenario with a turn in it gets to make that call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)