### PR TITLE
web: a note is one line until you point at it

### DIFF
--- a/e2e/features/note.feature
+++ b/e2e/features/note.feature
@@ -1,0 +1,53 @@
+Feature: a note folded to one line
+
+  A node's note is drawn one line tall, ellipsized, with the whole of it still
+  in the page: pointing at the node opens it, and pointing away folds it back.
+  The fold is a box, not a shorter string, so nothing a reader could search for
+  is missing while it is folded.
+
+  A note that already fits on one line has nothing to open, and shows nothing
+  saying it has.
+
+  Scenario: a long note is one line until you point at the node
+    When I open the home page
+    Then the note under "Ship the server" is folded to one line
+    And the note under "Ship the server" still says "only the first is on it"
+    When I point at "Ship the server"
+    Then the note under "Ship the server" shows all of it
+    When I point away
+    Then the note under "Ship the server" is folded to one line
+
+  # A node opens its OWN note. Were it the whole subtree's, pointing at a leaf
+  # would open every note above it at once — the page moving under the cursor
+  # to say something about nodes it is nowhere near.
+  Scenario: pointing at a child does not open its parent's note
+    When I open the home page
+    And I point at "Write the tests"
+    Then the note under "Ship the server" is folded to one line
+
+  Scenario: a note that fits on one line has nothing to open
+    When I open the home page
+    Then the note under "Inbox" shows all of it
+    And the note under "Inbox" is one line tall
+
+  # The note is focusable, so a tap is what opens it where there is no pointer
+  # to hover with. The pointer is taken off the note afterwards: on a desktop
+  # browser the click hovers it too, and hover is the mechanism this scenario
+  # is not about.
+  @phone
+  Scenario: a tap opens the note where there is no hover
+    When I open the home page
+    Then the note under "Ship the server" is folded to one line
+    When I tap the note under "Ship the server"
+    And I point away
+    Then the note under "Ship the server" shows all of it
+
+  Scenario: an open note is still open after the live view re-swaps it
+    When I open the home page
+    And I tap the note under "Ship the server"
+    And I point away
+    And I mark this page load
+    And I add the title "Feed the cat" to the outline
+    Then I see the title "Feed the cat"
+    And the page has not reloaded
+    And the note under "Ship the server" shows all of it

--- a/e2e/fixtures/Tasks.rkt
+++ b/e2e/fixtures/Tasks.rkt
@@ -6,6 +6,9 @@ Inbox #capture
     @date 2026-01-15
   [x] Ship the pitch
 Ship the server ^serve
+  : A fold is only real in a browser, so the note that proves it has to be
+  : long enough to wrap several times over on a desktop screen and on a phone
+  : alike. Every line of it is in the page; only the first is on it.
   @doc notes/serve.md
   Write the tests
 This week

--- a/e2e/steps/note_steps.js
+++ b/e2e/steps/note_steps.js
@@ -1,0 +1,97 @@
+// The note's fold: how tall the box is, and whether anything is being cut off
+// by it.
+//
+// Both questions are asked of the ELEMENT rather than of a class, because
+// there is no class to ask — the fold is CSS over a hover and a focus
+// (web/node), and nothing writes any state down. So "folded" is the box being
+// shorter than what is in it, and "open" is it no longer being so.
+//
+// A note is addressed through the node it belongs to, like every other part of
+// a node in this suite.
+
+import assert from "node:assert/strict";
+import { Then, When } from "@cucumber/cucumber";
+
+// The note of a node's OWN row: a descendant's is another node's.
+function note(world, title) {
+  return world.node(title).first().locator(":scope > .ol-row .ol-note").first();
+}
+
+/** How the box and its contents measure up, in one round trip: whether the
+ *  box is cutting anything off, and how many lines tall it is. The line count
+ *  is a ratio and not a pixel count — the note's own line-height is what a
+ *  line IS, and a rounded font metric would make an assertion about type
+ *  sizes out of an assertion about a fold. */
+async function measure(el) {
+  await el.waitFor();
+  return await el.evaluate((n) => {
+    const lineHeight = parseFloat(getComputedStyle(n).lineHeight);
+    return {
+      clipped: n.scrollHeight > n.clientHeight + 1,
+      lines: n.clientHeight / lineHeight,
+      text: n.textContent,
+    };
+  });
+}
+
+// One line tall AND cutting something off: a box that is one line tall
+// because that is all there is would pass half of this and mean the opposite.
+// The line count is generous on purpose — a note's first block carries a
+// margin, so one line of text is a little more than one line-height of box,
+// and two lines are a great deal more than this.
+Then("the note under {string} is folded to one line", async function (title) {
+  const m = await measure(note(this, title));
+  assert.ok(m.clipped, `${title}: the note is showing everything it has`);
+  assert.ok(
+    m.lines < 1.75,
+    `${title}: the note is ${m.lines.toFixed(2)} lines tall, not one`,
+  );
+});
+
+Then("the note under {string} is one line tall", async function (title) {
+  const m = await measure(note(this, title));
+  assert.ok(
+    m.lines < 1.75,
+    `${title}: the note is ${m.lines.toFixed(2)} lines tall, not one`,
+  );
+});
+
+// Nothing cut off. For the note that is already one line this is the whole
+// assertion: there is no ellipsis, because there is nothing to ellipsize.
+Then("the note under {string} shows all of it", async function (title) {
+  const m = await measure(note(this, title));
+  assert.ok(!m.clipped, `${title}: the note is still cutting itself off`);
+});
+
+// The point of a fold that is a BOX: folded or not, the text is in the page,
+// so find-in-page finds it and a morph has it to compare against.
+Then("the note under {string} still says {string}", async function (title, text) {
+  const m = await measure(note(this, title));
+  assert.ok(m.clipped, `${title}: the note is not folded, so this proves nothing`);
+  assert.ok(
+    m.text.includes(text),
+    `${title}: the folded note has lost "${text}"`,
+  );
+});
+
+// ---- the two ways to open one ----------------------------------------------
+
+// The pointer goes on the node's own TITLE: anywhere in the node opens it, and
+// the title is the part of it every node has.
+When("I point at {string}", async function (title) {
+  await this.node(title)
+    .first()
+    .locator(":scope > .ol-row .ol-title")
+    .first()
+    .hover();
+});
+
+// Off every node, without leaving the page: the top-left corner is the
+// sidebar's, which has no notes in it.
+When("I point away", async function () {
+  await this.page.mouse.move(0, 0);
+});
+
+When("I tap the note under {string}", async function (title) {
+  await note(this, title).click();
+});

--- a/e2e/support/outline.js
+++ b/e2e/support/outline.js
@@ -12,6 +12,14 @@
 // it is distinct enough that a step can name a node by a SUBSTRING of its
 // title and mean one node.
 //
+// Two of its notes are the sizes features/note.feature is about, and their
+// LENGTH is what makes them: "Ship the server" carries one long enough to wrap
+// several times at either viewport (so there is something to fold, and its
+// note-less child is a place to point at that must not open it), and "Inbox"
+// carries one that fits on a line at both (so there is nothing to fold at
+// all). "Write the tests" stays note-less for a second reason — two scenarios
+// delete that line, and a note under it would be orphaned by the same edit.
+//
 // EVERY edit a step makes to it changes the file's SIZE. The store's staleness
 // probe is mtime (whole seconds) + size, so a same-second same-size rewrite is
 // invisible to a running server — the same discipline

--- a/olai/tests/style.rkt
+++ b/olai/tests/style.rkt
@@ -401,6 +401,24 @@
                                box)
                 "the home-bar inset is padded for even where a keyboard covers it"))
 
+  ;; A note is FOLDED to one line by a box that is one line tall, never by a
+  ;; shorter string: the whole note is in the markup, and find-in-page and the
+  ;; morph both see it. What opens it is the other half — the node the pointer
+  ;; is in (and not its ancestors, which is what the :not(:has()) is for), and
+  ;; the note's own focus, which is the door a touch screen has instead of a
+  ;; hover. Behaviour is e2e/features/note.feature's; this is the rule staying
+  ;; the shape those journeys are about.
+  (test-case "a note is one line until the node is pointed at, or it has focus"
+    (define note (fragment->css (cdr (list-ref ordered-fragments (at "ol-note")))))
+    (check-true (regexp-match? #px"-webkit-line-clamp\\s*:\\s*1" note)
+                "the note is not clamped to its first line any more")
+    (check-false (regexp-match? #px"max-height|text-overflow" note)
+                 "the note is folded by something other than the line clamp")
+    (check-true (regexp-match? #px"\\.ol-node:hover:not\\(:has\\(\\.ol-node:hover\\)\\)" note)
+                "pointing into a subtree opens every ancestor's note too")
+    (check-true (regexp-match? #px"\\.ol-note:focus-within" note)
+                "the note does not open on focus: a touch screen has no other door"))
+
   ;; Sheet mode: below phone-max there is no room beside the outline, so the
   ;; panel covers it instead. That is ONE decision, and this is the test that
   ;; it stays one — every phone-width rule about the panel is in that block,

--- a/olai/web/node.rkt
+++ b/olai/web/node.rkt
@@ -226,11 +226,51 @@
 
 (define-style ol-dim #:color ,dim)
 
+;; THE NOTE, folded to one line.
+;;
+;; Folded is what a note is drawn as, and the fold is a BOX one line tall —
+;; never a shorter string. The whole note is in the markup either way, so
+;; find-in-page still finds the rest of it and a live re-swap morphs the same
+;; text it always did. A note that IS one line overflows nothing, and so gets
+;; no ellipsis and has nothing to open: the overflow is the affordance, and
+;; only an overflow draws one.
+;;
+;; It opens while the pointer is in the NODE — its own row, and the gutter
+;; beside its children — rather than only while it is on the row. Opening
+;; pushes the page down under the cursor, and a note that folded again the
+;; moment the pointer wobbled off the line it had just moved would do that
+;; twice. A node UNDER this one opens its own note instead of its ancestors',
+;; which is what the :not(:has()) says.
+;;
+;; And it opens on focus, which is the tap: a touch screen has no pointer to
+;; hover with, so the note is a focusable region (the tabindex the markup
+;; below puts on it) — a tap opens it, a tap elsewhere closes it, and a
+;; keyboard gets the same door for free. No script: a class a script toggled
+;; would be view state to put back after every morph, and this is state the
+;; browser is already keeping.
+;;
+;; The @doc lead (web/document) wears the same one-line look and is not the
+;; same mechanism — that one is one line because the rest of the document is a
+;; page away, and it does not open at all.
 (define-style ol-note
   #:margin-top 0.125rem
   #:color ,dim
   #:font-size 0.875rem
+  ;; folded: the first rendered line, and the ellipsis that says there is more
+  #:display -webkit-box
+  #:-webkit-box-orient vertical
+  #:-webkit-line-clamp 1
+  #:overflow hidden
   [,(sel '& is-done) #:opacity 0.65 #:text-decoration line-through]
+  ;; open: the pointer is in this node and in no node under it, or the note
+  ;; itself has the focus
+  [(> (: (: ,(sel ol-node) hover)
+         (apply not (: (apply has (: ,(sel ol-node) hover)))))
+      (,(sel ol-row) &))
+   (: & focus-within)
+   #:display block
+   #:-webkit-line-clamp none
+   #:overflow visible]
   ;; Markdown blocks inside a note: tightened, never the browser's defaults
   [(& p) #:margin (0.25rem 0)]
   [(& ul) (& ol) #:margin (0.25rem 0) #:padding-left 1.25rem]
@@ -366,7 +406,10 @@
                           (list (date-pill-xexpr (task-date tk) today done?))
                           '()))
                ,@(if (task-description tk)
-                     (list `(div ((class ,(classes ol-note (and done? is-done))))
+                     ;; folded to one line, and focusable so a touch screen
+                     ;; has a way to open it (the styles above say why)
+                     (list `(div ((class ,(classes ol-note (and done? is-done)))
+                                  (tabindex "0"))
                                  ,@(note->xexprs (task-description tk))))
                      '())))
    #:after-row (doc-block tk docs doc-expanded? zoom-base)


### PR DESCRIPTION
A node's note now draws one line tall, ellipsized, and opens when you point at
the node — or when the note has focus, which is the door a touch screen gets
instead of a hover. Roadmap's *notes fold to one line*.

## What it is

CSS, and nothing else. `.ol-note` is a `-webkit-box` clamped to one line; the
rule that opens it is

    .ol-node:hover:not(:has(.ol-node:hover)) > .ol-row .ol-note,
    .ol-note:focus-within

plus a `tabindex` on the note so there is something to focus. Decisions worth
naming:

* **The fold is a box, not a shorter string.** The whole note is in the markup
  either way, so find-in-page still finds the rest of it and a live re-swap
  morphs the same text it always did.
* **A note that IS one line gets nothing** — no ellipsis, nothing to open. The
  overflow is the affordance, and only an overflow draws one. Nothing had to
  measure anything to decide that.
* **It opens for the node the pointer is in, not for its ancestors.** That is
  the `:not(:has())`: without it, pointing at a leaf opens every note above it
  at once and the page moves under the cursor to say something about nodes it
  is nowhere near. Pointing anywhere in the node — its row, the gutter beside
  its children — keeps it open, which is the grace a note that folded the
  moment the pointer wobbled off the line would not have.
* **No script.** A class a script toggled would be view state to put back after
  every morph; hover and focus are state the browser already keeps, so the
  re-swap scenario passes for free.

The `@doc` lead one block down wears the same one-line look and stays a
separate mechanism — that one is one line because the rest of the document is a
page away, and it does not open at all.

## Tests

`e2e/features/note.feature` — folded/hover/away, a child that must not open its
parent's note, the one-line note with nothing to open, a tap at phone viewport
(pointer taken off afterwards, so hover cannot be what passed it), and an open
note surviving a live re-swap. The fixture's `Ship the server` grew the long
note those need; `Write the tests` stays note-less because two other scenarios
delete that line.

`olai/tests/style.rkt` gets one case holding the rule to that shape.

`just test` (340) and `just e2e` (68 scenarios) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)