### PR TITLE
arch: the layering stops being prose and becomes a checker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,13 +19,14 @@ Read [README.md](README.md) and `docs/*.md` first (especially [docs/hacking.md](
 
 ## LAYERING
 
+* Layering is DECLARED, not described: one `arch.rkt` per package (clock, owned authority, owned concepts), checked by `just arch` — dependency direction, ambient authority, one owner per concept, and the clocks against `git log`. Read [arch/README.md](arch/README.md) before adding a module, moving one, or arguing with a finding; the answers are fix the code or change the declaration, and there are no waivers. The rules that used to be prose here — core builds without `web/`, `acp.rkt` has no `web/`, store/watch/hub meet only in `serve.rkt`, pure logic takes `today` as an argument, keys are minted in the load layer, nothing else spells ACP or the conversation — are those checks now.
 * `lang/` readers -> `lang/expander` (`t` forms, closed grammar) -> task struct
-* `main.rkt` exports data model + pure queries + web render. CLI is app code, not library. Pure logic takes `today` as an argument (testable, no clocks).
+* `main.rkt` exports data model + pure queries + web render. CLI is app code, not library.
 * Writes live in `ops.rkt` (`add`/`done`/`move`/`daily` -> result struct, or an `exn:fail:op` naming a kind). `cli.rkt` is a shell: parse, call an op, render, map kind -> exit code. The web mutation routes will call the same ops.
-* Node keys are minted in the load layer, not the expander (see [docs/cli.md](docs/cli.md)); `store.rkt` owns snapshots and binds mirror sites before anything draws them. `index.rkt` inverts the keys (key -> node + its parent's key) and derives the trail above a node on demand — what `/n/<key>` and its breadcrumbs are drawn from. Addressing is not snapshotting: the store builds one index per load and asks it nothing.
-* Live view: store (what) -> `web/watch.rkt` (when) -> `web/events.rkt` (generic SSE hub); they meet only in `serve.rkt`, and the chat rides the same hub.
-* `olai/acp.rkt` speaks ACP: one subprocess, typed events out of one handler, no `web/`. `web/chat.rkt` makes those events a conversation — one turn at a time, chat frames, transcript. Nothing else spells either.
-* Core must build without `web/`: file naming is `olai/paths` (`file-label`, `key-label`), not a renderer helper.
+* `store.rkt` owns snapshots and binds mirror sites before anything draws them (see [docs/cli.md](docs/cli.md) for what a key is). `index.rkt` inverts the keys (key -> node + its parent's key) and derives the trail above a node on demand — what `/n/<key>` and its breadcrumbs are drawn from. Addressing is not snapshotting: the store builds one index per load and asks it nothing.
+* Live view: store (what) -> `web/watch.rkt` (when) -> `live/hub.rkt` (generic SSE hub), and the chat rides the same hub.
+* `olai/acp.rkt` speaks ACP: one subprocess, typed events out of one handler. `web/chat.rkt` makes those events a conversation — one turn at a time, chat frames, transcript.
+* File naming is `olai/paths` (`file-label`, `key-label`), not a renderer helper.
 * JSON is two modules, two version counters: `json/model` (what a node/tree IS, durable) and `json/reply` (command envelopes, agenda, calendar).
 * CSS cascade = layer (`'base` | `'component` | `'overlay`) then instantiation order; a class is defined in the module that DRAWS it. No native `@layer`.
 * `web/skin.rkt` composes the sheet (require order = cascade) and owns its URL; `render-page` is TOLD the href, so nothing downstream requires skin.

--- a/arch/README.md
+++ b/arch/README.md
@@ -1,0 +1,158 @@
+# arch
+
+Architecture as data. One `arch.rkt` per package says how fast the code under
+it moves, what ambient authority it may reach for, and which concepts it owns;
+`just arch` holds the tree to it.
+
+The alternative is what this repo had: layering as sentences in CLAUDE.md.
+Break one and the build stays green — an agent finds out in review, or never.
+
+```
+$ just arch
+arch: 115 modules in 9 declared packages — the tree agrees with itself
+```
+
+## The grammar
+
+```racket
+#lang arch
+(clock settling)                                 ; how fast this moves
+(owns)                                           ; no ambient authority
+(concept file-naming "file-label" "key-label")   ; names only this package spells
+(override "store.rkt" (owns filesystem))         ; how one module differs
+(override "cli.rkt"   (clock volatile) (owns (clock "today-iso-string")))
+```
+
+Four forms, and nothing else is an arch form.
+
+* **`(clock stable | settling | volatile)`** — required, once. Least volatile
+  first, and the order is the rank: a dependency may point at the same rank or
+  a lower one, never higher.
+* **`(owns authority ...)`** — the ambient authority this scope may reach for.
+  The set is closed: `clock`, `filesystem`, `filesystem-events`, `network`,
+  `subprocess`, `threads`, `randomness`. A new one is a roadmap proposal, not
+  an edit to [vocabulary.rkt](vocabulary.rkt).
+* **`(concept name "pattern" ...)`** — export names that belong to this scope
+  and to nothing else. `*` is the only wildcard.
+* **`(override "file.rkt" clause ...)`** — how one module differs. The clock
+  **replaces**; `owns` and `concept` **add**. The file has to exist, checked
+  when the declaration compiles.
+
+An authority can be handed on under another name — `(owns (clock
+"today-iso-string"))` on the module that exports it — so a caller of
+`today-iso-string` is reading the clock as surely as one calling `(today)`.
+Spellings go on an `override`, because they are a claim about one module's
+exports.
+
+## The checks
+
+| # | rule | what it replaced |
+|---|---|---|
+| 1 | dependencies point volatile → stable, never back | "core must build without web/", "acp has no web/", "store/watch/hub meet only in serve" |
+| 2 | an authority is used only where it is owned | "pure logic takes `today` as an argument (testable, no clocks)" |
+| 3 | one owner per tagged concept | "keys are minted in the load layer", "nothing else spells either" |
+| 4 | the declarations agree with `git log` | nothing — this one is new |
+
+Two smaller checks ride along, each auditing a declaration rather than the
+code: a spelling has to be a name its module really exports, and a concept has
+to have exactly one claimant. Without them the check they serve would quietly
+apply to nobody.
+
+A finding says where, then the rule, then the facts, then what to do:
+
+```
+olai/lang/expander.rkt:32:21: requires olai/dates.rkt: dependency points the wrong way
+  olai/lang/expander.rkt is declared stable (olai/lang/arch.rkt:10)
+  olai/dates.rkt is declared settling (olai/arch.rkt:6)
+  stable code must not depend on settling code — invert the edge, or move the code that reaches across
+```
+
+Longer than you would write for a human, on purpose. The reader is usually an
+agent, verbosity measurably raises its odds of fixing the right thing, and
+nobody reads any of it when the check passes.
+
+### No waivers
+
+There is no way for a module to exempt itself. The only two answers to a
+finding are **fix the code** or **change the declaration**, and both are lines
+in a diff somebody reviews.
+
+The one thing that is not checked is a module with no `arch.rkt` above it —
+that hole can only be opened by moving a module out of a declared package or
+deleting a declaration, which are also lines in a diff. It is what keeps a
+`.plt-user` full of somebody else's Racket from being architecture.
+
+### The churn audit
+
+Check 4 reads `git log -n30 --name-only` and compares it with the clocks:
+`stable` allows a file to change in up to a fifth of the window, `settling` up
+to a half, `volatile` has no ceiling. Only the tight end is checked — a module
+that declares itself volatile and never changes misleads nobody.
+
+With no history to read (no git, a shallow checkout, a build sandbox) the audit
+says so in the report and the other three checks run. That is not a waiver; it
+is the rule having nothing to apply to.
+
+## Seeing what it thinks
+
+```
+$ just arch --explain olai/web/watch.rkt
+olai/web/watch.rkt
+  governed by  olai/web/arch.rkt
+  clock        volatile           olai/web/arch.rkt:10 (package default)
+  owns         clock              olai/web/arch.rkt:19 (override "watch.rkt")
+               filesystem-events  olai/web/arch.rkt:19 (override "watch.rkt")
+               threads            olai/web/arch.rkt:19 (override "watch.rkt")
+  concepts     outline-watching "start-watcher" "seconds-until-midnight" olai/web/arch.rkt:20
+  churn        0 of the last 30 commits — volatile has no ceiling
+  requires     olai/store.rkt (settling)
+```
+
+A composition a reader cannot see through is one they argue with from memory,
+so this is interface and not a debug aid — the same reason `just expand` prints
+what a live form becomes.
+
+## How it works, and what it costs
+
+The checker asks three different things three different questions, and each
+answer is one module's business:
+
+* [source.rkt](source.rkt) reads the source — never expands it. Requires,
+  definitions, and every identifier the module *calls*, each with a srcloc.
+* [facts.rkt](facts.rkt) asks the compiled modules what they export and what
+  names reach them. `(dynamic-require path #f)` declares a module without
+  instantiating it, so nothing anybody wrote is ever run.
+* [churn.rkt](churn.rkt) shells out to git.
+
+With `.zo` on disk the whole tree is about two seconds, which is why `just
+arch` lives in the edit loop beside `just check` rather than only in CI.
+
+What reading rather than expanding costs, stated so nobody has to discover it:
+
+* A dependency introduced only by a macro is invisible. What a module *says* it
+  depends on is what an architecture check is about, and it is what a reader
+  sees too.
+* An authority is counted when its name is in operator position — `(today)`,
+  `(file-exists? p)`, `[current-directory d]` — or right after `apply`. Handing
+  one somewhere as a value (`(map file-exists? ps)`) is missed. The alternative
+  is a scope analysis, which is an expander, which is the cost being avoided.
+  This is also what keeps the rule from punishing the code that obeys it:
+  `(define (agenda-groups tasks today) ...)` takes the day as an argument,
+  which is the whole point, and must not read as a clock.
+* `only-in` narrows what a require brings in and this does not model it, so a
+  module that mentions a name it did not quite import is asked to declare an
+  authority it does not quite use. The error is on the side of declaring, which
+  is the side a reader can check.
+
+## Why it is its own package
+
+`live/` imports nothing from olai and never will. Its declaration is a `#lang
+arch` module, so the language cannot live inside `olai` without inverting that
+— and a package cycle is not a thing raco will build. So `arch` is a collection
+of its own, under both, depending on nothing but `base`.
+
+That is also why it is packaged for Nix rather than being a dev-time script:
+`live/arch.rkt` and `olai/**/arch.rkt` are modules, and any build that installs
+those collections has to be able to compile them. Shipping the checker with
+them is the price of the declarations living beside the code they are about,
+which is the whole point.

--- a/arch/README.md
+++ b/arch/README.md
@@ -9,7 +9,7 @@ Break one and the build stays green — an agent finds out in review, or never.
 
 ```
 $ just arch
-arch: 115 modules in 9 declared packages — the tree agrees with itself
+arch: 120 modules in 10 declared packages — the tree agrees with itself
 ```
 
 ## The grammar
@@ -124,6 +124,12 @@ answer is one module's business:
   instantiating it, so nothing anybody wrote is ever run.
 * [churn.rkt](churn.rkt) shells out to git.
 
+One more module has no business in any of the three: [wording.rkt](wording.rkt)
+says a list of words and guesses at a misspelling, and it is split from
+[vocabulary.rkt](vocabulary.rkt) because the ratified words change when a human
+ratifies one and the phrasing changes whenever somebody watches an agent
+misread a message.
+
 With `.zo` on disk the whole tree is about two seconds, which is why `just
 arch` lives in the edit loop beside `just check` rather than only in CI.
 
@@ -133,12 +139,14 @@ What reading rather than expanding costs, stated so nobody has to discover it:
   depends on is what an architecture check is about, and it is what a reader
   sees too.
 * An authority is counted when its name is in operator position — `(today)`,
-  `(file-exists? p)`, `[current-directory d]` — or right after `apply`. Handing
-  one somewhere as a value (`(map file-exists? ps)`) is missed. The alternative
-  is a scope analysis, which is an expander, which is the cost being avoided.
-  This is also what keeps the rule from punishing the code that obeys it:
-  `(define (agenda-groups tasks today) ...)` takes the day as an argument,
-  which is the whole point, and must not read as a clock.
+  `(file-exists? p)`, `[current-directory d]` — or right after `apply`. Binding
+  positions do not count, so `(for ([today days]) …)` and `(λ (now) …)` are the
+  code taking the thing as an argument, which is what the rule is FOR. The
+  binding forms are a short closed list in [source.rkt](source.rkt); a form
+  nobody listed is walked as ordinary code, which over-reports rather than
+  under-reports. Handing a spelling somewhere as a value (`(map file-exists?
+  ps)`) is missed — the alternative is a scope analysis, which is an expander,
+  which is the cost being avoided.
 * `only-in` narrows what a require brings in and this does not model it, so a
   module that mentions a name it did not quite import is asked to declare an
   authority it does not quite use. The error is on the side of declaring, which

--- a/arch/arch.rkt
+++ b/arch/arch.rkt
@@ -18,5 +18,6 @@
 
 ;; One walker over the anchor rules is the pattern this whole tool is about, so
 ;; it holds for the tool: the four checks live in one module and nowhere else.
-(override "vocabulary.rkt" (concept arch-vocabulary "authorit*" "clock-rank" "clock-churn-ceiling"))
+(override "vocabulary.rkt" (concept arch-vocabulary "authorit*" "clock-rank" "clock-allows"))
+(override "wording.rkt" (concept arch-wording "word-list" "did-you-mean"))
 (override "finding.rkt" (concept arch-finding "finding*"))

--- a/arch/arch.rkt
+++ b/arch/arch.rkt
@@ -1,0 +1,22 @@
+#lang arch
+
+;; The checker's own architecture. It reads the tree, so it is at the bottom of
+;; it: nothing here may depend on olai or live, and the grammar is the part
+;; that has to hold still.
+(clock stable)
+(owns)
+
+;; The three modules that touch the world, and each of them exists to keep the
+;; rest from having to: git's output format, the reader's, the module system's.
+(override "churn.rkt" (owns subprocess))
+(override "source.rkt" (owns filesystem))
+(override "scope.rkt" (owns filesystem))
+(override "explain.rkt" (owns filesystem))
+(override "main.rkt" (clock settling) (owns filesystem))
+(override "check.rkt" (clock settling))
+(override "expander.rkt" (owns filesystem))
+
+;; One walker over the anchor rules is the pattern this whole tool is about, so
+;; it holds for the tool: the four checks live in one module and nowhere else.
+(override "vocabulary.rkt" (concept arch-vocabulary "authorit*" "clock-rank" "clock-churn-ceiling"))
+(override "finding.rkt" (concept arch-finding "finding*"))

--- a/arch/arch.rkt
+++ b/arch/arch.rkt
@@ -17,7 +17,14 @@
 (override "expander.rkt" (owns filesystem))
 
 ;; One walker over the anchor rules is the pattern this whole tool is about, so
-;; it holds for the tool: the four checks live in one module and nowhere else.
-(override "vocabulary.rkt" (concept arch-vocabulary "authorit*" "clock-rank" "clock-allows"))
+;; it holds for the tool.
+;;
+;; The clock words are enumerated rather than globbed because `live/examples/
+;; counters/clock.rkt` exports `clock` and `clock-now` — a stream named after
+;; what it ticks, in a package that has nothing to do with this one. That is a
+;; real collision between two honest names, and the narrow list is what a
+;; declaration says when the code is right and the words merely coincide.
+(override "vocabulary.rkt"
+          (concept arch-vocabulary "authorit*" "clocks" "clock?" "clock-rank" "clock-allows"))
 (override "wording.rkt" (concept arch-wording "word-list" "did-you-mean"))
-(override "finding.rkt" (concept arch-finding "finding*"))
+(override "finding.rkt" (concept arch-finding "finding*" "make-labeller" "loc-brief"))

--- a/arch/check.rkt
+++ b/arch/check.rkt
@@ -45,27 +45,34 @@
 ;; notes    : what the run could not do — today only "there was no history to
 ;;            audit". Printed, never silent: a check that quietly does not run
 ;;            is the failure mode this whole tool exists to remove.
-(struct report (scopes sites churn findings notes) #:transparent)
+(struct report (scopes sites findings notes) #:transparent)
 
-;; One governed module, with everything anybody needs to say about it.
-(struct site (path source decl) #:transparent)
+;; One governed module, with everything anybody needs to say about it — read
+;; once, declared once, asked once. `defines` is what it exports AND defines,
+;; which three of the four checks want; deriving it per check was the same list
+;; built three times.
+(struct site (path source defines decl) #:transparent)
 
 (define (audit root #:window [window default-churn-window])
-  (define scopes (find-scopes root))
-  (define sites (sites-of scopes))
-  ;; Every module is read, declared and looked up exactly once. A dependency is
-  ;; a path, and check 1 asks about ~500 of them — deriving the far end's
-  ;; effective declaration again at each edge would be the same value computed
-  ;; a second way, which is the bug this tool is named after.
+  (define-values (scopes governed) (survey root))
+  (define sites
+    (for/list ([entry (in-list governed)])
+      (define path (cdr entry))
+      (site path
+            (read-source path)
+            (sort (module-defines path) symbol<?)
+            (effective-for (car entry) path))))
+  ;; A dependency is a path, and check 1 asks about ~900 of them. Deriving the
+  ;; far end's effective declaration again at each edge would be the same value
+  ;; computed a second way, which is the bug this tool is named after.
   (define by-path (for/hash ([s (in-list sites)]) (values (site-path s) s)))
   (define history (read-churn root window))
   (define spellings (spelling-table sites))
-  (define owners (concept-owners scopes))
-  (define (label p) (path-label p root))
+  (define owners (concept-owners sites))
+  (define label (make-labeller root))
   (report scopes
           sites
-          history
-          (sort
+          (sort-findings
            (append
             (spelling-findings sites label)
             (claim-findings owners label)
@@ -74,34 +81,22 @@
             (append* (for/list ([s (in-list sites)]) (check-concepts s owners label)))
             (if history
                 (append* (for/list ([s (in-list sites)]) (check-churn s history label)))
-                '()))
-           finding<?)
+                '())))
           (if history
               '()
               (list (string-append
                      "churn: no git history here, so no declaration was audited against it"
                      " — the other three checks ran")))))
 
-(define (sites-of scopes)
-  (append*
-   (for/list ([s (in-list scopes)])
-     (for/list ([m (in-list (scope-modules s scopes))])
-       (site m (read-source m) (declaration-for (scope-declaration s) (scope-relative s m)))))))
-
-(define (finding<? a b)
-  (define (key f)
-    (define loc (finding-loc f))
-    (list (format "~a" (and loc (srcloc-source loc)))
-          (or (and loc (srcloc-line loc)) 0)
-          (or (and loc (srcloc-column loc)) 0)))
-  (define ka (key a))
-  (define kb (key b))
-  (cond
-    [(string<? (car ka) (car kb)) #t]
-    [(string>? (car ka) (car kb)) #f]
-    [(< (cadr ka) (cadr kb)) #t]
-    [(> (cadr ka) (cadr kb)) #f]
-    [else (< (caddr ka) (caddr kb))]))
+;; File, then line, then column. `sort` is stable, so three passes in reverse
+;; key order say that in three lines and stay right when a fourth key is wanted.
+(define (sort-findings fs)
+  (define (part f get) (or (let ([loc (finding-loc f)]) (and loc (get loc))) 0))
+  (sort (sort (sort fs < #:key (λ (f) (part f srcloc-column)))
+              < #:key (λ (f) (part f srcloc-line)))
+        string<?
+        #:key (λ (f) (format "~a" (let ([loc (finding-loc f)]) (and loc (srcloc-source loc)))))
+        #:cache-keys? #t))
 
 ;; ---- 1: dependencies point volatile -> stable ----------------------------------
 
@@ -148,11 +143,10 @@
 (define (spelling-findings sites label)
   (append*
    (for/list ([s (in-list sites)])
-     (define defined (list->seteq (module-defines (site-path s))))
      (append*
       (for/list ([g (in-list (own-grants (site-decl s)))])
         (for/list ([name (in-list (grant-spellings g))]
-                   #:unless (set-member? defined (string->symbol name)))
+                   #:unless (memq (string->symbol name) (site-defines s)))
           (finding (grant-loc g)
                    (format "~a: not an export of ~a" name (label (site-path s)))
                    (list (format "an authority's spellings name what THIS module hands ~a on as"
@@ -174,14 +168,13 @@
   ;; import brought in. Both halves matter: the source says what it defines
   ;; under any name, and the module system says what a `struct` form defined
   ;; without anybody writing the name down.
-  (define defined
-    (set-union (list->seteq (hash-keys (source-definitions src)))
-               (list->seteq (module-defines (site-path s)))))
+  (define (bound-here? name)
+    (or (hash-has-key? (source-definitions src) name) (memq name (site-defines s))))
   (for*/list ([(name loc) (in-hash (source-mentions src))]
               [a (in-value (hash-ref spellings name #f))]
               #:when (and a
                           (set-member? visible name)
-                          (not (set-member? defined name))
+                          (not (bound-here? name))
                           (not (effective-owns? mine a))))
     (finding loc
              (format "~a: ambient authority `~a` is not owned here" name a)
@@ -218,26 +211,53 @@
 
 ;; ---- 3: one owner per concept -----------------------------------------------------
 
-;; A concept and where it is owned. `module` is #f when the whole package owns
-;; it, and one path when an override does.
-(struct owner (concept globs loc scope module) #:transparent)
+;; A concept, and the modules that may spell it.
+;;
+;; Read off `effective-claims`, exactly the way check 2 reads `effective-owns?`
+;; — so a package-level `(concept …)` reaches the modules that package governs
+;; and no further, which is what a package-level `(owns …)` already did.
+;; Deriving ownership from `scope-decl-modules` instead had made concepts the
+;; one thing in the tool that ignored nesting: `olai/arch.rkt` would own a
+;; concept inside `olai/web/`, where it owns no authority, and an override
+;; naming a module some deeper arch.rkt governs was dead for three checks and
+;; live for this one.
+;;
+;; sites : every module whose effective declaration carries this claim
+(struct owner (concept matchers loc sites) #:transparent)
 
-(define (concept-owners scopes)
-  (append*
-   (for/list ([s (in-list scopes)])
-     (append
-      (for/list ([c (in-list (scope-decl-claims (scope-declaration s)))])
-        (owner (claim-concept c) (claim-globs c) (claim-loc c) s #f))
-      (append*
-       (for/list ([m (in-list (scope-decl-modules (scope-declaration s)))])
-         (for/list ([c (in-list (module-decl-claims m))])
-           (owner (claim-concept c) (claim-globs c) (claim-loc c) s
-                  (simplify-path (build-path (scope-dir s) (module-decl-file m)))))))))))
+(define (concept-owners sites)
+  ;; One entry per DECLARATION, not per module: a package default is inherited
+  ;; by everything under it, and all of those are one claim wearing one srcloc.
+  (define by-loc (make-hash))
+  (for* ([s (in-list sites)] [c (in-list (effective-claims (site-decl s)))])
+    (hash-update! by-loc (claim-loc c)
+                  (λ (prev) (cons (car prev) (cons s (cdr prev))))
+                  (λ () (cons c '()))))
+  (for/list ([(loc entry) (in-hash by-loc)])
+    (define c (car entry))
+    (owner (claim-concept c) (map matcher (claim-globs c)) loc (reverse (cdr entry)))))
+
+;; A pattern and the regexp it is, compiled once when the claim is read rather
+;; than once per (export name x pattern) — which was twenty thousand identical
+;; compilations of thirty-one patterns.
+(struct matcher* (glob rx) #:transparent)
+
+;; `*` and nothing else. A concept names its exports the way a person would say
+;; them out loud — `mint-*`, `acp-*` — and anything richer would be a second
+;; pattern language for a reader to learn, in a file whose whole point is that
+;; it is read at a glance. The literal parts are quoted, so a `.` or a `?` in an
+;; export name is a character and not a metacharacter.
+(define (matcher glob)
+  (matcher* glob
+            (regexp (string-append "^"
+                                   (string-join (map regexp-quote (string-split glob "*" #:trim? #f))
+                                                ".*")
+                                   "$"))))
 
 (define (claim-findings owners label)
   (define seen (make-hasheq))
   (append*
-   (for/list ([o (in-list owners)])
+   (for/list ([o (in-list (sort owners string<? #:key (λ (o) (loc-brief (owner-loc o) label))))])
      (define prev (hash-ref seen (owner-concept o) #f))
      (hash-set! seen (owner-concept o) o)
      (if prev
@@ -249,44 +269,30 @@
 
 (define (check-concepts s owners label)
   (define src (site-source s))
-  (define here (site-path s))
-  (append*
-   (for/list ([name (in-list (module-defines here))])
-     (for*/list ([o (in-list owners)]
-                 [glob (in-value (matching-glob o name))]
-                 #:when (and glob (not (owned-by? o here))))
-       (finding (or (source-where src name) (srcloc here 1 0 1 0))
-                (format "~a: exports into concept `~a`" name (owner-concept o))
-                (list (format "that concept is owned by ~a (~a)"
-                              (owner-label o label) (loc-brief (owner-loc o) label))
-                      (format "the pattern it matched: \"~a\"" glob)
-                      "one owner per concept — require the name from the owner instead"))))))
+  (define mine (map claim-concept (effective-claims (site-decl s))))
+  (for*/list ([name (in-list (site-defines s))]
+              [o (in-list owners)]
+              #:unless (memq (owner-concept o) mine)
+              [hit (in-value (matching o name))]
+              #:when hit)
+    (finding (or (source-where src name) (srcloc (site-path s) 1 0 1 0))
+             (format "~a: exports into concept `~a`" name (owner-concept o))
+             (list (format "that concept is owned by ~a (~a)"
+                           (owner-label o label) (loc-brief (owner-loc o) label))
+                   (format "the pattern it matched: \"~a\"" (matcher*-glob hit))
+                   "one owner per concept — require the name from the owner instead"))))
 
-(define (matching-glob o name)
-  (for/first ([g (in-list (owner-globs o))] #:when (glob-matches? g name)) g))
+(define (matching o name)
+  (define s (symbol->string name))
+  (for/first ([m (in-list (owner-matchers o))] #:when (regexp-match? (matcher*-rx m) s)) m))
 
-;; `*` and nothing else. A concept names its exports the way a person would say
-;; them out loud — `mint-*`, `acp-*` — and anything richer would be a second
-;; pattern language for a reader to learn, in a file whose whole point is that
-;; it is read at a glance. The literal parts are quoted, so a `.` or a `?` in an
-;; export name is a character and not a metacharacter.
-(define (glob-matches? pattern name)
-  (define rx
-    (regexp (string-append "^"
-                           (string-join (map regexp-quote (string-split pattern "*" #:trim? #f))
-                                        ".*")
-                           "$")))
-  (regexp-match? rx (symbol->string name)))
-
-(define (owned-by? o path)
-  (if (owner-module o)
-      (equal? (owner-module o) path)
-      (scope-covers? (owner-scope o) path)))
-
+;; One module owns it, or a package does — which is exactly "how many modules
+;; carry this claim", so the message does not need a second field to say it.
 (define (owner-label o label)
-  (if (owner-module o)
-      (label (owner-module o))
-      (format "~a and everything under it" (label (scope-file (owner-scope o))))))
+  (define sites (owner-sites o))
+  (if (= 1 (length sites))
+      (label (site-path (car sites)))
+      (format "~a and everything under it" (label (srcloc-source (owner-loc o))))))
 
 ;; ---- 4: the declaration against the history ----------------------------------------
 

--- a/arch/check.rkt
+++ b/arch/check.rkt
@@ -25,7 +25,6 @@
 
 (require racket/contract
          racket/list
-         racket/path
          racket/set
          racket/string
          arch/churn
@@ -34,39 +33,43 @@
          arch/finding
          arch/scope
          arch/source
-         arch/vocabulary)
+         arch/vocabulary
+         arch/wording)
 
 (provide (struct-out report)
          (struct-out site)
          (contract-out
-          [audit (->* (path?) (#:window exact-positive-integer?) report?)]
-          [sites-of (-> (listof scope?) (listof site?))]))
+          [audit (->* (path?) (#:window exact-positive-integer?) report?)]))
 
 ;; findings : every violation, in file order
 ;; notes    : what the run could not do — today only "there was no history to
 ;;            audit". Printed, never silent: a check that quietly does not run
 ;;            is the failure mode this whole tool exists to remove.
-(struct report (root scopes sites churn findings notes) #:transparent)
+(struct report (scopes sites churn findings notes) #:transparent)
 
 ;; One governed module, with everything anybody needs to say about it.
 (struct site (path source decl) #:transparent)
 
-(define (audit root #:window [window 30])
+(define (audit root #:window [window default-churn-window])
   (define scopes (find-scopes root))
   (define sites (sites-of scopes))
+  ;; Every module is read, declared and looked up exactly once. A dependency is
+  ;; a path, and check 1 asks about ~500 of them — deriving the far end's
+  ;; effective declaration again at each edge would be the same value computed
+  ;; a second way, which is the bug this tool is named after.
+  (define by-path (for/hash ([s (in-list sites)]) (values (site-path s) s)))
   (define history (read-churn root window))
   (define spellings (spelling-table sites))
   (define owners (concept-owners scopes))
   (define (label p) (path-label p root))
-  (report root
-          scopes
+  (report scopes
           sites
           history
           (sort
            (append
             (spelling-findings sites label)
             (claim-findings owners label)
-            (append* (for/list ([s (in-list sites)]) (check-dependencies s scopes label)))
+            (append* (for/list ([s (in-list sites)]) (check-dependencies s by-path label)))
             (append* (for/list ([s (in-list sites)]) (check-authority s sites spellings label)))
             (append* (for/list ([s (in-list sites)]) (check-concepts s owners label)))
             (if history
@@ -102,12 +105,13 @@
 
 ;; ---- 1: dependencies point volatile -> stable ----------------------------------
 
-(define (check-dependencies s scopes label)
+(define (check-dependencies s by-path label)
   (define mine (site-decl s))
   (for*/list ([entry (in-list (source-requires (site-source s)))]
               [dep (in-value (car entry))]
               #:unless (equal? dep (site-path s))
-              [theirs (in-value (declaration-of scopes dep))]
+              [far (in-value (hash-ref by-path dep #f))]
+              [theirs (in-value (and far (site-decl far)))]
               #:when (and theirs
                           (> (clock-rank (effective-clock theirs))
                              (clock-rank (effective-clock mine)))))
@@ -261,38 +265,42 @@
 (define (matching-glob o name)
   (for/first ([g (in-list (owner-globs o))] #:when (glob-matches? g name)) g))
 
+;; `*` and nothing else. A concept names its exports the way a person would say
+;; them out loud — `mint-*`, `acp-*` — and anything richer would be a second
+;; pattern language for a reader to learn, in a file whose whole point is that
+;; it is read at a glance. The literal parts are quoted, so a `.` or a `?` in an
+;; export name is a character and not a metacharacter.
+(define (glob-matches? pattern name)
+  (define rx
+    (regexp (string-append "^"
+                           (string-join (map regexp-quote (string-split pattern "*" #:trim? #f))
+                                        ".*")
+                           "$")))
+  (regexp-match? rx (symbol->string name)))
+
 (define (owned-by? o path)
   (if (owner-module o)
       (equal? (owner-module o) path)
-      (under-scope? (owner-scope o) path)))
-
-(define (under-scope? s path)
-  (define rel (find-relative-path (scope-dir s) path))
-  (and (relative-path? rel) (not (string-prefix? (path->string rel) ".."))))
+      (scope-covers? (owner-scope o) path)))
 
 (define (owner-label o label)
   (if (owner-module o)
       (label (owner-module o))
-      (format "~a and everything under it" (label (owner-scope-file o)))))
-
-(define (owner-scope-file o) (scope-file (owner-scope o)))
+      (format "~a and everything under it" (label (scope-file (owner-scope o))))))
 
 ;; ---- 4: the declaration against the history ----------------------------------------
 
 (define (check-churn s history label)
   (define e (site-decl s))
-  (define ceiling (clock-churn-ceiling (effective-clock e)))
-  (define n (churn-count history (site-path s)))
   (define window (churn-window history))
+  (define allowed (clock-allows (effective-clock e) window))
+  (define n (churn-count history (site-path s)))
   (cond
-    [(and ceiling (> (/ n window) ceiling))
+    [(and allowed (> n allowed))
      (list (finding (effective-clock-loc e)
                     (format "~a: declared ~a, changed in ~a of the last ~a commits"
                             (label (site-path s)) (effective-clock e) n window)
-                    (list (format "~a allows up to ~a of ~a"
-                                  (effective-clock e)
-                                  (inexact->exact (floor (* ceiling window)))
-                                  window)
+                    (list (format "~a allows up to ~a of ~a" (effective-clock e) allowed window)
                           "either the code settles or the declaration changes — both are reviewable diffs")))]
     [else '()]))
 

--- a/arch/check.rkt
+++ b/arch/check.rkt
@@ -1,0 +1,304 @@
+#lang racket/base
+
+;; The four checks, over declarations and facts. One walk, no judgment calls.
+;;
+;;   1  dependencies point volatile -> stable, never back
+;;   2  ambient authority is used only where it is owned
+;;   3  one owner per tagged concept
+;;   4  the declarations agree with what git says actually changed
+;;
+;; Two smaller ones ride along, because each is the part of a bigger check that
+;; audits the DECLARATION rather than the code: a spelling handed on for an
+;; authority has to be a name the module really exports (check 2 is meaningless
+;; otherwise), and a concept has to have exactly one claimant (check 3 is
+;; meaningless otherwise).
+;;
+;; Nothing here reads a file, resolves a path, shells out or knows what git's
+;; output looks like. It is handed sources, names and counts, and it answers
+;; with findings — which is what lets the messages be tested against fixture
+;; trees three lines long.
+;;
+;; `label` is how a path is SAID: the checks build message text and a message
+;; with an absolute path in it is a message that differs on every machine. It
+;; arrives as an argument rather than as a parameter, because a checker with
+;; ambient state in it would be a poor advertisement for itself.
+
+(require racket/contract
+         racket/list
+         racket/path
+         racket/set
+         racket/string
+         arch/churn
+         arch/decl
+         arch/facts
+         arch/finding
+         arch/scope
+         arch/source
+         arch/vocabulary)
+
+(provide (struct-out report)
+         (struct-out site)
+         (contract-out
+          [audit (->* (path?) (#:window exact-positive-integer?) report?)]
+          [sites-of (-> (listof scope?) (listof site?))]))
+
+;; findings : every violation, in file order
+;; notes    : what the run could not do — today only "there was no history to
+;;            audit". Printed, never silent: a check that quietly does not run
+;;            is the failure mode this whole tool exists to remove.
+(struct report (root scopes sites churn findings notes) #:transparent)
+
+;; One governed module, with everything anybody needs to say about it.
+(struct site (path source decl) #:transparent)
+
+(define (audit root #:window [window 30])
+  (define scopes (find-scopes root))
+  (define sites (sites-of scopes))
+  (define history (read-churn root window))
+  (define spellings (spelling-table sites))
+  (define owners (concept-owners scopes))
+  (define (label p) (path-label p root))
+  (report root
+          scopes
+          sites
+          history
+          (sort
+           (append
+            (spelling-findings sites label)
+            (claim-findings owners label)
+            (append* (for/list ([s (in-list sites)]) (check-dependencies s scopes label)))
+            (append* (for/list ([s (in-list sites)]) (check-authority s sites spellings label)))
+            (append* (for/list ([s (in-list sites)]) (check-concepts s owners label)))
+            (if history
+                (append* (for/list ([s (in-list sites)]) (check-churn s history label)))
+                '()))
+           finding<?)
+          (if history
+              '()
+              (list (string-append
+                     "churn: no git history here, so no declaration was audited against it"
+                     " — the other three checks ran")))))
+
+(define (sites-of scopes)
+  (append*
+   (for/list ([s (in-list scopes)])
+     (for/list ([m (in-list (scope-modules s scopes))])
+       (site m (read-source m) (declaration-for (scope-declaration s) (scope-relative s m)))))))
+
+(define (finding<? a b)
+  (define (key f)
+    (define loc (finding-loc f))
+    (list (format "~a" (and loc (srcloc-source loc)))
+          (or (and loc (srcloc-line loc)) 0)
+          (or (and loc (srcloc-column loc)) 0)))
+  (define ka (key a))
+  (define kb (key b))
+  (cond
+    [(string<? (car ka) (car kb)) #t]
+    [(string>? (car ka) (car kb)) #f]
+    [(< (cadr ka) (cadr kb)) #t]
+    [(> (cadr ka) (cadr kb)) #f]
+    [else (< (caddr ka) (caddr kb))]))
+
+;; ---- 1: dependencies point volatile -> stable ----------------------------------
+
+(define (check-dependencies s scopes label)
+  (define mine (site-decl s))
+  (for*/list ([entry (in-list (source-requires (site-source s)))]
+              [dep (in-value (car entry))]
+              #:unless (equal? dep (site-path s))
+              [theirs (in-value (declaration-of scopes dep))]
+              #:when (and theirs
+                          (> (clock-rank (effective-clock theirs))
+                             (clock-rank (effective-clock mine)))))
+    (finding
+     (cdr entry)
+     (format "requires ~a: dependency points the wrong way" (label dep))
+     (list (declared-line (site-path s) mine label)
+           (declared-line dep theirs label)
+           (format "~a code must not depend on ~a code — invert the edge, or move the code that reaches across"
+                   (effective-clock mine) (effective-clock theirs))))))
+
+(define (declared-line path e label)
+  (format "~a is declared ~a (~a)"
+          (label path) (effective-clock e) (loc-brief (effective-clock-loc e) label)))
+
+;; ---- 2: authority used only where owned ------------------------------------------
+
+;; identifier -> authority. The base spellings are the language's own; the rest
+;; are handed on by the modules that own the authority, which is where the fact
+;; that `today-iso-string` reads a clock actually lives.
+(define (spelling-table sites)
+  (define table (make-hasheq))
+  (for* ([a (in-list authorities)] [s (in-list (authority-spellings a))])
+    (hash-set! table s a))
+  (for* ([s (in-list sites)]
+         [g (in-list (effective-grants (site-decl s)))]
+         [name (in-list (grant-spellings g))])
+    (hash-set! table (string->symbol name) (grant-authority g)))
+  table)
+
+;; A spelling is a promise that this module exports that name. When it does
+;; not, check 2 is quietly not applying to anybody — so this is the finding
+;; that keeps the table honest.
+(define (spelling-findings sites label)
+  (append*
+   (for/list ([s (in-list sites)])
+     (define defined (list->seteq (module-defines (site-path s))))
+     (append*
+      (for/list ([g (in-list (own-grants (site-decl s)))])
+        (for/list ([name (in-list (grant-spellings g))]
+                   #:unless (set-member? defined (string->symbol name)))
+          (finding (grant-loc g)
+                   (format "~a: not an export of ~a" name (label (site-path s)))
+                   (list (format "an authority's spellings name what THIS module hands ~a on as"
+                                 (grant-authority g))
+                         "a name nothing exports is a rule that applies to nobody"))))))))
+
+;; Grants from this module's own override, not from the package default: only
+;; those can carry spellings (the expander refuses the others), and only those
+;; are a claim about one module's exports.
+(define (own-grants e)
+  (define over (effective-module e))
+  (if over (module-decl-grants over) '()))
+
+(define (check-authority s sites spellings label)
+  (define src (site-source s))
+  (define mine (site-decl s))
+  (define visible (imported-names src))
+  ;; A module that binds the name itself is calling its own, whatever the
+  ;; import brought in. Both halves matter: the source says what it defines
+  ;; under any name, and the module system says what a `struct` form defined
+  ;; without anybody writing the name down.
+  (define defined
+    (set-union (list->seteq (hash-keys (source-definitions src)))
+               (list->seteq (module-defines (site-path s)))))
+  (for*/list ([(name loc) (in-hash (source-mentions src))]
+              [a (in-value (hash-ref spellings name #f))]
+              #:when (and a
+                          (set-member? visible name)
+                          (not (set-member? defined name))
+                          (not (effective-owns? mine a))))
+    (finding loc
+             (format "~a: ambient authority `~a` is not owned here" name a)
+             (list (format "~a owns: ~a" (label (site-path s)) (word-list (effective-owns mine)))
+                   (format "~a is owned by: ~a" a (owners-of a sites label))
+                   "take what you need as an argument — or the declaration changes, in review"))))
+
+;; Every name that reaches this module from something it requires, its #lang
+;; included. An over-approximation on purpose: `only-in` narrows what arrives
+;; and this does not model that, so a module that MENTIONS a name it did not
+;; quite import is asked to declare an authority it does not quite use. The
+;; error is on the side of declaring, which is the side a reader can check.
+(define (imported-names src)
+  (for/fold ([names (seteq)]) ([entry (in-list (source-requires src))])
+    (set-union names (names-from (car entry)))))
+
+;; Who else has this authority — the line that turns "you may not" into "ask
+;; one of these". Capped, because a repo where thirty modules own the
+;; filesystem would otherwise answer with a paragraph, and the point of the
+;; line is to be read.
+(define owners-shown 5)
+
+(define (owners-of a sites label)
+  (define who
+    (sort (for/list ([s (in-list sites)] #:when (effective-owns? (site-decl s) a))
+            (label (site-path s)))
+          string<?))
+  (cond
+    [(null? who) "nobody"]
+    [(<= (length who) owners-shown) (string-join who ", ")]
+    [else (format "~a, and ~a more"
+                  (string-join (take who owners-shown) ", ")
+                  (- (length who) owners-shown))]))
+
+;; ---- 3: one owner per concept -----------------------------------------------------
+
+;; A concept and where it is owned. `module` is #f when the whole package owns
+;; it, and one path when an override does.
+(struct owner (concept globs loc scope module) #:transparent)
+
+(define (concept-owners scopes)
+  (append*
+   (for/list ([s (in-list scopes)])
+     (append
+      (for/list ([c (in-list (scope-decl-claims (scope-declaration s)))])
+        (owner (claim-concept c) (claim-globs c) (claim-loc c) s #f))
+      (append*
+       (for/list ([m (in-list (scope-decl-modules (scope-declaration s)))])
+         (for/list ([c (in-list (module-decl-claims m))])
+           (owner (claim-concept c) (claim-globs c) (claim-loc c) s
+                  (simplify-path (build-path (scope-dir s) (module-decl-file m)))))))))))
+
+(define (claim-findings owners label)
+  (define seen (make-hasheq))
+  (append*
+   (for/list ([o (in-list owners)])
+     (define prev (hash-ref seen (owner-concept o) #f))
+     (hash-set! seen (owner-concept o) o)
+     (if prev
+         (list (finding (owner-loc o)
+                        (format "~a: a concept claimed twice" (owner-concept o))
+                        (list (format "already claimed at ~a" (loc-brief (owner-loc prev) label))
+                              "one owner per concept, and two claimants is no owner at all")))
+         '()))))
+
+(define (check-concepts s owners label)
+  (define src (site-source s))
+  (define here (site-path s))
+  (append*
+   (for/list ([name (in-list (module-defines here))])
+     (for*/list ([o (in-list owners)]
+                 [glob (in-value (matching-glob o name))]
+                 #:when (and glob (not (owned-by? o here))))
+       (finding (or (source-where src name) (srcloc here 1 0 1 0))
+                (format "~a: exports into concept `~a`" name (owner-concept o))
+                (list (format "that concept is owned by ~a (~a)"
+                              (owner-label o label) (loc-brief (owner-loc o) label))
+                      (format "the pattern it matched: \"~a\"" glob)
+                      "one owner per concept — require the name from the owner instead"))))))
+
+(define (matching-glob o name)
+  (for/first ([g (in-list (owner-globs o))] #:when (glob-matches? g name)) g))
+
+(define (owned-by? o path)
+  (if (owner-module o)
+      (equal? (owner-module o) path)
+      (under-scope? (owner-scope o) path)))
+
+(define (under-scope? s path)
+  (define rel (find-relative-path (scope-dir s) path))
+  (and (relative-path? rel) (not (string-prefix? (path->string rel) ".."))))
+
+(define (owner-label o label)
+  (if (owner-module o)
+      (label (owner-module o))
+      (format "~a and everything under it" (label (owner-scope-file o)))))
+
+(define (owner-scope-file o) (scope-file (owner-scope o)))
+
+;; ---- 4: the declaration against the history ----------------------------------------
+
+(define (check-churn s history label)
+  (define e (site-decl s))
+  (define ceiling (clock-churn-ceiling (effective-clock e)))
+  (define n (churn-count history (site-path s)))
+  (define window (churn-window history))
+  (cond
+    [(and ceiling (> (/ n window) ceiling))
+     (list (finding (effective-clock-loc e)
+                    (format "~a: declared ~a, changed in ~a of the last ~a commits"
+                            (label (site-path s)) (effective-clock e) n window)
+                    (list (format "~a allows up to ~a of ~a"
+                                  (effective-clock e)
+                                  (inexact->exact (floor (* ceiling window)))
+                                  window)
+                          "either the code settles or the declaration changes — both are reviewable diffs")))]
+    [else '()]))
+
+;; ---- where a declaration is, inside a message line ------------------------------------
+
+(define (loc-brief loc label)
+  (if loc
+      (format "~a:~a" (label (srcloc-source loc)) (or (srcloc-line loc) "?"))
+      "?"))

--- a/arch/churn.rkt
+++ b/arch/churn.rkt
@@ -1,0 +1,80 @@
+#lang racket/base
+
+;; How often a file actually changed, out of `git log`.
+;;
+;; This is the only fact in the checker that is not in the tree: a declaration
+;; can be read, an import can be resolved, but "settling" is a claim about
+;; TIME, and the only record of that is the history. No judgment lives here —
+;; the module counts commits, and arch/vocabulary owns what a count means.
+;;
+;; Git's output format is the volatility this module exists to encapsulate.
+;; `--name-only` with a machine-readable pretty format, no porcelain, no
+;; parsing of anything a locale could translate.
+;;
+;; When there is no history to read — no git, a checkout with none of it, a
+;; build sandbox — the answer is #f and the audit says so out loud in the
+;; report. That is not a waiver: a waiver is a module exempting itself from a
+;; rule, and this is the rule having nothing to apply to.
+
+(require racket/contract
+         racket/list
+         racket/path
+         racket/port
+         racket/string)
+
+(provide (struct-out churn)
+         (contract-out
+          [read-churn (-> path? exact-positive-integer? (or/c churn? #f))]
+          [churn-count (-> churn? path? exact-nonnegative-integer?)]
+          [churn-fraction (-> churn? path? real?)]))
+
+;; window : how many commits were actually read (a young repo has fewer than
+;;          were asked for, and the fraction has to be out of what exists)
+;; counts : (hash path -> commits touching it), paths absolute and simplified
+(struct churn (window counts) #:transparent)
+
+(define (read-churn root window)
+  (define git (find-executable-path "git"))
+  (define top (and git (git-line git root "rev-parse" "--show-toplevel")))
+  (and top
+       (let ()
+         ;; Paths in the log are relative to the repository, which is not
+         ;; necessarily the directory being checked.
+         (define repo (path->complete-path (string->path top)))
+         (define log (git-lines git root "log" (format "-n~a" window)
+                                "--pretty=format:@" "--name-only"))
+         (and log
+              (let ([counts (make-hash)]
+                    [commits 0])
+                (for ([line (in-list log)])
+                  (cond
+                    [(string=? line "@") (set! commits (add1 commits))]
+                    [(string=? line "") (void)]
+                    [else
+                     (define p (simplify-path (build-path repo line) #f))
+                     (hash-update! counts p add1 0)]))
+                (churn (max commits 1) counts))))))
+
+(define (churn-count c path)
+  (hash-ref (churn-counts c) (simplify-path path) 0))
+
+(define (churn-fraction c path)
+  (/ (churn-count c path) (churn-window c)))
+
+;; ---- talking to git -------------------------------------------------------------
+
+(define (git-lines git dir . args)
+  (define-values (sp out in err)
+    (apply subprocess #f #f #f git "-C" (path->string (path->complete-path dir)) args))
+  (close-output-port in)
+  (define lines (port->lines out))
+  ;; drained, never read: a subprocess whose stderr pipe fills up stops
+  (void (port->string err))
+  (subprocess-wait sp)
+  (close-input-port out)
+  (close-input-port err)
+  (and (zero? (subprocess-status sp)) lines))
+
+(define (git-line git dir . args)
+  (define lines (apply git-lines git dir args))
+  (and lines (pair? lines) (string-trim (car lines))))

--- a/arch/churn.rkt
+++ b/arch/churn.rkt
@@ -17,10 +17,9 @@
 ;; rule, and this is the rule having nothing to apply to.
 
 (require racket/contract
-         racket/list
-         racket/path
          racket/port
-         racket/string)
+         racket/string
+         racket/system)
 
 (provide (struct-out churn)
          (contract-out
@@ -40,14 +39,19 @@
 
 (define (read-churn root window)
   (define git (find-executable-path "git"))
-  (define top (and git (git-line git root "rev-parse" "--show-toplevel")))
-  (and top
-       (let ()
-         ;; Paths in the log are relative to the repository, which is not
-         ;; necessarily the directory being checked.
-         (define repo (path->complete-path (string->path top)))
-         (define log (git-lines git root "log" (format "-n~a" window)
-                                "--pretty=format:@" "--name-only"))
+  ;; Paths in the log are relative to the REPOSITORY, which is not necessarily
+  ;; the directory being checked. `--show-prefix` says where the one sits
+  ;; inside the other, so every path can be rebuilt from `root` — the same path
+  ;; the declarations were found under.
+  ;;
+  ;; Rebuilt from `root` and not from `--show-toplevel` on purpose: git
+  ;; resolves symlinks and Racket's `simple-form-path` does not, so on a macOS
+  ;; temp directory (`/var/folders/…` against `/private/var/folders/…`) the two
+  ;; spellings of one directory would never match and every count would be zero.
+  (define prefix (and git (git-first git root "rev-parse" "--show-prefix")))
+  (and prefix
+       (let ([log (git-lines git root "log" (format "-n~a" window)
+                             "--pretty=format:@" "--name-only")])
          (and log
               (let ([counts (make-hash)]
                     [commits 0])
@@ -55,28 +59,40 @@
                   (cond
                     [(string=? line "@") (set! commits (add1 commits))]
                     [(string=? line "") (void)]
-                    [else
-                     (define p (simplify-path (build-path repo line) #f))
-                     (hash-update! counts p add1 0)]))
+                    [(under-prefix line prefix)
+                     => (λ (rel) (hash-update! counts (build-path root rel) add1 0))]
+                    [else (void)]))
                 (churn (max commits 1) counts))))))
 
+;; A repository-relative path, said relative to the directory being checked —
+;; or #f when it is somewhere else in the repository entirely.
+(define (under-prefix line prefix)
+  (and (string-prefix? line prefix)
+       (> (string-length line) (string-length prefix))
+       (substring line (string-length prefix))))
+
 (define (churn-count c path)
-  (hash-ref (churn-counts c) (simplify-path path) 0))
+  (hash-ref (churn-counts c) path 0))
 
 ;; ---- talking to git -------------------------------------------------------------
 
+;; `system*` and not `system`: no shell, so nothing in a path is ever a word
+;; somebody else gets to parse. `/exit-code` because that is the whole of what
+;; this needs to know about failure — a checkout with no repository in it is
+;; not an error, it is an audit with nothing to audit.
 (define (git-lines git dir . args)
-  (define-values (sp out in err)
-    (apply subprocess #f #f #f git "-C" (path->string (path->complete-path dir)) args))
-  (close-output-port in)
-  (define lines (port->lines out))
-  ;; drained, never read: a subprocess whose stderr pipe fills up stops
-  (void (port->string err))
-  (subprocess-wait sp)
-  (close-input-port out)
-  (close-input-port err)
-  (and (zero? (subprocess-status sp)) lines))
+  (define out (open-output-string))
+  (define code
+    (parameterize ([current-output-port out]
+                   ;; drained, never read: a subprocess whose stderr pipe fills
+                   ;; up stops
+                   [current-error-port (open-output-nowhere)])
+      (apply system*/exit-code git "-C" (path->string (path->complete-path dir)) args)))
+  (and (zero? code) (string-split (get-output-string out) "\n" #:trim? #f)))
 
-(define (git-line git dir . args)
+;; The first line, or "" when the command said nothing — which is what
+;; `--show-prefix` says from the top of a repository, and is not the same
+;; answer as "this is not a repository" (that one is #f).
+(define (git-first git dir . args)
   (define lines (apply git-lines git dir args))
-  (and lines (pair? lines) (string-trim (car lines))))
+  (and lines (if (pair? lines) (string-trim (car lines)) "")))

--- a/arch/churn.rkt
+++ b/arch/churn.rkt
@@ -24,9 +24,14 @@
 
 (provide (struct-out churn)
          (contract-out
+          [default-churn-window exact-positive-integer?]
           [read-churn (-> path? exact-positive-integer? (or/c churn? #f))]
-          [churn-count (-> churn? path? exact-nonnegative-integer?)]
-          [churn-fraction (-> churn? path? real?)]))
+          [churn-count (-> churn? path? exact-nonnegative-integer?)]))
+
+;; How much history an audit reads unless somebody says otherwise. One number,
+;; here rather than in the checker AND the command line, because two defaults
+;; for one fact is how they drift apart.
+(define default-churn-window 30)
 
 ;; window : how many commits were actually read (a young repo has fewer than
 ;;          were asked for, and the fraction has to be out of what exists)
@@ -57,9 +62,6 @@
 
 (define (churn-count c path)
   (hash-ref (churn-counts c) (simplify-path path) 0))
-
-(define (churn-fraction c path)
-  (/ (churn-count c path) (churn-window c)))
 
 ;; ---- talking to git -------------------------------------------------------------
 

--- a/arch/decl.rkt
+++ b/arch/decl.rkt
@@ -25,8 +25,7 @@
 ;; prints one — goes through these accessors.
 
 (require racket/contract
-         racket/list
-         arch/vocabulary)
+         racket/list)
 
 (provide (struct-out grant)
          (struct-out claim)
@@ -58,16 +57,16 @@
 ;; One `(override "file.rkt" ...)`. `clock` is #f when the override did not
 ;; mention one, which is the ordinary case: a module usually differs in what it
 ;; owns, not in how fast it moves.
-(struct module-decl (file clock clock-loc grants claims loc) #:transparent)
+(struct module-decl (file clock clock-loc grants claims) #:transparent)
 
-;; One `arch.rkt`. `source` is its own path, so every message can say which
-;; declaration it is quoting.
-(struct scope-decl (source clock clock-loc grants claims modules) #:transparent)
+;; One `arch.rkt`, whole.
+(struct scope-decl (clock clock-loc grants claims modules) #:transparent)
 
 ;; The answer for ONE module: what it may depend on, what it may reach for,
-;; what it owns. `scope` is the arch.rkt this came out of; `module` is the
-;; override that applied, or #f when the package default stood.
-(struct effective (path scope module clock clock-loc grants claims) #:transparent)
+;; what it owns. `module` is the override that applied, or #f when the package
+;; default stood — which is the one thing `--explain` needs in order to say
+;; where a line came from.
+(struct effective (module clock clock-loc grants claims) #:transparent)
 
 ;; scope-decl x "web/watch.rkt" -> effective
 ;;
@@ -78,9 +77,7 @@
     (for/first ([m (in-list (scope-decl-modules scope))]
                 #:when (string=? (module-decl-file m) file))
       m))
-  (effective file
-             scope
-             over
+  (effective over
              (or (and over (module-decl-clock over)) (scope-decl-clock scope))
              (or (and over (module-decl-clock-loc over)) (scope-decl-clock-loc scope))
              (append (scope-decl-grants scope)
@@ -88,8 +85,12 @@
              (append (scope-decl-claims scope)
                      (if over (module-decl-claims over) '()))))
 
+;; What it owns, for a message: sorted and said once each.
 (define (effective-owns e)
   (sort (remove-duplicates (map grant-authority (effective-grants e))) symbol<?))
 
+;; Whether it owns one thing, which is a different question and asked far more
+;; often — once per authority-bearing identifier in the tree. A scan over at
+;; most seven grants, not a sort of them.
 (define (effective-owns? e authority)
-  (and (memq authority (effective-owns e)) #t))
+  (for/or ([g (in-list (effective-grants e))]) (eq? authority (grant-authority g))))

--- a/arch/decl.rkt
+++ b/arch/decl.rkt
@@ -1,0 +1,112 @@
+#lang racket/base
+
+;; What a declaration IS, and how a package's defaults and a module's override
+;; compose into the one answer a check asks for.
+;;
+;; Two shapes, because a declaration is written at two altitudes: a `scope-decl`
+;; is what an `arch.rkt` says about everything under it, and a `module-decl` is
+;; the `(override "file.rkt" ...)` that one module carries when it differs. The
+;; merge is `declaration-for`, and it is the only place the two meet — a check
+;; never sees a default and an override separately, which is what keeps
+;; "effective declaration" from being computed twice, differently.
+;;
+;; Composition, spelled out because it is the part a reader has to trust:
+;;
+;;   clock   — the override REPLACES. A module is at one clock or another.
+;;   owns    — the override ADDS. The package says what is ordinary; the
+;;             exceptions declare themselves, and a default of `(owns)` plus a
+;;             module that owns the filesystem reads the way it is meant to.
+;;   concept — ADDS, same reason. A package-level concept is owned by the whole
+;;             directory; a concept on an override is owned by that one file.
+;;
+;; Nothing here reads a file, expands anything or knows what a check is. This
+;; is the vocabulary's grammar in struct form, and every consumer — the
+;; expander that builds one, the checker that reads one, `--explain` that
+;; prints one — goes through these accessors.
+
+(require racket/contract
+         racket/list
+         racket/string
+         arch/vocabulary)
+
+(provide (struct-out grant)
+         (struct-out claim)
+         (struct-out module-decl)
+         (struct-out scope-decl)
+         (struct-out effective)
+         (contract-out
+          [declaration-for (-> scope-decl? string? effective?)]
+          [effective-owns (-> effective? (listof symbol?))]
+          [effective-owns? (-> effective? symbol? boolean?)]
+          [glob-matches? (-> string? symbol? boolean?)]))
+
+;; One authority, owned here.
+;;
+;; `spellings` is the door this module opens onto it: `olai/dates.rkt` owns the
+;; clock and hands it on as `today-iso-string`, so a module that calls THAT is
+;; reading the clock as surely as one that calls `(today)`. Declared on the
+;; owner because the owner is where the fact is — the checker ships the base
+;; spellings of the language it is checking, and nothing else.
+;;
+;; loc: the srcloc of the form, for the message that says where a thing was
+;;      declared.
+(struct grant (authority spellings loc) #:transparent)
+
+;; One concept, owned here. `globs` are the export names that belong to it —
+;; `mint-*` for node-key minting — and matching one from anywhere else is the
+;; violation.
+(struct claim (concept globs loc) #:transparent)
+
+;; One `(override "file.rkt" ...)`. `clock` is #f when the override did not
+;; mention one, which is the ordinary case: a module usually differs in what it
+;; owns, not in how fast it moves.
+(struct module-decl (file clock clock-loc grants claims loc) #:transparent)
+
+;; One `arch.rkt`. `source` is its own path, so every message can say which
+;; declaration it is quoting.
+(struct scope-decl (source clock clock-loc grants claims modules) #:transparent)
+
+;; The answer for ONE module: what it may depend on, what it may reach for,
+;; what it owns. `scope` is the arch.rkt this came out of; `module` is the
+;; override that applied, or #f when the package default stood.
+(struct effective (path scope module clock clock-loc grants claims) #:transparent)
+
+;; scope-decl x "web/watch.rkt" -> effective
+;;
+;; `file` is relative to the arch.rkt's own directory, which is how an override
+;; names its module and how the caller has to ask.
+(define (declaration-for scope file)
+  (define over
+    (for/first ([m (in-list (scope-decl-modules scope))]
+                #:when (string=? (module-decl-file m) file))
+      m))
+  (effective file
+             scope
+             over
+             (or (and over (module-decl-clock over)) (scope-decl-clock scope))
+             (or (and over (module-decl-clock-loc over)) (scope-decl-clock-loc scope))
+             (append (scope-decl-grants scope)
+                     (if over (module-decl-grants over) '()))
+             (append (scope-decl-claims scope)
+                     (if over (module-decl-claims over) '()))))
+
+(define (effective-owns e)
+  (sort (remove-duplicates (map grant-authority (effective-grants e))) symbol<?))
+
+(define (effective-owns? e authority)
+  (and (memq authority (effective-owns e)) #t))
+
+;; ---- globs -------------------------------------------------------------------
+
+;; `*` and nothing else. A concept names its exports the way a person would say
+;; them out loud — `mint-*`, `acp-*` — and anything richer would be a second
+;; pattern language for a reader to learn, in a file whose whole point is that
+;; it is read at a glance. The literal parts are quoted, so a `.` or a `?` in an
+;; export name is a character and not a metacharacter.
+(define (glob-matches? pattern name)
+  (define rx
+    (regexp (string-append "^"
+                           (string-join (map regexp-quote (string-split pattern "*" #:trim? #f))
+                                        ".*")
+                           "$")))
+  (regexp-match? rx (symbol->string name)))

--- a/arch/decl.rkt
+++ b/arch/decl.rkt
@@ -26,7 +26,6 @@
 
 (require racket/contract
          racket/list
-         racket/string
          arch/vocabulary)
 
 (provide (struct-out grant)
@@ -37,8 +36,7 @@
          (contract-out
           [declaration-for (-> scope-decl? string? effective?)]
           [effective-owns (-> effective? (listof symbol?))]
-          [effective-owns? (-> effective? symbol? boolean?)]
-          [glob-matches? (-> string? symbol? boolean?)]))
+          [effective-owns? (-> effective? symbol? boolean?)]))
 
 ;; One authority, owned here.
 ;;
@@ -95,18 +93,3 @@
 
 (define (effective-owns? e authority)
   (and (memq authority (effective-owns e)) #t))
-
-;; ---- globs -------------------------------------------------------------------
-
-;; `*` and nothing else. A concept names its exports the way a person would say
-;; them out loud — `mint-*`, `acp-*` — and anything richer would be a second
-;; pattern language for a reader to learn, in a file whose whole point is that
-;; it is read at a glance. The literal parts are quoted, so a `.` or a `?` in an
-;; export name is a character and not a metacharacter.
-(define (glob-matches? pattern name)
-  (define rx
-    (regexp (string-append "^"
-                           (string-join (map regexp-quote (string-split pattern "*" #:trim? #f))
-                                        ".*")
-                           "$")))
-  (regexp-match? rx (symbol->string name)))

--- a/arch/default.nix
+++ b/arch/default.nix
@@ -1,0 +1,41 @@
+# The `arch` collection: the declaration language, and the checker over it.
+#
+# Its own derivation because it is its own package — a library with its own
+# reason to be built, under both `live` and `olai` rather than inside either.
+# flake.nix only callPackages it, like acp/, e2e/ and live/ do.
+#
+# It is packaged at all, rather than being a dev-time script, because the two
+# collections it sits under carry `#lang arch` files: `live/arch.rkt` and
+# `olai/**/arch.rkt` are modules, and a build that installs those packages has
+# to be able to compile them. Shipping the checker with them is the price of
+# the declarations living beside the code they are about, which is the whole
+# point of the thing.
+{ lib, stdenvNoCC }:
+
+stdenvNoCC.mkDerivation {
+  pname = "arch";
+  version = "0.1";
+
+  # What the collection IS, said positively: this file is about producing the
+  # package rather than in it, and the README is documentation the package
+  # does not need in order to work.
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.difference ./. (lib.fileset.unions [ ./default.nix ./README.md ]);
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -a ./* $out/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "#lang arch: a package's architecture as data, and the checker that holds it to it";
+    license = licenses.agpl3Plus;
+  };
+}

--- a/arch/expander.rkt
+++ b/arch/expander.rkt
@@ -33,6 +33,7 @@
                      racket/path
                      racket/string
                      syntax/parse
+                     syntax/srcloc
                      arch/vocabulary
                      arch/wording))
 
@@ -60,9 +61,16 @@
     (define hit (did-you-mean name candidates))
     (if hit (list (format "did you mean: ~a?" hit)) '()))
 
-  ;; '(a b c) -> '(() (a) (a b)): what had already been seen at each element.
-  (define (inits xs)
-    (for/list ([i (in-range (length xs))]) (take xs i)))
+  ;; The first element that repeats something before it: that element, and what
+  ;; came before it. Three rules ask this — an authority owned twice, a module
+  ;; overridden twice — and each wants both halves, the repeat to blame and the
+  ;; list to quote back. `check-duplicates` hands over only the first.
+  (define (first-repeat xs key same?)
+    (let loop ([seen '()] [rest xs])
+      (cond
+        [(null? rest) (values #f '())]
+        [(member (key (car rest)) (map key seen) same?) (values (car rest) (reverse seen))]
+        [else (loop (cons (car rest) seen) (cdr rest))])))
 
   (define (head-of stx)
     (and (pair? (syntax-e stx)) (car (syntax-e stx))))
@@ -138,11 +146,11 @@
       [(owns g ...)
        (define gs (for/list ([g (in-list (syntax->list #'(g ...)))])
                     (parse-grant g #:in-override? in-override?)))
-       (for ([g (in-list gs)] [seen (in-list (inits (map pgrant-authority gs)))])
-         (when (memq (pgrant-authority g) seen)
-           (arch-error (pgrant-stx g) "an authority owned twice"
-                       "one entry per authority; a second is either a typo or a merge that went wrong"
-                       (format "already owned here: ~a" (word-list seen)))))
+       (define-values (again before) (first-repeat gs pgrant-authority eq?))
+       (when again
+         (arch-error (pgrant-stx again) "an authority owned twice"
+                     "one entry per authority; a second is either a typo or a merge that went wrong"
+                     (format "already owned here: ~a" (word-list (map pgrant-authority before)))))
        (clause 'owns gs stx)]
       [(concept name:id glob:str ...+)
        (for ([g (in-list (syntax->list #'(glob ...)))])
@@ -177,16 +185,27 @@
                        (suggestion (syntax-e head) '(clock owns concept override))
                        '()))]))
 
-  (define (clock-clause cs)
-    (for/first ([c (in-list cs)] #:when (eq? 'clock (clause-tag c))) c))
-
-  (define (check-one-clock cs)
+  ;; The one clock in `cs`, and both ways that can go wrong. One slot, one
+  ;; rule, one traversal — "no clock" and "a second clock" are the same
+  ;; question asked of the same list, and answering them in two functions meant
+  ;; a caller could ask one and forget the other.
+  ;;
+  ;; `blame` is what a missing clock is reported against, and #f when a missing
+  ;; one is fine (an override says how a module DIFFERS, and usually not in
+  ;; speed).
+  (define (the-clock cs #:blame [blame #f])
     (define found (for/list ([c (in-list cs)] #:when (eq? 'clock (clause-tag c))) c))
     (when (> (length found) 1)
       (arch-error (clause-loc (cadr found))
                   "a second clock"
                   "one clock per declaration — a module moves at one speed or the other"
-                  (format "the first is at line ~a" (or (syntax-line (clause-loc (car found))) "?")))))
+                  (format "the first is at line ~a" (or (syntax-line (clause-loc (car found))) "?"))))
+    (when (and blame (null? found))
+      (arch-error blame #:who 'arch
+                  "no clock"
+                  "an arch.rkt says how fast the code under it moves, before anything else"
+                  (format "write (clock ~a) at the top; clocks: ~a" (car clocks) (word-list clocks))))
+    (and (pair? found) (car found)))
 
   ;; ---- where a form is, as something the runtime can rebuild -----------------
 
@@ -197,10 +216,13 @@
       [(string? s) s]
       [else #f]))
 
+  ;; The same five fields `build-source-location-list` already knows how to
+  ;; take, emitted as a constructor call the module can rebuild at run time.
+  ;; Only the source needs converting: a declaration is read once and its
+  ;; messages are printed later, so the path travels as a string.
   (define (loc-stx stx)
-    #`(srcloc #,(source-string stx)
-              #,(syntax-line stx) #,(syntax-column stx)
-              #,(syntax-position stx) #,(syntax-span stx)))
+    (define parts (build-source-location-list stx))
+    #`(srcloc #,(source-string stx) #,@(map (λ (v) #`'#,v) (cdr parts))))
 
   ;; ---- clauses -> the constructor calls that build a declaration -------------
 
@@ -212,14 +234,13 @@
                              '#,(pgrant-spellings g)
                              #,(loc-stx (pgrant-stx g))))))))
 
+  ;; No duplicate-concept rule here on purpose. Two arch.rkt files can claim
+  ;; one concept as easily as one file can, so the rule is inherently about the
+  ;; whole tree — and the checker enforces it there, over every scope and every
+  ;; level at once. A compile-time copy would be a second, narrower wording of
+  ;; one rule, and a reader who satisfied it would have learned the wrong rule.
   (define (claims-stx cs)
     (define claims (for/list ([c (in-list cs)] #:when (eq? 'concept (clause-tag c))) c))
-    (for ([c (in-list claims)]
-          [seen (in-list (inits (map (λ (c) (car (clause-payload c))) claims)))])
-      (when (memq (car (clause-payload c)) seen)
-        (arch-error (clause-loc c) "a concept claimed twice"
-                    "one owner per concept, and that includes twice in one file"
-                    "merge the two pattern lists into one (concept ...) form")))
     #`(list #,@(for/list ([c (in-list claims)])
                  #`(claim '#,(car (clause-payload c))
                           '#,(cdr (clause-payload c))
@@ -237,16 +258,14 @@
       [(override file:str clause ...)
        (define cs (for/list ([c (in-list (syntax->list #'(clause ...)))])
                     (parse-clause c #:in-override? #t)))
-       (check-one-clock cs)
-       (define ck (clock-clause cs))
+       (define ck (the-clock cs))
        (parsed-override
         #'file
         #`(module-decl '#,(syntax-e #'file)
                        #,(if ck #`'#,(clause-payload ck) #'#f)
                        #,(if ck (loc-stx (clause-loc ck)) #'#f)
                        #,(grants-stx cs)
-                       #,(claims-stx cs)
-                       #,(loc-stx stx)))]
+                       #,(claims-stx cs)))]
       [(override . _)
        (arch-error stx "malformed override"
                    "override names one module by its path, relative to this arch.rkt"
@@ -255,15 +274,17 @@
   ;; An override names a FILE, and the file has to be there. A rename that
   ;; leaves the declaration behind is the failure this catches, and it is worth
   ;; a compile error rather than a rule that quietly stops applying.
+  (define (override-file o) (syntax-e (parsed-override-file-stx o)))
+
   (define (check-overrides overrides)
-    (for ([o (in-list overrides)]
-          [seen (in-list (inits (map (λ (o) (syntax-e (parsed-override-file-stx o))) overrides)))])
+    (define-values (again before) (first-repeat overrides override-file string=?))
+    (when again
+      (arch-error (parsed-override-file-stx again) #:who 'override "a module overridden twice"
+                  "one override per module; merge the clauses into one form"
+                  (format "already overridden: ~a" (string-join (map override-file before) ", "))))
+    (for ([o (in-list overrides)])
       (define stx (parsed-override-file-stx o))
       (define file (syntax-e stx))
-      (when (member file seen)
-        (arch-error stx #:who 'override "a module overridden twice"
-                    "one override per module; merge the clauses into one form"
-                    (format "already overridden: ~a" (string-join seen ", "))))
       (unless (relative-path? file)
         (arch-error stx #:who 'override "not a relative path"
                     "override names a module underneath this arch.rkt, never an absolute path"))
@@ -286,21 +307,15 @@
        (partition (λ (f) (syntax-parse f #:datum-literals (override) [(override . _) #t] [_ #f]))
                   (syntax->list #'(form ...))))
      (define top (map parse-clause top-forms))
-     (check-one-clock top)
-     (unless (clock-clause top)
-       (arch-error stx #:who 'arch
-                   "no clock"
-                   "an arch.rkt says how fast the code under it moves, before anything else"
-                   (format "write (clock ~a) at the top; clocks: ~a" (car clocks) (word-list clocks))))
+     (define ck (the-clock top #:blame stx))
      (define overrides (map parse-override over-forms))
      (check-overrides overrides)
-     (with-syntax ([clock-word (clause-payload (clock-clause top))]
-                   [clock-loc (loc-stx (clause-loc (clock-clause top)))]
+     (with-syntax ([clock-word (clause-payload ck)]
+                   [clock-loc (loc-stx (clause-loc ck))]
                    [grants (grants-stx top)]
                    [claims (claims-stx top)]
-                   [(over ...) (map parsed-override-code overrides)]
-                   [source (source-string stx)])
+                   [(over ...) (map parsed-override-code overrides)])
        #'(#%module-begin
           (provide declaration)
           (define declaration
-            (scope-decl 'source 'clock-word clock-loc grants claims (list over ...)))))]))
+            (scope-decl 'clock-word clock-loc grants claims (list over ...)))))]))

--- a/arch/expander.rkt
+++ b/arch/expander.rkt
@@ -33,7 +33,8 @@
                      racket/path
                      racket/string
                      syntax/parse
-                     arch/vocabulary))
+                     arch/vocabulary
+                     arch/wording))
 
 (provide (rename-out [module-begin #%module-begin])
          #%app #%datum #%top quote)

--- a/arch/expander.rkt
+++ b/arch/expander.rkt
@@ -1,0 +1,305 @@
+#lang racket/base
+
+;; #lang arch — a package's architecture, written down.
+;;
+;;   #lang arch
+;;   (clock settling)
+;;   (owns)
+;;   (concept file-naming "file-label" "key-label")
+;;   (override "store.rkt" (owns filesystem))
+;;   (override "cli.rkt"   (clock volatile) (owns (clock "today-iso-string")))
+;;
+;; Four forms, and the vocabulary inside them is closed (arch/vocabulary). The
+;; module's whole value is a `declaration` — one `scope-decl`, provided — and
+;; the checker is its only reader.
+;;
+;; Everything a declaration can get wrong is caught HERE, at compile time, with
+;; the srcloc of the offending form: a clock word nobody ratified, an authority
+;; that is a typo for a real one, an `(override "moved.rkt" ...)` naming a file
+;; that is not there any more. That last one is the same call `@doc` and
+;; `@include` make in the outline language, for the same reason — a declaration
+;; about a file that does not exist is not a stale comment, it is a form that is
+;; wrong, and it should reach an agent through the compiler rather than as
+;; silence.
+;;
+;; The messages are longer than you would write for a human: rule, then what
+;; the form takes, then what IS in the vocabulary, then a did-you-mean. That is
+;; the shape the research says raises agent success, and it costs nothing —
+;; nobody reads these except when something is already broken.
+
+(require arch/decl
+         (for-syntax racket/base
+                     racket/list
+                     racket/path
+                     racket/string
+                     syntax/parse
+                     arch/vocabulary))
+
+(provide (rename-out [module-begin #%module-begin])
+         #%app #%datum #%top quote)
+
+(begin-for-syntax
+
+  ;; ---- how a refusal reads ---------------------------------------------------
+
+  ;; Rule first, then one indented line per thing the reader needs. Blamed on
+  ;; `stx`, which is always the smallest form that is actually wrong — the
+  ;; authority word, not the `owns` around it.
+  ;; `who` names the FORM that is refusing, for the cases where the offending
+  ;; syntax is a bare string or the whole module and Racket would print `?`.
+  (define (arch-error stx rule #:who [who #f] . lines)
+    (raise-syntax-error
+     who
+     (string-join (cons rule (for/list ([l (in-list (flatten lines))])
+                               (string-append "  " l)))
+                  "\n")
+     stx))
+
+  (define (suggestion name candidates)
+    (define hit (did-you-mean name candidates))
+    (if hit (list (format "did you mean: ~a?" hit)) '()))
+
+  ;; '(a b c) -> '(() (a) (a b)): what had already been seen at each element.
+  (define (inits xs)
+    (for/list ([i (in-range (length xs))]) (take xs i)))
+
+  (define (head-of stx)
+    (and (pair? (syntax-e stx)) (car (syntax-e stx))))
+
+  ;; ---- the closed words ------------------------------------------------------
+
+  (define (parse-clock-word stx)
+    (unless (and (identifier? stx) (clock? (syntax-e stx)))
+      (arch-error stx
+                  "not a clock"
+                  "clock takes one of the three ratified words, least volatile first"
+                  (format "clocks: ~a" (word-list clocks))
+                  (if (identifier? stx) (suggestion (syntax-e stx) clocks) '())))
+    (syntax-e stx))
+
+  (define (parse-authority-word stx)
+    (unless (and (identifier? stx) (authority? (syntax-e stx)))
+      (arch-error stx
+                  "not an authority"
+                  "owns takes ambient authorities, and the set is closed"
+                  (format "authorities: ~a" (word-list authorities))
+                  "a new authority is a roadmap proposal, not an edit here"
+                  (if (identifier? stx) (suggestion (syntax-e stx) authorities) '())))
+    (syntax-e stx))
+
+  ;; `filesystem`, or `(clock "today-iso-string")` — the authority, and the
+  ;; local identifiers this module hands it on as.
+  (struct pgrant (authority spellings stx) #:transparent)
+
+  (define (parse-grant stx #:in-override? in-override?)
+    (syntax-parse stx
+      [a:id (pgrant (parse-authority-word #'a) '() stx)]
+      [(a s:str ...+)
+       ;; A spelling is a claim about ONE module's exports — "I own the clock,
+       ;; and here is what I hand it on as". A package default applies to every
+       ;; module under it, so the same words there would be a claim about all of
+       ;; them at once, which is not a thing anybody means.
+       (unless in-override?
+         (arch-error stx "a spelling on a package default"
+                     "the names an authority is handed on as belong to the module that exports them"
+                     (format "move it to an (override \"some.rkt\" (owns (~a ~s)))"
+                             (syntax->datum #'a) (syntax-e (car (syntax->list #'(s ...)))))))
+       (for ([s (in-list (syntax->list #'(s ...)))])
+         (when (string=? "" (syntax-e s))
+           (arch-error s "an empty spelling"
+                       "a spelling is the identifier this module hands the authority on as")))
+       (pgrant (parse-authority-word #'a) (map syntax-e (syntax->list #'(s ...))) stx)]
+      [(a)
+       (arch-error stx "an empty spelling list"
+                   "an authority in parentheses names the identifiers this module hands it on as"
+                   (format "write ~a on its own, or (~a \"some-name\")"
+                           (syntax->datum #'a) (syntax->datum #'a)))]
+      [_
+       (arch-error stx "not an authority"
+                   "owns takes bare words, or (authority \"spelling\" ...)"
+                   (format "authorities: ~a" (word-list authorities)))]))
+
+  ;; ---- clauses ---------------------------------------------------------------
+
+  ;; A clause carries a tag so the assembly below can tell the three apart
+  ;; without re-parsing. `loc` is the whole form: what a message points at.
+  (struct clause (tag payload loc) #:transparent)
+
+  (define (parse-clause stx #:in-override? [in-override? #f])
+    (syntax-parse stx
+      #:datum-literals (clock owns concept override)
+      [(clock c)
+       (clause 'clock (parse-clock-word #'c) stx)]
+      [(clock . _)
+       (arch-error stx "malformed clock"
+                   "clock takes exactly one word: (clock stable)"
+                   (format "clocks: ~a" (word-list clocks)))]
+      [(owns g ...)
+       (define gs (for/list ([g (in-list (syntax->list #'(g ...)))])
+                    (parse-grant g #:in-override? in-override?)))
+       (for ([g (in-list gs)] [seen (in-list (inits (map pgrant-authority gs)))])
+         (when (memq (pgrant-authority g) seen)
+           (arch-error (pgrant-stx g) "an authority owned twice"
+                       "one entry per authority; a second is either a typo or a merge that went wrong"
+                       (format "already owned here: ~a" (word-list seen)))))
+       (clause 'owns gs stx)]
+      [(concept name:id glob:str ...+)
+       (for ([g (in-list (syntax->list #'(glob ...)))])
+         (when (string=? "" (syntax-e g))
+           (arch-error g "an empty export pattern"
+                       "a concept's patterns are export names, `*` allowed: \"mint-*\"")))
+       (clause 'concept
+               (cons (syntax-e #'name) (map syntax-e (syntax->list #'(glob ...))))
+               stx)]
+      [(concept name:id)
+       (arch-error stx "a concept with no spelling"
+                   "concept names the EXPORTS that belong to it, so a check has something to match"
+                   (format "write (concept ~a \"~a-*\") — one pattern at least"
+                           (syntax->datum #'name) (syntax->datum #'name)))]
+      [(concept . _)
+       (arch-error stx "malformed concept"
+                   "concept takes a name and one or more export patterns"
+                   "for example: (concept node-key-minting \"mint-*\")")]
+      [(override . _)
+       #:when in-override?
+       (arch-error stx "an override inside an override"
+                   "override names ONE module, and a module has nothing under it"
+                   "write a second (override \"other.rkt\" ...) beside this one")]
+      [_
+       (define head (head-of stx))
+       (arch-error (or head stx)
+                   (if in-override? "not an override clause" "not an arch form")
+                   (if in-override?
+                       "an override says how one module differs: clock, owns, concept"
+                       "an arch.rkt says clock, owns, concept, override — and nothing else")
+                   (if (and head (identifier? head))
+                       (suggestion (syntax-e head) '(clock owns concept override))
+                       '()))]))
+
+  (define (clock-clause cs)
+    (for/first ([c (in-list cs)] #:when (eq? 'clock (clause-tag c))) c))
+
+  (define (check-one-clock cs)
+    (define found (for/list ([c (in-list cs)] #:when (eq? 'clock (clause-tag c))) c))
+    (when (> (length found) 1)
+      (arch-error (clause-loc (cadr found))
+                  "a second clock"
+                  "one clock per declaration — a module moves at one speed or the other"
+                  (format "the first is at line ~a" (or (syntax-line (clause-loc (car found))) "?")))))
+
+  ;; ---- where a form is, as something the runtime can rebuild -----------------
+
+  (define (source-string stx)
+    (define s (syntax-source stx))
+    (cond
+      [(path? s) (path->string (simplify-path s #f))]
+      [(string? s) s]
+      [else #f]))
+
+  (define (loc-stx stx)
+    #`(srcloc #,(source-string stx)
+              #,(syntax-line stx) #,(syntax-column stx)
+              #,(syntax-position stx) #,(syntax-span stx)))
+
+  ;; ---- clauses -> the constructor calls that build a declaration -------------
+
+  (define (grants-stx cs)
+    #`(list #,@(append*
+                (for/list ([c (in-list cs)] #:when (eq? 'owns (clause-tag c)))
+                  (for/list ([g (in-list (clause-payload c))])
+                    #`(grant '#,(pgrant-authority g)
+                             '#,(pgrant-spellings g)
+                             #,(loc-stx (pgrant-stx g))))))))
+
+  (define (claims-stx cs)
+    (define claims (for/list ([c (in-list cs)] #:when (eq? 'concept (clause-tag c))) c))
+    (for ([c (in-list claims)]
+          [seen (in-list (inits (map (λ (c) (car (clause-payload c))) claims)))])
+      (when (memq (car (clause-payload c)) seen)
+        (arch-error (clause-loc c) "a concept claimed twice"
+                    "one owner per concept, and that includes twice in one file"
+                    "merge the two pattern lists into one (concept ...) form")))
+    #`(list #,@(for/list ([c (in-list claims)])
+                 #`(claim '#,(car (clause-payload c))
+                          '#,(cdr (clause-payload c))
+                          #,(loc-stx (clause-loc c))))))
+
+  ;; ---- overrides -------------------------------------------------------------
+
+  ;; The filename's syntax is kept beside the generated code: the duplicate and
+  ;; missing-file checks can only be made once every override is parsed.
+  (struct parsed-override (file-stx code) #:transparent)
+
+  (define (parse-override stx)
+    (syntax-parse stx
+      #:datum-literals (override)
+      [(override file:str clause ...)
+       (define cs (for/list ([c (in-list (syntax->list #'(clause ...)))])
+                    (parse-clause c #:in-override? #t)))
+       (check-one-clock cs)
+       (define ck (clock-clause cs))
+       (parsed-override
+        #'file
+        #`(module-decl '#,(syntax-e #'file)
+                       #,(if ck #`'#,(clause-payload ck) #'#f)
+                       #,(if ck (loc-stx (clause-loc ck)) #'#f)
+                       #,(grants-stx cs)
+                       #,(claims-stx cs)
+                       #,(loc-stx stx)))]
+      [(override . _)
+       (arch-error stx "malformed override"
+                   "override names one module by its path, relative to this arch.rkt"
+                   "for example: (override \"web/watch.rkt\" (owns filesystem-events))")]))
+
+  ;; An override names a FILE, and the file has to be there. A rename that
+  ;; leaves the declaration behind is the failure this catches, and it is worth
+  ;; a compile error rather than a rule that quietly stops applying.
+  (define (check-overrides overrides)
+    (for ([o (in-list overrides)]
+          [seen (in-list (inits (map (λ (o) (syntax-e (parsed-override-file-stx o))) overrides)))])
+      (define stx (parsed-override-file-stx o))
+      (define file (syntax-e stx))
+      (when (member file seen)
+        (arch-error stx #:who 'override "a module overridden twice"
+                    "one override per module; merge the clauses into one form"
+                    (format "already overridden: ~a" (string-join seen ", "))))
+      (unless (relative-path? file)
+        (arch-error stx #:who 'override "not a relative path"
+                    "override names a module underneath this arch.rkt, never an absolute path"))
+      (unless (regexp-match? #rx"[.]rkt$" file)
+        (arch-error stx #:who 'override "not a module"
+                    "override names a .rkt file — the thing that has imports and exports"))
+      (define dir (let ([s (syntax-source stx)]) (and (path? s) (path-only s))))
+      (when (and dir (not (file-exists? (build-path dir file))))
+        (arch-error stx #:who 'override "no such module"
+                    (format "there is no ~a beside this arch.rkt" file)
+                    "a declaration about a file that moved is a rule that stopped applying")))))
+
+;; ---- the module ---------------------------------------------------------------
+
+(define-syntax (module-begin stx)
+  (syntax-parse stx
+    #:datum-literals (override)
+    [(_ form ...)
+     (define-values (over-forms top-forms)
+       (partition (λ (f) (syntax-parse f #:datum-literals (override) [(override . _) #t] [_ #f]))
+                  (syntax->list #'(form ...))))
+     (define top (map parse-clause top-forms))
+     (check-one-clock top)
+     (unless (clock-clause top)
+       (arch-error stx #:who 'arch
+                   "no clock"
+                   "an arch.rkt says how fast the code under it moves, before anything else"
+                   (format "write (clock ~a) at the top; clocks: ~a" (car clocks) (word-list clocks))))
+     (define overrides (map parse-override over-forms))
+     (check-overrides overrides)
+     (with-syntax ([clock-word (clause-payload (clock-clause top))]
+                   [clock-loc (loc-stx (clause-loc (clock-clause top)))]
+                   [grants (grants-stx top)]
+                   [claims (claims-stx top)]
+                   [(over ...) (map parsed-override-code overrides)]
+                   [source (source-string stx)])
+       #'(#%module-begin
+          (provide declaration)
+          (define declaration
+            (scope-decl 'source 'clock-word clock-loc grants claims (list over ...)))))]))

--- a/arch/explain.rkt
+++ b/arch/explain.rkt
@@ -19,8 +19,8 @@
 ;;     requires     olai/store.rkt (settling)
 
 (require racket/contract
+         racket/format
          racket/list
-         racket/path
          racket/string
          arch/churn
          arch/decl
@@ -33,7 +33,7 @@
           [explain (-> path? (listof scope?) (or/c churn? #f) path? string?)]))
 
 (define (explain module scopes history root)
-  (define (label p) (path-label p root))
+  (define label (make-labeller root))
   (define s (governing scopes module))
   (cond
     [(not s)
@@ -44,67 +44,67 @@
             "  put one beside it, or move the module into a package that has one")
       "\n")]
     [else
-     (define decl (declaration-for (scope-declaration s) (scope-relative s module)))
+     (define decl (effective-for s module))
+     (define over (effective-module decl))
      (string-join
       (append
        (list (format "~a" (label module))
              (row "governed by" (label (scope-file s)))
              (row "clock"
-                  (format "~a~a"
-                          (pad (format "~a" (effective-clock decl)) 19)
-                          (origin-of (effective-module decl)
-                                     (and (effective-module decl)
-                                          (module-decl-clock (effective-module decl)))
-                                     (effective-clock-loc decl)
-                                     label))))
-       (owns-rows decl label)
-       (concept-rows decl label)
+                  (said (format "~a" (effective-clock decl))
+                        (origin-of (and over (module-decl-clock over) over)
+                                   (effective-clock-loc decl) label))))
+       (rows "owns"
+             (for/list ([g (in-list (effective-grants decl))])
+               (said (format "~a~a" (grant-authority g) (spelling-note g))
+                     (origin-of (and (memq g (own-grants over)) over) (grant-loc g) label)))
+             #:empty "nothing")
+       (rows "concepts"
+             (for/list ([c (in-list (effective-claims decl))])
+               (said (format "~a ~a" (claim-concept c)
+                             (string-join (map (λ (g) (format "~s" g)) (claim-globs c)) " "))
+                     (loc-brief (claim-loc c) label))))
        (list (churn-row module decl history))
-       (requires-rows module scopes label))
+       (rows "requires" (dependency-lines module scopes label)
+             #:empty "nothing else that is declared"))
       "\n")]))
+
+;; The label sits on the first row and the rest hang under it — one shape for
+;; every column, including the empty case, which was three different
+;; conventions when each list built its own rows.
+(define (rows name values #:empty [empty #f])
+  (cond
+    [(and (null? values) empty) (list (row name empty))]
+    [else (for/list ([v (in-list values)] [i (in-naturals)])
+            (row (if (zero? i) name "") v))]))
 
 (define (row name value)
   (format "  ~a ~a" (pad name 12) value))
 
+;; A value and where it came from, in two columns.
+(define (said value origin)
+  (format "~a~a" (pad value 19) origin))
+
+;; Padded to a column, and always at least one space: a value that overflows
+;; its column still has to separate from the next one.
 (define (pad s n)
-  (string-append s (make-string (max 1 (- n (string-length s))) #\space)))
+  (~a s " " #:min-width n))
 
 ;; Which file said it, and whether it said it about this module or about the
-;; whole package.
-(define (origin-of over from-override? loc label)
-  (format "~a:~a ~a"
-          (label (srcloc-source loc)) (or (srcloc-line loc) "?")
-          (if (and over from-override?)
-              (format "(override ~s)" (module-decl-file over))
-              "(package default)")))
+;; whole package. `over` is the override to attribute it to, or #f — the two
+;; are one fact, and asking for them separately meant a reader had to check
+;; that the second could not contradict the first.
+(define (origin-of over loc label)
+  (format "~a ~a"
+          (loc-brief loc label)
+          (if over (format "(override ~s)" (module-decl-file over)) "(package default)")))
 
-(define (owns-rows decl label)
-  (define over (effective-module decl))
-  (define own (if over (module-decl-grants over) '()))
-  (define grants (effective-grants decl))
-  (cond
-    [(null? grants) (list (row "owns" "nothing"))]
-    [else
-     (for/list ([g (in-list grants)] [i (in-naturals)])
-       (row (if (zero? i) "owns" "")
-            (format "~a~a"
-                    (pad (format "~a~a" (grant-authority g) (spelling-note g)) 19)
-                    (origin-of over (memq g own) (grant-loc g) label))))]))
+(define (own-grants over) (if over (module-decl-grants over) '()))
 
 (define (spelling-note g)
   (if (null? (grant-spellings g))
       ""
       (format " (~a)" (string-join (grant-spellings g) ", "))))
-
-(define (concept-rows decl label)
-  (for/list ([c (in-list (effective-claims decl))] [i (in-naturals)])
-    (row (if (zero? i) "concepts" "")
-         (format "~a~a"
-                 (pad (format "~a ~a" (claim-concept c)
-                              (string-join (for/list ([g (in-list (claim-globs c))]) (format "~s" g)) " "))
-                      19)
-                 (format "~a:~a" (label (srcloc-source (claim-loc c)))
-                         (or (srcloc-line (claim-loc c)) "?"))))))
 
 (define (churn-row module decl history)
   (cond
@@ -122,18 +122,13 @@
 
 ;; What it depends on, inside the declared world, and at what clock — the other
 ;; half of "why is this edge legal".
-(define (requires-rows module scopes label)
-  (define deps
-    (sort
-     (remove-duplicates
-      (for*/list ([entry (in-list (source-requires (read-source module)))]
-                  [dep (in-value (car entry))]
-                  #:unless (equal? dep module)
-                  [d (in-value (declaration-of scopes dep))]
-                  #:when d)
-        (format "~a (~a)" (label dep) (effective-clock d))))
-     string<?))
-  (if (null? deps)
-      (list (row "requires" "nothing else that is declared"))
-      (for/list ([d (in-list deps)] [i (in-naturals)])
-        (row (if (zero? i) "requires" "") d))))
+(define (dependency-lines module scopes label)
+  (sort
+   (remove-duplicates
+    (for*/list ([entry (in-list (source-requires (read-source module)))]
+                [dep (in-value (car entry))]
+                #:unless (equal? dep module)
+                [s (in-value (governing scopes dep))]
+                #:when s)
+      (format "~a (~a)" (label dep) (effective-clock (effective-for s dep)))))
+   string<?))

--- a/arch/explain.rkt
+++ b/arch/explain.rkt
@@ -1,0 +1,140 @@
+#lang racket/base
+
+;; What one module's declaration comes to, after the package default and its
+;; own override.
+;;
+;; A declaration a reader cannot see through is a declaration they argue with
+;; from memory. The composition here is small — a clock replaced, two lists
+;; appended — and it is still two files away from the module it is about, so
+;; the dump is part of the interface and not a debugging convenience. Same
+;; reason `just expand` prints what a live form becomes.
+;;
+;;   $ just arch --explain olai/web/watch.rkt
+;;   olai/web/watch.rkt
+;;     governed by  olai/web/arch.rkt
+;;     clock        volatile           olai/web/arch.rkt:29 (package default)
+;;     owns         clock              olai/web/arch.rkt:44 (override "watch.rkt")
+;;                  filesystem-events  olai/web/arch.rkt:44 (override "watch.rkt")
+;;     churn        1 of the last 30 commits — volatile has no ceiling
+;;     requires     olai/store.rkt (settling)
+
+(require racket/contract
+         racket/list
+         racket/path
+         racket/string
+         arch/churn
+         arch/decl
+         arch/finding
+         arch/scope
+         arch/source
+         arch/vocabulary)
+
+(provide (contract-out
+          [explain (-> path? (listof scope?) (or/c churn? #f) path? string?)]))
+
+(define (explain module scopes history root)
+  (define (label p) (path-label p root))
+  (define s (governing scopes module))
+  (cond
+    [(not s)
+     (string-join
+      (list (format "~a" (label module))
+            "  governed by  nothing"
+            "  no arch.rkt sits above this module, so no check applies to it"
+            "  put one beside it, or move the module into a package that has one")
+      "\n")]
+    [else
+     (define decl (declaration-for (scope-declaration s) (scope-relative s module)))
+     (string-join
+      (append
+       (list (format "~a" (label module))
+             (row "governed by" (label (scope-file s)))
+             (row "clock"
+                  (format "~a~a"
+                          (pad (format "~a" (effective-clock decl)) 19)
+                          (origin-of (effective-module decl)
+                                     (and (effective-module decl)
+                                          (module-decl-clock (effective-module decl)))
+                                     (effective-clock-loc decl)
+                                     label))))
+       (owns-rows decl label)
+       (concept-rows decl label)
+       (list (churn-row module decl history))
+       (requires-rows module scopes label))
+      "\n")]))
+
+(define (row name value)
+  (format "  ~a ~a" (pad name 12) value))
+
+(define (pad s n)
+  (string-append s (make-string (max 1 (- n (string-length s))) #\space)))
+
+;; Which file said it, and whether it said it about this module or about the
+;; whole package.
+(define (origin-of over from-override? loc label)
+  (format "~a:~a ~a"
+          (label (srcloc-source loc)) (or (srcloc-line loc) "?")
+          (if (and over from-override?)
+              (format "(override ~s)" (module-decl-file over))
+              "(package default)")))
+
+(define (owns-rows decl label)
+  (define over (effective-module decl))
+  (define own (if over (module-decl-grants over) '()))
+  (define grants (effective-grants decl))
+  (cond
+    [(null? grants) (list (row "owns" "nothing"))]
+    [else
+     (for/list ([g (in-list grants)] [i (in-naturals)])
+       (row (if (zero? i) "owns" "")
+            (format "~a~a"
+                    (pad (format "~a~a" (grant-authority g) (spelling-note g)) 19)
+                    (origin-of over (memq g own) (grant-loc g) label))))]))
+
+(define (spelling-note g)
+  (if (null? (grant-spellings g))
+      ""
+      (format " (~a)" (string-join (grant-spellings g) ", "))))
+
+(define (concept-rows decl label)
+  (for/list ([c (in-list (effective-claims decl))] [i (in-naturals)])
+    (row (if (zero? i) "concepts" "")
+         (format "~a~a"
+                 (pad (format "~a ~a" (claim-concept c)
+                              (string-join (for/list ([g (in-list (claim-globs c))]) (format "~s" g)) " "))
+                      19)
+                 (format "~a:~a" (label (srcloc-source (claim-loc c)))
+                         (or (srcloc-line (claim-loc c)) "?"))))))
+
+(define (churn-row module decl history)
+  (define ceiling (clock-churn-ceiling (effective-clock decl)))
+  (cond
+    [(not history) (row "churn" "no git history here — the audit did not run")]
+    [else
+     (row "churn"
+          (format "~a of the last ~a commits — ~a"
+                  (churn-count history module)
+                  (churn-window history)
+                  (if ceiling
+                      (format "~a allows up to ~a"
+                              (effective-clock decl)
+                              (inexact->exact (floor (* ceiling (churn-window history)))))
+                      (format "~a has no ceiling" (effective-clock decl)))))]))
+
+;; What it depends on, inside the declared world, and at what clock — the other
+;; half of "why is this edge legal".
+(define (requires-rows module scopes label)
+  (define deps
+    (sort
+     (remove-duplicates
+      (for*/list ([entry (in-list (source-requires (read-source module)))]
+                  [dep (in-value (car entry))]
+                  #:unless (equal? dep module)
+                  [d (in-value (declaration-of scopes dep))]
+                  #:when d)
+        (format "~a (~a)" (label dep) (effective-clock d))))
+     string<?))
+  (if (null? deps)
+      (list (row "requires" "nothing else that is declared"))
+      (for/list ([d (in-list deps)] [i (in-naturals)])
+        (row (if (zero? i) "requires" "") d))))

--- a/arch/explain.rkt
+++ b/arch/explain.rkt
@@ -107,18 +107,17 @@
                          (or (srcloc-line (claim-loc c)) "?"))))))
 
 (define (churn-row module decl history)
-  (define ceiling (clock-churn-ceiling (effective-clock decl)))
   (cond
     [(not history) (row "churn" "no git history here — the audit did not run")]
     [else
+     (define window (churn-window history))
+     (define allowed (clock-allows (effective-clock decl) window))
      (row "churn"
           (format "~a of the last ~a commits — ~a"
                   (churn-count history module)
-                  (churn-window history)
-                  (if ceiling
-                      (format "~a allows up to ~a"
-                              (effective-clock decl)
-                              (inexact->exact (floor (* ceiling (churn-window history)))))
+                  window
+                  (if allowed
+                      (format "~a allows up to ~a" (effective-clock decl) allowed)
                       (format "~a has no ceiling" (effective-clock decl)))))]))
 
 ;; What it depends on, inside the declared world, and at what clock — the other

--- a/arch/facts.rkt
+++ b/arch/facts.rkt
@@ -17,7 +17,6 @@
 ;; here; neither module computes the other's answer.
 
 (require racket/contract
-         racket/list
          racket/set)
 
 (provide (contract-out
@@ -33,9 +32,13 @@
     (car e)))
 
 ;; Every name `path` exports, at every phase, whether it defined it or not.
-;; This is the set a requiring module gets to see.
+;; This is the set a requiring module gets to see — memoized like the export
+;; list it comes from, because the common answer is racket/base's fifteen
+;; hundred names and nine hundred require edges ask for it.
+(define names-cache (make-hash))
+
 (define (names-from path)
-  (list->seteq (map car (exports path))))
+  (hash-ref! names-cache path (λ () (list->seteq (map car (exports path))))))
 
 ;; ---- the module system ---------------------------------------------------------
 

--- a/arch/facts.rkt
+++ b/arch/facts.rkt
@@ -22,7 +22,6 @@
 
 (provide (contract-out
           [module-defines (-> path? (listof symbol?))]
-          [module-provides (-> path? (listof symbol?))]
           [names-from (-> path? set?)]))
 
 ;; Everything `path` provides that it also DEFINES — a re-export is somebody
@@ -33,13 +32,10 @@
   (for/list ([e (in-list (exports path))] #:when (null? (cadr e)))
     (car e)))
 
-(define (module-provides path)
-  (map car (exports path)))
-
 ;; Every name `path` exports, at every phase, whether it defined it or not.
 ;; This is the set a requiring module gets to see.
 (define (names-from path)
-  (list->seteq (module-provides path)))
+  (list->seteq (map car (exports path))))
 
 ;; ---- the module system ---------------------------------------------------------
 

--- a/arch/facts.rkt
+++ b/arch/facts.rkt
@@ -1,0 +1,58 @@
+#lang racket/base
+
+;; The two questions only a compiler can answer: what a module EXPORTS, and
+;; what names reach it from everything it requires.
+;;
+;; Both come off compiled modules — `(dynamic-require path #f)` declares a
+;; module without instantiating it, so nothing here runs anybody's code, opens
+;; anybody's port or starts anybody's thread. The whole tree costs about a
+;; second with `.zo` on disk, which is why `just arch` depends on `just build`
+;; the way `just test` does.
+;;
+;; Why not read `provide` and `require` out of the source instead: `(provide
+;; (struct-out task))` is nine names and `(provide (all-defined-out))` is
+;; however many there are today. A source reader would have to become a small
+;; expander to answer that, and would then be wrong in a different way from the
+;; real one. Locations come from the source (arch/source); names come from
+;; here; neither module computes the other's answer.
+
+(require racket/contract
+         racket/list
+         racket/set)
+
+(provide (contract-out
+          [module-defines (-> path? (listof symbol?))]
+          [module-provides (-> path? (listof symbol?))]
+          [names-from (-> path? set?)]))
+
+;; Everything `path` provides that it also DEFINES — a re-export is somebody
+;; else's name passing through, and a facade that re-exports the tree is not a
+;; second owner of everything in it. The module system says which is which: a
+;; locally defined export has no nominal source module beside it.
+(define (module-defines path)
+  (for/list ([e (in-list (exports path))] #:when (null? (cadr e)))
+    (car e)))
+
+(define (module-provides path)
+  (map car (exports path)))
+
+;; Every name `path` exports, at every phase, whether it defined it or not.
+;; This is the set a requiring module gets to see.
+(define (names-from path)
+  (list->seteq (module-provides path)))
+
+;; ---- the module system ---------------------------------------------------------
+
+;; Declared once per path per process. Two modules requiring racket/base ask
+;; the same question, and the answer is thousands of names.
+(define exports-cache (make-hash))
+
+(define (exports path)
+  (hash-ref! exports-cache
+             path
+             (λ ()
+               (dynamic-require path #f)
+               (define-values (vars stxs) (module->exports path))
+               (for*/list ([group (in-list (append vars stxs))]
+                           [e (in-list (cdr group))])
+                 (list (car e) (cadr e))))))

--- a/arch/finding.rkt
+++ b/arch/finding.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-;; What a violation looks like when it reaches somebody.
+;; What a violation looks like when it reaches somebody, and how a place is
+;; said.
 ;;
 ;; The shape is the house's, and it is the same one the outline language and
 ;; the live forms use: where, then the rule that was broken, then the facts
@@ -9,28 +10,36 @@
 ;; prose.
 ;;
 ;;   olai/lang/expander.rkt:14:10: requires olai/web/render.rkt: dependency points the wrong way
-;;     olai/lang/expander.rkt is stable (olai/lang/arch.rkt:2:0)
-;;     olai/web/render.rkt is volatile (olai/web/arch.rkt:2:0)
+;;     olai/lang/expander.rkt is stable (olai/lang/arch.rkt:2)
+;;     olai/web/render.rkt is volatile (olai/web/arch.rkt:2)
 ;;     stable code must not depend on volatile code — invert the edge or move the code
 ;;
 ;; Longer than you would write for a human, on purpose: the reader is usually
 ;; an agent, verbosity measurably raises its odds of fixing the right thing,
 ;; and nobody reads any of this when the check passes.
 ;;
-;; Paths print relative to the directory being checked. An absolute path in a
-;; message is a path that differs on every machine, and this output is read in
-;; a terminal, a CI log and a diff.
+;; Paths print relative to the directory being checked, and this module is the
+;; only place that knows how: `make-labeller` hands out the one function, and
+;; the checks and `--explain` both build their message lines with it. An
+;; absolute path in a message is a path that differs on every machine, and this
+;; output is read in a terminal, a CI log and a diff.
+;;
+;; Racket's own `srcloc->string` would do the first line, but only by
+;; parameterizing `current-directory-for-user` — an ambient read, in the tool
+;; whose whole job is to say where ambient reads are allowed. Six lines are
+;; cheaper than that joke.
 
 (require racket/contract
-         racket/list
-         racket/path
-         racket/string)
+         racket/path)
 
 (provide (struct-out finding)
          (contract-out
+          [make-labeller (-> path? labeller/c)]
           [finding->string (-> finding? path? string?)]
-          [loc->string (-> (or/c srcloc? #f) path? string?)]
-          [path-label (-> (or/c path? string? #f) path? string?)]))
+          [loc-brief (-> (or/c srcloc? #f) labeller/c string?)]))
+
+;; How a path is said inside a message.
+(define labeller/c (-> (or/c path? string? #f) string?))
 
 ;; loc  : where the OFFENDING form is — the require spec, the identifier, the
 ;;        clock word. Never the module as a whole when something smaller is
@@ -39,25 +48,32 @@
 ;; why  : the facts, one per line
 (struct finding (loc rule why) #:transparent)
 
+(define (make-labeller root)
+  (define here (simple-form-path root))
+  (λ (p)
+    (cond
+      [(not p) "?"]
+      [else
+       (define full (simple-form-path (if (path? p) p (string->path (format "~a" p)))))
+       (define rel (find-relative-path here full))
+       (path->string (if (relative-path? rel) rel full))])))
+
 (define (finding->string f root)
-  (string-join
-   (cons (format "~a: ~a" (loc->string (finding-loc f) root) (finding-rule f))
-         (for/list ([l (in-list (finding-why f))]) (string-append "  " l)))
-   "\n"))
+  (define label (make-labeller root))
+  (apply string-append
+         (format "~a: ~a" (loc-full (finding-loc f) label) (finding-rule f))
+         (for/list ([l (in-list (finding-why f))]) (string-append "\n  " l))))
 
-(define (loc->string loc root)
-  (cond
-    [(not loc) "arch"]
-    [else
-     (format "~a:~a:~a"
-             (path-label (srcloc-source loc) root)
-             (or (srcloc-line loc) "?")
-             (or (srcloc-column loc) 0))]))
+;; file:line:col — the line an editor jumps to.
+(define (loc-full loc label)
+  (if loc
+      (format "~a:~a:~a" (label (srcloc-source loc)) (or (srcloc-line loc) "?")
+              (or (srcloc-column loc) 0))
+      "arch"))
 
-(define (path-label p root)
-  (cond
-    [(not p) "?"]
-    [else
-     (define full (if (path? p) p (string->path (format "~a" p))))
-     (define rel (find-relative-path (simple-form-path root) (simple-form-path full)))
-     (path->string (if (relative-path? rel) rel full))]))
+;; file:line — enough to find a declaration that a message is quoting, inside
+;; a line that is already saying something else.
+(define (loc-brief loc label)
+  (if loc
+      (format "~a:~a" (label (srcloc-source loc)) (or (srcloc-line loc) "?"))
+      "?"))

--- a/arch/finding.rkt
+++ b/arch/finding.rkt
@@ -1,0 +1,63 @@
+#lang racket/base
+
+;; What a violation looks like when it reaches somebody.
+;;
+;; The shape is the house's, and it is the same one the outline language and
+;; the live forms use: where, then the rule that was broken, then the facts
+;; that make it a rule, then what to do about it. Every line after the first is
+;; indented, so a wall of them still reads as a list of problems and not as
+;; prose.
+;;
+;;   olai/lang/expander.rkt:14:10: requires olai/web/render.rkt: dependency points the wrong way
+;;     olai/lang/expander.rkt is stable (olai/lang/arch.rkt:2:0)
+;;     olai/web/render.rkt is volatile (olai/web/arch.rkt:2:0)
+;;     stable code must not depend on volatile code — invert the edge or move the code
+;;
+;; Longer than you would write for a human, on purpose: the reader is usually
+;; an agent, verbosity measurably raises its odds of fixing the right thing,
+;; and nobody reads any of this when the check passes.
+;;
+;; Paths print relative to the directory being checked. An absolute path in a
+;; message is a path that differs on every machine, and this output is read in
+;; a terminal, a CI log and a diff.
+
+(require racket/contract
+         racket/list
+         racket/path
+         racket/string)
+
+(provide (struct-out finding)
+         (contract-out
+          [finding->string (-> finding? path? string?)]
+          [loc->string (-> (or/c srcloc? #f) path? string?)]
+          [path-label (-> (or/c path? string? #f) path? string?)]))
+
+;; loc  : where the OFFENDING form is — the require spec, the identifier, the
+;;        clock word. Never the module as a whole when something smaller is
+;;        wrong.
+;; rule : one line, the headline
+;; why  : the facts, one per line
+(struct finding (loc rule why) #:transparent)
+
+(define (finding->string f root)
+  (string-join
+   (cons (format "~a: ~a" (loc->string (finding-loc f) root) (finding-rule f))
+         (for/list ([l (in-list (finding-why f))]) (string-append "  " l)))
+   "\n"))
+
+(define (loc->string loc root)
+  (cond
+    [(not loc) "arch"]
+    [else
+     (format "~a:~a:~a"
+             (path-label (srcloc-source loc) root)
+             (or (srcloc-line loc) "?")
+             (or (srcloc-column loc) 0))]))
+
+(define (path-label p root)
+  (cond
+    [(not p) "?"]
+    [else
+     (define full (if (path? p) p (string->path (format "~a" p))))
+     (define rel (find-relative-path (simple-form-path root) (simple-form-path full)))
+     (path->string (if (relative-path? rel) rel full))]))

--- a/arch/info.rkt
+++ b/arch/info.rkt
@@ -1,0 +1,12 @@
+#lang info
+
+(define collection "arch")
+;; Nothing. The checker reads source, compiled modules and `git log`, and all
+;; three come with the distribution — a tool that tells a repo what it may
+;; depend on has no business growing dependencies of its own.
+(define deps '("base"))
+(define build-deps '("rackunit-lib"))
+(define pkg-desc "#lang arch: a package's architecture as data, and the checker that holds it to it")
+(define version "0.1")
+(define pkg-authors '(srid))
+(define license 'AGPL-3.0-or-later)

--- a/arch/lang/reader.rkt
+++ b/arch/lang/reader.rkt
@@ -1,0 +1,2 @@
+#lang s-exp syntax/module-reader
+arch/expander

--- a/arch/main.rkt
+++ b/arch/main.rkt
@@ -16,9 +16,7 @@
 ;; about itself, 1 when it does not.
 
 (require racket/cmdline
-         racket/list
          racket/path
-         racket/string
          arch/check
          arch/churn
          arch/explain
@@ -44,7 +42,7 @@
   (exit (if target (run-explain here target window) (run-check here window))))
 
 (define (run-explain root file window)
-  (define scopes (find-scopes root))
+  (define-values (scopes _governed) (survey root))
   (displayln (explain (path->complete-path (simplify-path (string->path file)))
                       scopes
                       (read-churn root window)

--- a/arch/main.rkt
+++ b/arch/main.rkt
@@ -26,7 +26,7 @@
          arch/scope)
 
 (module+ main
-  (define window 30)
+  (define window default-churn-window)
   (define target #f)
   (define root
     (command-line

--- a/arch/main.rkt
+++ b/arch/main.rkt
@@ -1,0 +1,73 @@
+#lang racket/base
+
+;; `just arch` — the checker, from a terminal.
+;;
+;;   just arch                              check the tree
+;;   just arch --explain olai/web/watch.rkt one module's effective declaration
+;;   just arch --window 60                  audit a longer stretch of history
+;;
+;; Plain text, not JSON, and deliberately: this is a developer tool in the same
+;; family as `just expand`, its whole output is a rule and how to satisfy it,
+;; and the reader — human or agent — wants the sentence, not a field. The olai
+;; CLI is the surface that answers in JSON, because it is the one with a
+;; contract.
+;;
+;; Exit status is the contract here: 0 when the tree agrees with what it says
+;; about itself, 1 when it does not.
+
+(require racket/cmdline
+         racket/list
+         racket/path
+         racket/string
+         arch/check
+         arch/churn
+         arch/explain
+         arch/finding
+         arch/scope)
+
+(module+ main
+  (define window 30)
+  (define target #f)
+  (define root
+    (command-line
+     #:program "arch"
+     #:once-each
+     [("--explain") file "Print one module's effective declaration and stop"
+                    (set! target file)]
+     [("--window") n "Commits of history the churn audit reads (default 30)"
+                   (set! window (string->number n))]
+     #:args ([dir "."])
+     dir))
+  (unless (and (exact-integer? window) (positive? window))
+    (raise-user-error 'arch "--window takes a positive number of commits"))
+  (define here (simple-form-path (string->path root)))
+  (exit (if target (run-explain here target window) (run-check here window))))
+
+(define (run-explain root file window)
+  (define scopes (find-scopes root))
+  (displayln (explain (path->complete-path (simplify-path (string->path file)))
+                      scopes
+                      (read-churn root window)
+                      root))
+  0)
+
+(define (run-check root window)
+  (define r (audit root #:window window))
+  (for ([f (in-list (report-findings r))])
+    (displayln (finding->string f root))
+    (newline))
+  (for ([n (in-list (report-notes r))])
+    (eprintf "arch: ~a\n" n))
+  (define modules (length (report-sites r)))
+  (define packages (length (report-scopes r)))
+  (cond
+    [(null? (report-findings r))
+     (printf "arch: ~a modules in ~a declared packages — the tree agrees with itself\n"
+             modules packages)
+     0]
+    [else
+     (printf "arch: ~a finding~a across ~a modules in ~a declared packages\n"
+             (length (report-findings r))
+             (if (= 1 (length (report-findings r))) "" "s")
+             modules packages)
+     1]))

--- a/arch/scope.rkt
+++ b/arch/scope.rkt
@@ -24,6 +24,7 @@
          (contract-out
           [find-scopes (-> path? (listof scope?))]
           [governing (-> (listof scope?) path? (or/c scope? #f))]
+          [scope-covers? (-> scope? path? boolean?)]
           [scope-modules (-> scope? (listof scope?) (listof path?))]
           [declaration-of (-> (listof scope?) path? (or/c effective? #f))]
           [scope-relative (-> scope? path? string?)]))
@@ -61,10 +62,13 @@
 ;; deepest-first, so this is the first hit.
 (define (governing scopes path)
   (define target (simplify-path path))
-  (for/first ([s (in-list scopes)] #:when (under? (scope-dir s) target)) s))
+  (for/first ([s (in-list scopes)] #:when (scope-covers? s target)) s))
 
-(define (under? dir path)
-  (define rel (find-relative-path dir path))
+;; Does this declaration sit above that path? Exported because check 3 asks the
+;; same question of a package-level concept — "is this module inside the scope
+;; that claimed it" — and two spellings of "under" is one too many.
+(define (scope-covers? s path)
+  (define rel (find-relative-path (scope-dir s) (simplify-path path)))
   (and (relative-path? rel) (not (string-prefix? (path->string rel) ".."))))
 
 ;; Every module this scope actually governs: the .rkt files beneath it that no

--- a/arch/scope.rkt
+++ b/arch/scope.rkt
@@ -7,6 +7,12 @@
 ;; and nothing has to say so twice. Deepest wins, which is the rule a reader
 ;; already assumes from where the file sits.
 ;;
+;; `survey` is one walk down the tree carrying the nearest declaration with it,
+;; so a module is assigned as it is met rather than looked up afterwards
+;; against every scope in the repo. That is why there is no `in-directory`
+;; here: the walk has to see a directory's own `arch.rkt` before it descends
+;; into it, and a sequence hands out the files with nothing carried down.
+;;
 ;; A module with no `arch.rkt` above it is not governed and not checked. That
 ;; is a hole with a shape: it can only be opened by MOVING a module out of a
 ;; declared package or by DELETING a declaration, and both are lines in a diff
@@ -22,82 +28,70 @@
 
 (provide (struct-out scope)
          (contract-out
-          [find-scopes (-> path? (listof scope?))]
+          [survey (-> path? (values (listof scope?) (listof (cons/c scope? path?))))]
           [governing (-> (listof scope?) path? (or/c scope? #f))]
           [scope-covers? (-> scope? path? boolean?)]
-          [scope-modules (-> scope? (listof scope?) (listof path?))]
-          [declaration-of (-> (listof scope?) path? (or/c effective? #f))]
-          [scope-relative (-> scope? path? string?)]))
+          [effective-for (-> scope? path? effective?)]))
 
 ;; dir         : the directory the declaration governs, as a directory path
 ;; file        : the arch.rkt itself
 ;; declaration : its scope-decl
 (struct scope (dir file declaration) #:transparent)
 
-;; Every arch.rkt under `root`, loaded. `compiled` and hidden directories are
-;; skipped: one holds bytecode and the other holds tooling, and neither is
-;; anybody's architecture.
-(define (find-scopes root)
-  (sort
-   (for/list ([p (in-list (arch-files (simple-form-path root)))])
-     (scope (path-only p) p (dynamic-require p 'declaration)))
-   >
-   #:key (λ (s) (string-length (path->string (scope-dir s))))))
+;; Every declaration under `root`, and every module each one governs. One walk:
+;; a directory's own arch.rkt becomes the nearest declaration for everything
+;; below it, and a module is assigned to whatever that is when the walk reaches
+;; it. `compiled` and hidden directories are skipped — one holds bytecode and
+;; the other holds tooling, and neither is anybody's architecture.
+(define (survey root)
+  (define scopes '())
+  (define modules '())
+  (let walk ([dir (simple-form-path root)] [nearest #f])
+    (define entries (sort (directory-list dir #:build? #t) path<?))
+    (define here
+      (cond
+        [(for/first ([e (in-list entries)] #:when (declaration-file? e)) e)
+         => (λ (file)
+              (define s (scope dir (simplify-path file) (dynamic-require file 'declaration)))
+              (set! scopes (cons s scopes))
+              s)]
+        [else nearest]))
+    (for ([e (in-list entries)])
+      (define name (path->string (file-name-from-path e)))
+      (cond
+        [(directory-exists? e)
+         (unless (or (string=? name "compiled") (string-prefix? name "."))
+           (walk e here))]
+        [(and here (string-suffix? name ".rkt") (not (string=? name "arch.rkt")))
+         (set! modules (cons (cons here (simplify-path e)) modules))]
+        [else (void)])))
+  (values (reverse scopes) (reverse modules)))
 
-(define (arch-files root)
-  (let walk ([dir root])
-    (append*
-     (for/list ([entry (in-list (directory-list dir #:build? #t))])
-       (cond
-         [(directory-exists? entry)
-          (define name (path->string (file-name-from-path entry)))
-          (if (or (string=? name "compiled") (string-prefix? name "."))
-              '()
-              (walk entry))]
-         [(equal? "arch.rkt" (path->string (file-name-from-path entry)))
-          (list (simplify-path entry))]
-         [else '()])))))
+(define (declaration-file? entry)
+  (and (not (directory-exists? entry))
+       (equal? "arch.rkt" (path->string (file-name-from-path entry)))))
 
-;; The deepest scope whose directory contains `path`. `find-scopes` sorts
-;; deepest-first, so this is the first hit.
+;; The deepest scope whose directory contains `path` — for the one caller that
+;; has a module and no walk to hang it off, `--explain`.
 (define (governing scopes path)
-  (define target (simplify-path path))
-  (for/first ([s (in-list scopes)] #:when (scope-covers? s target)) s))
+  (for/fold ([best #f]) ([s (in-list scopes)] #:when (scope-covers? s path))
+    (if (and best (> (depth (scope-dir best)) (depth (scope-dir s)))) best s)))
 
-;; Does this declaration sit above that path? Exported because check 3 asks the
-;; same question of a package-level concept — "is this module inside the scope
-;; that claimed it" — and two spellings of "under" is one too many.
+(define (depth dir) (length (explode-path dir)))
+
+;; Does this declaration sit above that path? Check 3 asks the same question of
+;; a package-level concept — "is this module inside the scope that claimed it"
+;; — and two spellings of "under" is one too many.
 (define (scope-covers? s path)
   (define rel (find-relative-path (scope-dir s) (simplify-path path)))
   (and (relative-path? rel) (not (string-prefix? (path->string rel) ".."))))
 
-;; Every module this scope actually governs: the .rkt files beneath it that no
-;; deeper scope has taken, minus the declarations themselves.
-(define (scope-modules s scopes)
-  (sort
-   (let walk ([dir (scope-dir s)])
-     (append*
-      (for/list ([entry (in-list (directory-list dir #:build? #t))])
-        (define name (path->string (file-name-from-path entry)))
-        (cond
-          [(directory-exists? entry)
-           (if (or (string=? name "compiled") (string-prefix? name "."))
-               '()
-               (walk entry))]
-          [(not (string-suffix? name ".rkt")) '()]
-          [(string=? name "arch.rkt") '()]
-          [(eq? s (governing scopes entry)) (list (simplify-path entry))]
-          [else '()]))))
-   string<?
-   #:key path->string))
-
-;; The one answer a check asks for: what does this module say about itself,
-;; after its package's defaults and its own override.
-(define (declaration-of scopes path)
-  (define s (governing scopes path))
-  (and s (declaration-for (scope-declaration s) (scope-relative s path))))
-
-;; How an override names this module: its path relative to the arch.rkt, in
-;; unix spelling, which is what somebody types into the declaration.
-(define (scope-relative s path)
-  (path->string (find-relative-path (scope-dir s) (simplify-path path))))
+;; The one answer a check asks for: what this scope says about that module,
+;; after its defaults and the module's own override. Every caller goes through
+;; here, so "effective declaration" is composed in one place AND asked for in
+;; one way.
+(define (effective-for s path)
+  (declaration-for (scope-declaration s)
+                   ;; how an override names it: relative to the arch.rkt, in
+                   ;; the spelling somebody types into the declaration
+                   (path->string (find-relative-path (scope-dir s) (simplify-path path)))))

--- a/arch/scope.rkt
+++ b/arch/scope.rkt
@@ -1,0 +1,99 @@
+#lang racket/base
+
+;; Which declaration governs which module.
+;;
+;; An `arch.rkt` governs every `.rkt` beneath it, down to the next `arch.rkt`:
+;; `olai/web/serve.rkt` answers to `olai/web/arch.rkt`, not to `olai/arch.rkt`,
+;; and nothing has to say so twice. Deepest wins, which is the rule a reader
+;; already assumes from where the file sits.
+;;
+;; A module with no `arch.rkt` above it is not governed and not checked. That
+;; is a hole with a shape: it can only be opened by MOVING a module out of a
+;; declared package or by DELETING a declaration, and both are lines in a diff
+;; somebody reviews. Silence is what the checker refuses; absence, out loud, it
+;; can live with. It is also what keeps installed packages under the tree —
+;; a `.plt-user` full of somebody else's Racket — from being architecture.
+
+(require racket/contract
+         racket/list
+         racket/path
+         racket/string
+         arch/decl)
+
+(provide (struct-out scope)
+         (contract-out
+          [find-scopes (-> path? (listof scope?))]
+          [governing (-> (listof scope?) path? (or/c scope? #f))]
+          [scope-modules (-> scope? (listof scope?) (listof path?))]
+          [declaration-of (-> (listof scope?) path? (or/c effective? #f))]
+          [scope-relative (-> scope? path? string?)]))
+
+;; dir         : the directory the declaration governs, as a directory path
+;; file        : the arch.rkt itself
+;; declaration : its scope-decl
+(struct scope (dir file declaration) #:transparent)
+
+;; Every arch.rkt under `root`, loaded. `compiled` and hidden directories are
+;; skipped: one holds bytecode and the other holds tooling, and neither is
+;; anybody's architecture.
+(define (find-scopes root)
+  (sort
+   (for/list ([p (in-list (arch-files (simple-form-path root)))])
+     (scope (path-only p) p (dynamic-require p 'declaration)))
+   >
+   #:key (λ (s) (string-length (path->string (scope-dir s))))))
+
+(define (arch-files root)
+  (let walk ([dir root])
+    (append*
+     (for/list ([entry (in-list (directory-list dir #:build? #t))])
+       (cond
+         [(directory-exists? entry)
+          (define name (path->string (file-name-from-path entry)))
+          (if (or (string=? name "compiled") (string-prefix? name "."))
+              '()
+              (walk entry))]
+         [(equal? "arch.rkt" (path->string (file-name-from-path entry)))
+          (list (simplify-path entry))]
+         [else '()])))))
+
+;; The deepest scope whose directory contains `path`. `find-scopes` sorts
+;; deepest-first, so this is the first hit.
+(define (governing scopes path)
+  (define target (simplify-path path))
+  (for/first ([s (in-list scopes)] #:when (under? (scope-dir s) target)) s))
+
+(define (under? dir path)
+  (define rel (find-relative-path dir path))
+  (and (relative-path? rel) (not (string-prefix? (path->string rel) ".."))))
+
+;; Every module this scope actually governs: the .rkt files beneath it that no
+;; deeper scope has taken, minus the declarations themselves.
+(define (scope-modules s scopes)
+  (sort
+   (let walk ([dir (scope-dir s)])
+     (append*
+      (for/list ([entry (in-list (directory-list dir #:build? #t))])
+        (define name (path->string (file-name-from-path entry)))
+        (cond
+          [(directory-exists? entry)
+           (if (or (string=? name "compiled") (string-prefix? name "."))
+               '()
+               (walk entry))]
+          [(not (string-suffix? name ".rkt")) '()]
+          [(string=? name "arch.rkt") '()]
+          [(eq? s (governing scopes entry)) (list (simplify-path entry))]
+          [else '()]))))
+   string<?
+   #:key path->string))
+
+;; The one answer a check asks for: what does this module say about itself,
+;; after its package's defaults and its own override.
+(define (declaration-of scopes path)
+  (define s (governing scopes path))
+  (and s (declaration-for (scope-declaration s) (scope-relative s path))))
+
+;; How an override names this module: its path relative to the arch.rkt, in
+;; unix spelling, which is what somebody types into the declaration.
+(define (scope-relative s path)
+  (path->string (find-relative-path (scope-dir s) (simplify-path path))))

--- a/arch/source.rkt
+++ b/arch/source.rkt
@@ -37,22 +37,19 @@
           [source-where (-> source? symbol? (or/c srcloc? #f))]))
 
 ;; path        : the module, absolute and simplified
-;; lang        : the resolved path of its #lang, or #f when that is not a file
-;;               (racket/base and friends resolve to files too — everything
-;;               outside the tree is dropped by the caller, not here)
-;; requires    : (listof (cons path srcloc)) — resolved, in source order
+;; requires    : (listof (cons path srcloc)) — resolved, in source order, the
+;;               #lang first: it is a dependency like any other, and the one
+;;               every module has
 ;; definitions : (hash symbol srcloc)
 ;; mentions    : (hash symbol srcloc), first occurrence
-(struct source (path lang requires definitions mentions) #:transparent)
+(struct source (path requires definitions mentions) #:transparent)
 
 (define (read-source path)
   (define-values (lang-stx body) (module-parts (read-module path)))
-  ;; The #lang is a dependency like any other, and the one every module has.
-  ;; It is listed first so a message about it points at the first line, which
-  ;; is where it is written.
+  ;; The #lang goes in with the requires, first, so a message about it points
+  ;; at the first line — which is where it is written.
   (define lang (and lang-stx (resolve-quietly lang-stx path)))
   (source (simplify-path path)
-          lang
           (append (if lang (list (cons lang (loc-of lang-stx))) '())
                   (append* (for/list ([form (in-list body)]) (requires-in form path))))
           (definitions-of body)

--- a/arch/source.rkt
+++ b/arch/source.rkt
@@ -1,0 +1,249 @@
+#lang racket/base
+
+;; A module as its SOURCE says it — read, never expanded.
+;;
+;; Three things come out of one read, and each one is a place a message has to
+;; be able to point at:
+;;
+;;   requires    what this module says it depends on, resolved to paths, with
+;;               the srcloc of the require spec that said it
+;;   definitions what it defines, by name, with where
+;;   mentions    every identifier it writes down, with where it first appears
+;;
+;; Reading rather than expanding is a decision about COST: `just arch` has to
+;; live in the edit loop beside `just check`, and expanding this tree takes
+;; tens of seconds. It is also a decision about MEANING — an architecture check
+;; is about what a module says it depends on, not about what a macro it uses
+;; happened to pull in behind it.
+;;
+;; What it costs: a dependency introduced only by a macro is invisible here.
+;; That is the honest trade, and it is the same one a reader makes.
+;;
+;; The names come from the module system instead (arch/facts): what a module
+;; EXPORTS and what it IMPORTS are questions only a compiler can answer, and
+;; asking a compiled module is cheap. Locations are this file's; names are that
+;; one's; nothing computes both.
+
+(require racket/contract
+         racket/list
+         racket/path
+         racket/string
+         syntax/modread
+         syntax/modresolve)
+
+(provide (struct-out source)
+         (contract-out
+          [read-source (-> path? source?)]
+          [source-where (-> source? symbol? (or/c srcloc? #f))]))
+
+;; path        : the module, absolute and simplified
+;; lang        : the resolved path of its #lang, or #f when that is not a file
+;;               (racket/base and friends resolve to files too — everything
+;;               outside the tree is dropped by the caller, not here)
+;; requires    : (listof (cons path srcloc)) — resolved, in source order
+;; definitions : (hash symbol srcloc)
+;; mentions    : (hash symbol srcloc), first occurrence
+(struct source (path lang requires definitions mentions) #:transparent)
+
+(define (read-source path)
+  (define-values (lang-stx body) (module-parts (read-module path)))
+  ;; The #lang is a dependency like any other, and the one every module has.
+  ;; It is listed first so a message about it points at the first line, which
+  ;; is where it is written.
+  (define lang (and lang-stx (resolve-quietly lang-stx path)))
+  (source (simplify-path path)
+          lang
+          (append (if lang (list (cons lang (loc-of lang-stx))) '())
+                  (append* (for/list ([form (in-list body)]) (requires-in form path))))
+          (definitions-of body)
+          (mentions-of body)))
+
+;; Where a name is written in this module: its definition if it has one, else
+;; the struct it comes off (an accessor is defined by the `struct` form and
+;; appears nowhere by that name), else nothing.
+(define (source-where src name)
+  (define defs (source-definitions src))
+  (or (hash-ref defs name #f)
+      (for/or ([(defined loc) (in-hash defs)])
+        (define d (symbol->string defined))
+        (define n (symbol->string name))
+        (and (or (string-prefix? n (string-append d "-"))
+                 (string=? n (string-append d "?"))
+                 (string=? n (string-append "make-" d))
+                 (string=? n (string-append "struct:" d)))
+             loc))))
+
+;; ---- reading -----------------------------------------------------------------
+
+(define (read-module path)
+  (parameterize ([read-accept-reader #t]
+                 [read-accept-lang #t])
+    (with-module-reading-parameterization
+     (λ ()
+       (call-with-input-file path
+         (λ (in)
+           (port-count-lines! in)
+           (read-syntax path in)))))))
+
+;; (module name lang body ...) — and the body is sometimes already wrapped in a
+;; #%module-begin, which is what a `#lang` built on syntax/module-reader hands
+;; back.
+(define (module-parts stx)
+  (define e (syntax->list stx))
+  (cond
+    [(and e (>= (length e) 3))
+     (define lang (caddr e))
+     (define rest (cdddr e))
+     (values lang
+             (if (and (= 1 (length rest)) (module-begin-form? (car rest)))
+                 (cdr (syntax->list (car rest)))
+                 rest))]
+    [else (values #f '())]))
+
+(define (module-begin-form? stx)
+  (define e (and (pair? (syntax-e stx)) (syntax-e (car (syntax-e stx)))))
+  (eq? e '#%module-begin))
+
+;; ---- requires ------------------------------------------------------------------
+
+;; The require-spec grammar, as far as this tree writes it. An unknown form is
+;; an ERROR and not a shrug: a spec the checker cannot read is a dependency it
+;; cannot see, and a check with an invisible hole in it is worse than no check.
+(define (requires-in form path)
+  (define e (syntax->list form))
+  (cond
+    [(and e (pair? e) (memq (syntax-e (car e)) '(require)))
+     (append* (for/list ([spec (in-list (cdr e))]) (spec-targets spec path)))]
+    ;; requires nested in a submodule or a begin-for-syntax are this module's
+    ;; too — they are what it needs in order to be itself.
+    [(and e (pair? e) (memq (syntax-e (car e)) '(begin begin-for-syntax module module* module+)))
+     (append* (for/list ([f (in-list (cdr e))]) (requires-in f path)))]
+    [else '()]))
+
+(define (spec-targets spec path)
+  (define e (and (pair? (syntax-e spec)) (syntax->list spec)))
+  (define head (and e (pair? e) (identifier? (car e)) (syntax-e (car e))))
+  (cond
+    ;; a bare collection path, or a string beside this file
+    [(or (identifier? spec) (string? (syntax-e spec)))
+     (define resolved (resolve-quietly spec path))
+     (if resolved (list (cons resolved (loc-of spec))) '())]
+    ;; the phase shifts and the name filters: what they wrap is the dependency
+    [(memq head '(for-syntax for-template for-label combine-in))
+     (append* (for/list ([s (in-list (cdr e))]) (spec-targets s path)))]
+    [(memq head '(for-meta only-meta-in))
+     (append* (for/list ([s (in-list (cddr e))]) (spec-targets s path)))]
+    [(memq head '(only-in except-in rename-in relative-in))
+     (spec-targets (cadr e) path)]
+    [(eq? head 'prefix-in)
+     (spec-targets (caddr e) path)]
+    ;; (submod "file.rkt" test) depends on the file; (submod "." test) on
+    ;; nothing outside this module
+    [(eq? head 'submod)
+     (if (member (syntax-e (cadr e)) '("." ".."))
+         '()
+         (spec-targets (cadr e) path))]
+    [(memq head '(file lib planet quote))
+     (define resolved (resolve-quietly spec path))
+     (if resolved (list (cons resolved (loc-of spec))) '())]
+    [else
+     (error 'arch
+            (string-append
+             "unreadable require form\n"
+             "  ~a:~a:~a\n"
+             "  the checker reads require specs itself, and does not know this one: ~s\n"
+             "  teach arch/source.rkt the form, or spell the require a way it knows")
+            path (or (syntax-line spec) "?") (or (syntax-column spec) "?")
+            (syntax->datum spec))]))
+
+;; A spec that names something not installed resolves to nothing; that is a
+;; problem for the compiler, not for a layering check.
+(define (resolve-quietly spec path)
+  (with-handlers ([exn:fail? (λ (_e) #f)])
+    (define r (resolve-module-path (syntax->datum spec) path))
+    (and (path? r) (simplify-path r))))
+
+;; ---- definitions and mentions ---------------------------------------------------
+
+(define definer-rx #px"^(define|struct)")
+
+(define (definitions-of body)
+  (define out (make-hasheq))
+  (define (record! name-stx loc)
+    (when (and (identifier? name-stx) (not (hash-has-key? out (syntax-e name-stx))))
+      (hash-set! out (syntax-e name-stx) loc)))
+  (let walk ([forms body])
+    (for ([form (in-list forms)])
+      (define e (and (pair? (syntax-e form)) (syntax->list form)))
+      (when (and e (>= (length e) 2) (identifier? (car e)))
+        (define head (symbol->string (syntax-e (car e))))
+        (when (regexp-match? definer-rx head)
+          (define target (cadr e))
+          (cond
+            ;; (define (name arg ...) ...) and (define ((name a) b) ...)
+            [(pair? (syntax-e target))
+             (let dig ([t target])
+               (if (pair? (syntax-e t)) (dig (car (syntax-e t))) (record! t (loc-of form))))]
+            [else (record! target (loc-of form))]))
+        (walk (cdr e)))))
+  out)
+
+;; Every identifier the module CALLS, and where it first calls it.
+;;
+;; Called, not merely written: an authority is a power a module exercises, and
+;; a module exercises it by putting the name in operator position — `(today)`,
+;; `(file-exists? p)`, `(thread proc)`, `[current-directory dir]` inside a
+;; `parameterize`. The name appearing anywhere else is usually the opposite of
+;; using it: `(define (agenda-groups tasks today) ...)` is a function that takes
+;; the day as an argument, which is the thing the rule is FOR, and counting
+;; that as a clock read would have made the rule punish the code that obeys it.
+;;
+;; `(apply subprocess #f #f #f cmd args)` is a call with a word in front of it,
+;; so the word after `apply` counts too.
+;;
+;; What it misses: a spelling handed somewhere as a value — `(map file-exists?
+;; ps)`. Nothing in this tree does that with an authority, and the alternative
+;; is a scope analysis, which is an expander, which is the cost this whole file
+;; exists to avoid.
+;;
+;; Quoted data is skipped either way: `'(today now)` is a list of two symbols,
+;; and the module that tabulates authority spellings would otherwise look like
+;; the one module that uses every authority there is.
+(define (mentions-of body)
+  (define out (make-hasheq))
+  (define (record! s)
+    (when (and (syntax? s) (symbol? (syntax-e s)) (not (hash-has-key? out (syntax-e s))))
+      (hash-set! out (syntax-e s) (loc-of s))))
+  (let walk ([s body])
+    (cond
+      [(list? s) (for-each walk s)]
+      [(not (syntax? s)) (void)]
+      [(quoted? s) (void)]
+      [else
+       (define e (syntax-e s))
+       (cond
+         [(pair? e)
+          (define parts (syntax->list s))
+          (record! (car e))
+          (when (and parts
+                     (>= (length parts) 2)
+                     (identifier? (car parts))
+                     (eq? 'apply (syntax-e (car parts))))
+            (record! (cadr parts)))
+          (walk (car e))
+          (walk (cdr e))]
+         [(vector? e) (for-each walk (vector->list e))]
+         [(box? e) (walk (unbox e))]
+         [else (void)])]))
+  out)
+
+(define (quoted? stx)
+  (define e (syntax-e stx))
+  (and (pair? e)
+       (identifier? (car e))
+       (memq (syntax-e (car e)) '(quote quote-syntax))
+       #t))
+
+(define (loc-of stx)
+  (srcloc (syntax-source stx) (syntax-line stx) (syntax-column stx)
+          (syntax-position stx) (syntax-span stx)))

--- a/arch/source.rkt
+++ b/arch/source.rkt
@@ -28,8 +28,10 @@
          racket/list
          racket/path
          racket/string
+         racket/set
          syntax/modread
-         syntax/modresolve)
+         syntax/modresolve
+         syntax/srcloc)
 
 (provide (struct-out source)
          (contract-out
@@ -55,20 +57,12 @@
           (definitions-of body)
           (mentions-of body)))
 
-;; Where a name is written in this module: its definition if it has one, else
-;; the struct it comes off (an accessor is defined by the `struct` form and
-;; appears nowhere by that name), else nothing.
+;; Where a name is written in this module, or #f. A struct's accessors appear
+;; nowhere by their own name, so the `struct` form records them as it is read
+;; — which is why this is a lookup and not a second guess at the same naming
+;; rule, run backwards.
 (define (source-where src name)
-  (define defs (source-definitions src))
-  (or (hash-ref defs name #f)
-      (for/or ([(defined loc) (in-hash defs)])
-        (define d (symbol->string defined))
-        (define n (symbol->string name))
-        (and (or (string-prefix? n (string-append d "-"))
-                 (string=? n (string-append d "?"))
-                 (string=? n (string-append "make-" d))
-                 (string=? n (string-append "struct:" d)))
-             loc))))
+  (hash-ref (source-definitions src) name #f))
 
 ;; ---- reading -----------------------------------------------------------------
 
@@ -162,28 +156,65 @@
 
 ;; ---- definitions and mentions ---------------------------------------------------
 
-(define definer-rx #px"^(define|struct)")
+;; Is this the head of a form that BINDS its second subform?
+;;
+;; `define`-anything (which covers this repo's own `define-style`,
+;; `define-tokens`, `define-stream` …) and `struct` itself. Spelled as a
+;; membership test rather than as `^(define|struct)`, because that pattern also
+;; matched `struct-out` and `struct-copy` — so `(provide (struct-out task))`
+;; recorded `task` as defined at the PROVIDE's line, and every message about a
+;; struct pointed at the top of the file instead of at the struct.
+(define (definer? head)
+  (or (string-prefix? head "define") (string=? head "struct")))
 
 (define (definitions-of body)
   (define out (make-hasheq))
   (define (record! name-stx loc)
     (when (and (identifier? name-stx) (not (hash-has-key? out (syntax-e name-stx))))
       (hash-set! out (syntax-e name-stx) loc)))
+  ;; `(define (name arg ...) ...)`, `(define ((name a) b) ...)` — the name is
+  ;; at the bottom left of however many argument lists there are.
+  (define (record-target! target loc)
+    (cond
+      [(pair? (syntax-e target))
+       (let dig ([t target])
+         (if (pair? (syntax-e t)) (dig (car (syntax-e t))) (record! t loc)))]
+      [else (record! target loc)]))
   (let walk ([forms body])
     (for ([form (in-list forms)])
       (define e (and (pair? (syntax-e form)) (syntax->list form)))
       (when (and e (>= (length e) 2) (identifier? (car e)))
         (define head (symbol->string (syntax-e (car e))))
-        (when (regexp-match? definer-rx head)
-          (define target (cadr e))
+        (when (definer? head)
+          (define loc (loc-of form))
           (cond
-            ;; (define (name arg ...) ...) and (define ((name a) b) ...)
-            [(pair? (syntax-e target))
-             (let dig ([t target])
-               (if (pair? (syntax-e t)) (dig (car (syntax-e t))) (record! t (loc-of form))))]
-            [else (record! target (loc-of form))]))
+            ;; A struct binds a whole family, and none of the family is written
+            ;; down anywhere. Recording them here is what lets `source-where`
+            ;; be a lookup rather than a second, backwards guess at the same
+            ;; naming rule.
+            [(string=? head "struct") (record-struct! record! e loc)]
+            ;; (define-values (a b) e) binds every name in the list
+            [(and (string-suffix? head "-values") (pair? (syntax-e (cadr e))))
+             (for ([n (in-list (or (syntax->list (cadr e)) '()))]) (record! n loc))]
+            [else (record-target! (cadr e) loc)]))
         (walk (cdr e)))))
   out)
+
+;; (struct point (x y) …) binds point, point?, make-point, struct:point,
+;; point-x, point-y. Over-reaching costs nothing — a name nobody looks up is a
+;; hash entry — and under-reaching costs a message pointing at the wrong line.
+(define (record-struct! record! parts loc)
+  (define name-stx (cadr parts))
+  (unless (pair? (syntax-e name-stx))
+    (record! name-stx loc)
+    (define name (symbol->string (syntax-e name-stx)))
+    (define (derived s) (record! (datum->syntax name-stx (string->symbol s)) loc))
+    (derived (string-append name "?"))
+    (derived (string-append "make-" name))
+    (derived (string-append "struct:" name))
+    (for ([f (in-list (if (> (length parts) 2) (or (syntax->list (caddr parts)) '()) '()))]
+          #:when (identifier? f))
+      (derived (string-append name "-" (symbol->string (syntax-e f)))))))
 
 ;; Every identifier the module CALLS, and where it first calls it.
 ;;
@@ -206,33 +237,88 @@
 ;; Quoted data is skipped either way: `'(today now)` is a list of two symbols,
 ;; and the module that tabulates authority spellings would otherwise look like
 ;; the one module that uses every authority there is.
+;;
+;; And BINDING positions are skipped, because "the first thing in a pair" is
+;; not the same as "the operator of a call". `(for ([today days]) …)`,
+;; `(λ (now) …)` and `(let ([now (f)]) …)` all put a name where a call would
+;; sit, and every one of them is code taking the thing as an argument — the
+;; exact shape check 2 exists to reward. Counting them would have made the rule
+;; punish the code that obeys it, which is the failure mode a grammar with
+;; arbitrary gaps produces: thrash against a rule nobody can infer.
 (define (mentions-of body)
   (define out (make-hasheq))
   (define (record! s)
     (when (and (syntax? s) (symbol? (syntax-e s)) (not (hash-has-key? out (syntax-e s))))
       (hash-set! out (syntax-e s) (loc-of s))))
-  (let walk ([s body])
+  (let walk ([s body] [skip (seteq)])
     (cond
-      [(list? s) (for-each walk s)]
+      [(list? s) (for ([x (in-list s)]) (walk x skip))]
       [(not (syntax? s)) (void)]
       [(quoted? s) (void)]
+      [(set-member? skip s) (void)]
       [else
        (define e (syntax-e s))
        (cond
          [(pair? e)
           (define parts (syntax->list s))
+          (define bound (bound-positions parts))
           (record! (car e))
+          ;; `(apply subprocess #f #f #f cmd args)` is a call with a word in
+          ;; front of it, so the word after `apply` counts too.
           (when (and parts
                      (>= (length parts) 2)
                      (identifier? (car parts))
                      (eq? 'apply (syntax-e (car parts))))
             (record! (cadr parts)))
-          (walk (car e))
-          (walk (cdr e))]
-         [(vector? e) (for-each walk (vector->list e))]
-         [(box? e) (walk (unbox e))]
+          (define skip* (if (set-empty? bound) skip (set-union skip bound)))
+          (walk (car e) skip*)
+          (walk (cdr e) skip*)]
+         [(vector? e) (for ([x (in-vector e)]) (walk x skip))]
+         [(box? e) (walk (unbox e) skip)]
          [else (void)])]))
   out)
+
+;; The subforms of `parts` that hold NAMES rather than calls.
+;;
+;; A closed list, and deliberately a short one: it is about Racket's binding
+;; forms, not about this repo, and a form nobody listed is walked as ordinary
+;; code — which over-reports rather than under-reports, and that is the
+;; direction the README already commits to.
+(define (bound-positions parts)
+  (define head (and parts (pair? parts) (identifier? (car parts))
+                    (symbol->string (syntax-e (car parts)))))
+  (define (at n) (if (and head (> (length parts) n)) (seteq (list-ref parts n)) (seteq)))
+  (cond
+    [(not head) (seteq)]
+    ;; (lambda (a b) …) — the formals, whole
+    [(member head '("lambda" "λ")) (at 1)]
+    ;; (define-values (a b) e) — the name list
+    [(string-suffix? head "-values") (at 1)]
+    ;; (struct point (x y) …) — the field list
+    [(member head '("struct" "define-struct")) (at 2)]
+    ;; (let ([a e] …) …), (let loop ([a e]) …), and the whole `for` family:
+    ;; the first subform of every clause is a name, or a list of them
+    [(or (member head '("let" "let*" "letrec"))
+         (regexp-match? #px"^for\\*?(/|$)" head))
+     (clause-names parts (if (regexp-match? #px"^for\\*?/fold" head) 2 1))]
+    [else (seteq)]))
+
+;; The name half of each clause, out of the first `lists` list-shaped subforms
+;; — `for/fold` has two clause lists, everything else here has one. A clause
+;; that is not a list at all (`#:when e`) binds nothing and is left alone.
+(define (clause-names parts lists)
+  (for*/fold ([names (seteq)])
+             ([group (in-list (take-lists (cdr parts) lists))]
+              [clause (in-list group)]
+              #:when (pair? (or (syntax->list clause) '())))
+    (set-add names (car (syntax->list clause)))))
+
+(define (take-lists stxs n)
+  (let loop ([stxs stxs] [n n] [out '()])
+    (cond
+      [(or (zero? n) (null? stxs)) (reverse out)]
+      [(syntax->list (car stxs)) => (λ (l) (loop (cdr stxs) (sub1 n) (cons l out)))]
+      [else (loop (cdr stxs) n out)])))
 
 (define (quoted? stx)
   (define e (syntax-e stx))
@@ -241,6 +327,6 @@
        (memq (syntax-e (car e)) '(quote quote-syntax))
        #t))
 
-(define (loc-of stx)
-  (srcloc (syntax-source stx) (syntax-line stx) (syntax-column stx)
-          (syntax-position stx) (syntax-span stx)))
+;; `build-source-location` is the distribution's spelling of the same five
+;; accessors; the checker has no business owning a second one.
+(define loc-of build-source-location)

--- a/arch/tests/arch.rkt
+++ b/arch/tests/arch.rkt
@@ -1,0 +1,7 @@
+#lang arch
+
+;; The checker's tests. They write little trees of declarations and modules
+;; into temp directories, run git in them and read the findings back, so they
+;; own what a test owns.
+(clock volatile)
+(owns clock filesystem filesystem-events network subprocess threads randomness)

--- a/arch/tests/check.rkt
+++ b/arch/tests/check.rkt
@@ -1,0 +1,233 @@
+#lang racket/base
+
+;; The four checks, each against a repository small enough to read.
+;;
+;; A finding is a message and a place, and both are the contract: the message
+;; is what an agent acts on, and the srcloc is how it finds the thing to act
+;; on. So every case here asserts the rule line, the facts under it, and the
+;; file:line the finding points at.
+
+(require racket/list
+         racket/path
+         racket/string
+         arch/check
+         arch/finding
+         arch/tests/tree)
+
+(module+ test
+  (require rackunit))
+
+(define (findings dir #:window [window 30])
+  (report-findings (audit dir #:window window)))
+
+;; The one finding a case is about — a fixture with two is a fixture that has
+;; stopped being an example.
+(define (only-finding dir #:window [window 30])
+  (define fs (findings dir #:window window))
+  (unless (= 1 (length fs))
+    (error 'only-finding "expected one finding, got ~a:\n~a"
+           (length fs)
+           (string-join (for/list ([f (in-list fs)]) (finding->string f dir)) "\n")))
+  (car fs))
+
+(define (rule f) (finding-rule f))
+(define (why f) (string-join (finding-why f) "\n"))
+(define (at f dir)
+  (list (path->string (find-relative-path (simple-form-path dir)
+                                          (simple-form-path (srcloc-source (finding-loc f)))))
+        (srcloc-line (finding-loc f))))
+
+;; ---- 1: dependencies point volatile -> stable ------------------------------------
+
+(module+ test
+  (test-case "a stable module requiring a volatile one"
+    (call-with-tree
+     (list (cons "core/arch.rkt" "#lang arch\n(clock stable)\n(owns)\n")
+           (cons "core/grammar.rkt" "#lang racket/base\n(require \"../view/draw.rkt\")\n")
+           (cons "view/arch.rkt" "#lang arch\n(clock volatile)\n(owns)\n")
+           (cons "view/draw.rkt" "#lang racket/base\n"))
+     (λ (dir)
+       (define f (only-finding dir))
+       (check-equal? (rule f) "requires view/draw.rkt: dependency points the wrong way")
+       (check-true (string-contains? (why f) "core/grammar.rkt is declared stable (core/arch.rkt:2)"))
+       (check-true (string-contains? (why f) "view/draw.rkt is declared volatile (view/arch.rkt:2)"))
+       (check-true (string-contains? (why f) "stable code must not depend on volatile code"))
+       ;; the require spec, not the module
+       (check-equal? (at f dir) (list "core/grammar.rkt" 2)))))
+
+  (test-case "the same edge the other way round is fine"
+    (call-with-tree
+     (list (cons "core/arch.rkt" "#lang arch\n(clock stable)\n(owns)\n")
+           (cons "core/grammar.rkt" "#lang racket/base\n")
+           (cons "view/arch.rkt" "#lang arch\n(clock volatile)\n(owns)\n")
+           (cons "view/draw.rkt" "#lang racket/base\n(require \"../core/grammar.rkt\")\n"))
+     (λ (dir) (check-equal? (findings dir) '()))))
+
+  (test-case "a module with no arch.rkt above it is nobody's dependency to police"
+    (call-with-tree
+     (list (cons "core/arch.rkt" "#lang arch\n(clock stable)\n(owns)\n")
+           (cons "core/grammar.rkt" "#lang racket/base\n(require \"../loose/thing.rkt\")\n")
+           (cons "loose/thing.rkt" "#lang racket/base\n"))
+     (λ (dir) (check-equal? (findings dir) '())))))
+
+;; ---- 2: authority used only where owned -----------------------------------------
+
+(module+ test
+  (test-case "reaching for the filesystem without owning it"
+    (call-with-tree
+     (list (cons "core/arch.rkt" "#lang arch\n(clock stable)\n(owns)\n")
+           (cons "core/reader.rkt"
+                 "#lang racket/base\n(require racket/file)\n(define (peek p)\n  (file->string p))\n"))
+     (λ (dir)
+       (define f (only-finding dir))
+       (check-equal? (rule f) "file->string: ambient authority `filesystem` is not owned here")
+       (check-true (string-contains? (why f) "core/reader.rkt owns: (none)"))
+       (check-true (string-contains? (why f) "filesystem is owned by: nobody"))
+       (check-true (string-contains? (why f) "take what you need as an argument"))
+       (check-equal? (at f dir) (list "core/reader.rkt" 4)))))
+
+  (test-case "an authority that is owned is not a finding"
+    (call-with-tree
+     (list (cons "core/arch.rkt"
+                 "#lang arch\n(clock stable)\n(owns)\n(override \"reader.rkt\" (owns filesystem))\n")
+           (cons "core/reader.rkt" "#lang racket/base\n(require racket/file)\n(define (peek p) (file->string p))\n"))
+     (λ (dir) (check-equal? (findings dir) '()))))
+
+  (test-case "a name taken as an argument is not a clock read"
+    ;; the rule this whole check exists for: pure logic takes `today` as an
+    ;; argument, and the argument must not read as the thing it replaces
+    (call-with-tree
+     (list (cons "core/arch.rkt"
+                 (string-append "#lang arch\n(clock stable)\n(owns)\n"
+                                "(override \"dates.rkt\" (owns clock))\n"))
+           (cons "core/dates.rkt"
+                 "#lang racket/base\n(provide today)\n(define (today) (current-seconds))\n")
+           (cons "core/agenda.rkt"
+                 (string-append "#lang racket/base\n(require \"dates.rkt\")\n"
+                                "(define (overdue? day today) (string<? day today))\n")))
+     (λ (dir) (check-equal? (findings dir) '()))))
+
+  (test-case "an authority handed on under another name"
+    (call-with-tree
+     (list (cons "core/arch.rkt"
+                 (string-append "#lang arch\n(clock stable)\n(owns)\n"
+                                "(override \"dates.rkt\" (owns (clock \"today-string\")))\n"))
+           (cons "core/dates.rkt"
+                 (string-append "#lang racket/base\n(provide today-string)\n"
+                                "(define (today-string) (number->string (current-seconds)))\n"))
+           (cons "core/agenda.rkt"
+                 (string-append "#lang racket/base\n(require \"dates.rkt\")\n"
+                                "(define (now) (today-string))\n")))
+     (λ (dir)
+       (define f (only-finding dir))
+       (check-equal? (rule f) "today-string: ambient authority `clock` is not owned here")
+       (check-true (string-contains? (why f) "clock is owned by: core/dates.rkt"))
+       (check-equal? (at f dir) (list "core/agenda.rkt" 3)))))
+
+  (test-case "a spelling nothing exports is a rule that applies to nobody"
+    (call-with-tree
+     (list (cons "core/arch.rkt"
+                 (string-append "#lang arch\n(clock stable)\n(owns)\n"
+                                "(override \"dates.rkt\" (owns (clock \"today-strng\")))\n"))
+           (cons "core/dates.rkt"
+                 (string-append "#lang racket/base\n(provide today-string)\n"
+                                "(define (today-string) (number->string (current-seconds)))\n")))
+     (λ (dir)
+       (define f (only-finding dir))
+       (check-equal? (rule f) "today-strng: not an export of core/dates.rkt")
+       (check-true (string-contains? (why f) "a name nothing exports is a rule that applies to nobody"))
+       (check-equal? (at f dir) (list "core/arch.rkt" 4))))))
+
+;; ---- 3: one owner per concept -----------------------------------------------------
+
+(module+ test
+  (test-case "a second module exporting into somebody else's concept"
+    (call-with-tree
+     (list (cons "core/arch.rkt"
+                 (string-append "#lang arch\n(clock stable)\n(owns)\n"
+                                "(override \"load.rkt\" (concept node-key-minting \"mint-*\"))\n"))
+           (cons "core/load.rkt" "#lang racket/base\n(provide mint-keys)\n(define (mint-keys t) t)\n")
+           (cons "view/arch.rkt" "#lang arch\n(clock volatile)\n(owns)\n")
+           (cons "view/draw.rkt"
+                 (string-append "#lang racket/base\n(provide mint-key*)\n"
+                                "\n\n(define (mint-key* n) n)\n")))
+     (λ (dir)
+       (define f (only-finding dir))
+       (check-equal? (rule f) "mint-key*: exports into concept `node-key-minting`")
+       (check-true (string-contains? (why f) "that concept is owned by core/load.rkt (core/arch.rkt:4)"))
+       (check-true (string-contains? (why f) "the pattern it matched: \"mint-*\""))
+       (check-true (string-contains? (why f) "one owner per concept"))
+       ;; the definition, not the provide
+       (check-equal? (at f dir) (list "view/draw.rkt" 5)))))
+
+  (test-case "a re-export is not a second owner"
+    (call-with-tree
+     (list (cons "core/arch.rkt"
+                 (string-append "#lang arch\n(clock stable)\n(owns)\n"
+                                "(override \"load.rkt\" (concept node-key-minting \"mint-*\"))\n"))
+           (cons "core/load.rkt" "#lang racket/base\n(provide mint-keys)\n(define (mint-keys t) t)\n")
+           (cons "core/facade.rkt"
+                 "#lang racket/base\n(require \"load.rkt\")\n(provide (all-from-out \"load.rkt\"))\n"))
+     (λ (dir) (check-equal? (findings dir) '()))))
+
+  (test-case "two packages claiming one concept"
+    (call-with-tree
+     (list (cons "core/arch.rkt" "#lang arch\n(clock stable)\n(owns)\n(concept keys \"mint-*\")\n")
+           (cons "core/load.rkt" "#lang racket/base\n")
+           (cons "view/arch.rkt" "#lang arch\n(clock volatile)\n(owns)\n(concept keys \"key-*\")\n")
+           (cons "view/draw.rkt" "#lang racket/base\n"))
+     (λ (dir)
+       (define f (only-finding dir))
+       (check-equal? (rule f) "keys: a concept claimed twice")
+       (check-true (string-contains? (why f) "one owner per concept, and two claimants is no owner at all"))))))
+
+;; ---- 4: the declaration against the history ------------------------------------------
+
+(module+ test
+  (test-case "declared stable, and the history disagrees"
+    (call-with-tree
+     (list (cons "core/arch.rkt" "#lang arch\n(clock stable)\n(owns)\n")
+           (cons "core/busy.rkt" "#lang racket/base\n")
+           (cons "core/calm.rkt" "#lang racket/base\n"))
+     (λ (dir)
+       ;; ten commits, eight of them touching busy.rkt: over stable's fifth
+       (git-history! dir (append (for/list ([_ (in-range 8)]) (list "core/busy.rkt"))
+                                 (for/list ([_ (in-range 2)]) (list "core/calm.rkt"))))
+       (define f (only-finding dir #:window 10))
+       (check-equal? (rule f) "core/busy.rkt: declared stable, changed in 8 of the last 10 commits")
+       (check-true (string-contains? (why f) "stable allows up to 2 of 10"))
+       (check-true (string-contains? (why f) "either the code settles or the declaration changes"))
+       ;; the clock word that is the lie
+       (check-equal? (at f dir) (list "core/arch.rkt" 2)))))
+
+  (test-case "volatile has no ceiling"
+    (call-with-tree
+     (list (cons "core/arch.rkt" "#lang arch\n(clock volatile)\n(owns)\n")
+           (cons "core/busy.rkt" "#lang racket/base\n"))
+     (λ (dir)
+       (git-history! dir (for/list ([_ (in-range 6)]) (list "core/busy.rkt")))
+       (check-equal? (findings dir #:window 6) '()))))
+
+  (test-case "no history is said out loud, and the other checks still run"
+    (call-with-tree
+     (list (cons "core/arch.rkt" "#lang arch\n(clock stable)\n(owns)\n")
+           (cons "core/busy.rkt" "#lang racket/base\n"))
+     (λ (dir)
+       (define r (audit dir))
+       (check-equal? (report-findings r) '())
+       (check-equal? (length (report-notes r)) 1)
+       (check-true (string-contains? (car (report-notes r)) "no git history here"))))))
+
+;; ---- how a finding prints -------------------------------------------------------------
+
+(module+ test
+  (test-case "a finding prints as where, then the rule, then why"
+    (call-with-tree
+     (list (cons "core/arch.rkt" "#lang arch\n(clock stable)\n(owns)\n")
+           (cons "core/reader.rkt"
+                 "#lang racket/base\n(require racket/file)\n(define (peek p) (file->string p))\n"))
+     (λ (dir)
+       (define lines (string-split (finding->string (only-finding dir) dir) "\n"))
+       (check-equal? (car lines)
+                     "core/reader.rkt:3:18: file->string: ambient authority `filesystem` is not owned here")
+       (check-true (andmap (λ (l) (string-prefix? l "  ")) (cdr lines)))))))

--- a/arch/tests/check.rkt
+++ b/arch/tests/check.rkt
@@ -32,9 +32,11 @@
 
 (define (rule f) (finding-rule f))
 (define (why f) (string-join (finding-why f) "\n"))
+;; Said the way a message says it — through the labeller the findings
+;; themselves print with, so a change to how a path is rendered fails here
+;; rather than passing against a second copy of the rendering.
 (define (at f dir)
-  (list (path->string (find-relative-path (simple-form-path dir)
-                                          (simple-form-path (srcloc-source (finding-loc f)))))
+  (list ((make-labeller dir) (srcloc-source (finding-loc f)))
         (srcloc-line (finding-loc f))))
 
 ;; ---- 1: dependencies point volatile -> stable ------------------------------------
@@ -160,6 +162,24 @@
        ;; the definition, not the provide
        (check-equal? (at f dir) (list "view/draw.rkt" 5)))))
 
+  ;; Concepts reach exactly as far as authority does — the modules a package
+  ;; governs, and not the ones a deeper arch.rkt has taken over. Read off
+  ;; `effective-claims` for that reason: derived from the scope tree instead,
+  ;; a claim in the outer declaration owned a module whose own package it had
+  ;; nothing to say about.
+  (test-case "a package's concept stops where the next package starts"
+    (call-with-tree
+     (list (cons "core/arch.rkt"
+                 "#lang arch\n(clock stable)\n(owns)\n(concept node-key-minting \"mint-*\")\n")
+           (cons "core/load.rkt" "#lang racket/base\n(provide mint-keys)\n(define (mint-keys t) t)\n")
+           (cons "core/deep/arch.rkt" "#lang arch\n(clock stable)\n(owns)\n")
+           (cons "core/deep/other.rkt"
+                 "#lang racket/base\n(provide mint-other)\n(define (mint-other t) t)\n"))
+     (λ (dir)
+       (define f (only-finding dir))
+       (check-equal? (rule f) "mint-other: exports into concept `node-key-minting`")
+       (check-true (string-contains? (why f) "that concept is owned by core/load.rkt")))))
+
   (test-case "a re-export is not a second owner"
     (call-with-tree
      (list (cons "core/arch.rkt"
@@ -169,6 +189,20 @@
            (cons "core/facade.rkt"
                  "#lang racket/base\n(require \"load.rkt\")\n(provide (all-from-out \"load.rkt\"))\n"))
      (λ (dir) (check-equal? (findings dir) '()))))
+
+  ;; The rule is the checker's and nowhere else: two arch.rkt files can collide
+  ;; as easily as one file can, so a compile-time copy would be a second,
+  ;; narrower wording of one rule.
+  (test-case "one file claiming a concept twice"
+    (call-with-tree
+     (list (cons "core/arch.rkt"
+                 (string-append "#lang arch\n(clock stable)\n(owns)\n"
+                                "(concept keys \"mint-*\")\n(concept keys \"key-*\")\n"))
+           (cons "core/load.rkt" "#lang racket/base\n"))
+     (λ (dir)
+       (define f (only-finding dir))
+       (check-equal? (rule f) "keys: a concept claimed twice")
+       (check-equal? (at f dir) (list "core/arch.rkt" 5)))))
 
   (test-case "two packages claiming one concept"
     (call-with-tree

--- a/arch/tests/explain.rkt
+++ b/arch/tests/explain.rkt
@@ -1,0 +1,71 @@
+#lang racket/base
+
+;; `just arch --explain FILE`: the effective declaration, printed.
+;;
+;; Tested like a form's expansion, because it is the same kind of thing. A
+;; composition a reader cannot see through is one they argue with from memory,
+;; and what makes the dump trustworthy is that it says where every line came
+;; from — package default or override, and which file said it.
+
+(require racket/string
+         arch/churn
+         arch/explain
+         arch/scope
+         arch/tests/tree)
+
+(module+ test
+  (require rackunit))
+
+(define (explained dir file)
+  (explain (build-path dir file) (find-scopes dir) (read-churn dir 30) dir))
+
+(module+ test
+  (test-case "a module that takes the package default"
+    (call-with-tree
+     (list (cons "core/arch.rkt" "#lang arch\n(clock settling)\n(owns)\n")
+           (cons "core/plain.rkt" "#lang racket/base\n"))
+     (λ (dir)
+       (define out (explained dir "core/plain.rkt"))
+       (check-true (string-contains? out "governed by  core/arch.rkt"))
+       (check-true (string-contains? out "clock        settling"))
+       (check-true (string-contains? out "(package default)"))
+       (check-true (string-contains? out "owns         nothing"))
+       (check-true (string-contains? out "requires     nothing else that is declared")))))
+
+  (test-case "a module whose override replaces the clock and adds authority"
+    (call-with-tree
+     (list (cons "core/arch.rkt"
+                 (string-append "#lang arch\n(clock settling)\n(owns)\n"
+                                "(override \"dates.rkt\" (clock stable) (owns (clock \"today-string\")))\n"))
+           (cons "core/dates.rkt"
+                 (string-append "#lang racket/base\n(provide today-string)\n"
+                                "(define (today-string) \"\")\n"))
+           (cons "core/use.rkt" "#lang racket/base\n(require \"dates.rkt\")\n"))
+     (λ (dir)
+       (define out (explained dir "core/use.rkt"))
+       (check-true (string-contains? out "clock        settling"))
+       (check-true (string-contains? out "requires     core/dates.rkt (stable)"))
+       (define dates (explained dir "core/dates.rkt"))
+       (check-true (string-contains? dates "clock        stable"))
+       (check-true (string-contains? dates "(override \"dates.rkt\")"))
+       (check-true (string-contains? dates "clock (today-string)")))))
+
+  (test-case "the churn line says what the clock allows"
+    (call-with-tree
+     (list (cons "core/arch.rkt" "#lang arch\n(clock stable)\n(owns)\n")
+           (cons "core/plain.rkt" "#lang racket/base\n"))
+     (λ (dir)
+       (check-true (string-contains? (explained dir "core/plain.rkt")
+                                     "no git history here"))
+       (git-history! dir (list (list "core/plain.rkt")))
+       (check-true (string-contains? (explained dir "core/plain.rkt")
+                                     "stable allows up to")))))
+
+  (test-case "a module no arch.rkt governs says so"
+    (call-with-tree
+     (list (cons "core/arch.rkt" "#lang arch\n(clock stable)\n(owns)\n")
+           (cons "loose/thing.rkt" "#lang racket/base\n"))
+     (λ (dir)
+       (define out (explained dir "loose/thing.rkt"))
+       (check-true (string-contains? out "governed by  nothing"))
+       (check-true (string-contains? out "no check applies to it"))))))

--- a/arch/tests/explain.rkt
+++ b/arch/tests/explain.rkt
@@ -17,7 +17,8 @@
   (require rackunit))
 
 (define (explained dir file)
-  (explain (build-path dir file) (find-scopes dir) (read-churn dir 30) dir))
+  (define-values (scopes _governed) (survey dir))
+  (explain (build-path dir file) scopes (read-churn dir 30) dir))
 
 (module+ test
   (test-case "a module that takes the package default"

--- a/arch/tests/lang.rkt
+++ b/arch/tests/lang.rkt
@@ -8,8 +8,7 @@
 ;; makes it fixable. Neither is worth having without the other, so every case
 ;; here checks both.
 
-(require racket/list
-         racket/string
+(require racket/string
          arch/tests/tree)
 
 (module+ test
@@ -99,13 +98,6 @@
     (define r (refusal "(clock stable)\n(concept node-key-minting)\n"))
     (check-true (string-contains? (message r) "a concept with no spelling"))
     (check-true (string-contains? (message r) "(concept node-key-minting \"node-key-minting-*\")")))
-
-  (test-case "a concept claimed twice in one file"
-    (define r (refusal (string-append "(clock stable)\n"
-                                      "(concept keys \"mint-*\")\n"
-                                      "(concept keys \"key-*\")\n")))
-    (check-true (string-contains? (message r) "a concept claimed twice"))
-    (check-equal? (line r) 4))
 
   (test-case "a spelling on a package default"
     (define r (refusal "(clock stable)\n(owns (clock \"today-iso-string\"))\n"))

--- a/arch/tests/lang.rkt
+++ b/arch/tests/lang.rkt
@@ -1,0 +1,127 @@
+#lang racket/base
+
+;; What #lang arch refuses, and where it says the problem is.
+;;
+;; Both halves are the contract. A message that names the rule and lists the
+;; vocabulary is what makes the language teachable; a `file:line:col` on the
+;; OFFENDING form — the authority word, not the `owns` around it — is what
+;; makes it fixable. Neither is worth having without the other, so every case
+;; here checks both.
+
+(require racket/list
+         racket/string
+         arch/tests/tree)
+
+(module+ test
+  (require rackunit))
+
+;; Compiling the declaration is what raises, so the fixture is a directory with
+;; one arch.rkt in it and whatever modules its overrides name.
+(define (refusal body #:beside [beside '()])
+  (call-with-tree
+   (append beside (list (cons "arch.rkt" (string-append "#lang arch\n" body))))
+   (λ (dir)
+     (with-handlers ([exn:fail:syntax?
+                      (λ (e)
+                        (define stx (and (pair? (exn:fail:syntax-exprs e))
+                                         (car (exn:fail:syntax-exprs e))))
+                        (list (exn-message e)
+                              (and stx (syntax-line stx))
+                              (and stx (syntax-column stx))))])
+       (dynamic-require (build-path dir "arch.rkt") 'declaration)
+       (list "no refusal" #f #f)))))
+
+(define (message r) (car r))
+(define (line r) (cadr r))
+(define (column r) (caddr r))
+
+(module+ test
+  (test-case "not a clock"
+    (define r (refusal "(clock stabel)\n(owns)\n"))
+    (check-true (string-contains? (message r) "not a clock"))
+    (check-true (string-contains? (message r) "clocks: stable, settling, volatile"))
+    (check-true (string-contains? (message r) "did you mean: stable?"))
+    ;; the WORD, not the form around it
+    (check-equal? (line r) 2)
+    (check-equal? (column r) 7))
+
+  (test-case "not an authority"
+    (define r (refusal "(clock stable)\n(owns filesytem)\n"))
+    (check-true (string-contains? (message r) "not an authority"))
+    (check-true (string-contains? (message r) "filesystem-events"))
+    (check-true (string-contains? (message r) "a new authority is a roadmap proposal"))
+    (check-true (string-contains? (message r) "did you mean: filesystem?"))
+    (check-equal? (line r) 3)
+    (check-equal? (column r) 6))
+
+  (test-case "no clock"
+    (define r (refusal "(owns)\n"))
+    (check-true (string-contains? (message r) "no clock"))
+    (check-true (string-contains? (message r) "(clock stable)")))
+
+  (test-case "a second clock"
+    (define r (refusal "(clock stable)\n(clock volatile)\n"))
+    (check-true (string-contains? (message r) "a second clock"))
+    (check-true (string-contains? (message r) "the first is at line 2"))
+    (check-equal? (line r) 3))
+
+  (test-case "not an arch form"
+    (define r (refusal "(clock stable)\n(layer web)\n"))
+    (check-true (string-contains? (message r) "not an arch form"))
+    (check-true (string-contains? (message r) "clock, owns, concept, override"))
+    (check-equal? (line r) 3)
+    (check-equal? (column r) 1))
+
+  (test-case "an override naming a module that is not there"
+    (define r (refusal "(clock stable)\n(override \"gone.rkt\" (owns clock))\n"))
+    (check-true (string-contains? (message r) "no such module"))
+    (check-true (string-contains? (message r) "there is no gone.rkt beside this arch.rkt"))
+    ;; the STRING that named it
+    (check-equal? (line r) 3)
+    (check-equal? (column r) 10))
+
+  (test-case "a module overridden twice"
+    (define r (refusal (string-append "(clock stable)\n"
+                                      "(override \"a.rkt\" (owns clock))\n"
+                                      "(override \"a.rkt\" (owns threads))\n")
+                       #:beside (list (cons "a.rkt" "#lang racket/base\n"))))
+    (check-true (string-contains? (message r) "a module overridden twice"))
+    (check-equal? (line r) 4))
+
+  (test-case "an authority owned twice"
+    (define r (refusal "(clock stable)\n(owns clock threads clock)\n"))
+    (check-true (string-contains? (message r) "an authority owned twice"))
+    (check-true (string-contains? (message r) "already owned here: clock, threads"))
+    (check-equal? (line r) 3)
+    (check-equal? (column r) 20))
+
+  (test-case "a concept with no spelling"
+    (define r (refusal "(clock stable)\n(concept node-key-minting)\n"))
+    (check-true (string-contains? (message r) "a concept with no spelling"))
+    (check-true (string-contains? (message r) "(concept node-key-minting \"node-key-minting-*\")")))
+
+  (test-case "a concept claimed twice in one file"
+    (define r (refusal (string-append "(clock stable)\n"
+                                      "(concept keys \"mint-*\")\n"
+                                      "(concept keys \"key-*\")\n")))
+    (check-true (string-contains? (message r) "a concept claimed twice"))
+    (check-equal? (line r) 4))
+
+  (test-case "a spelling on a package default"
+    (define r (refusal "(clock stable)\n(owns (clock \"today-iso-string\"))\n"))
+    (check-true (string-contains? (message r) "a spelling on a package default"))
+    (check-true (string-contains? (message r) "(override \"some.rkt\" (owns (clock \"today-iso-string\"))")))
+
+  (test-case "an override inside an override"
+    (define r (refusal "(clock stable)\n(override \"a.rkt\" (override \"b.rkt\" (owns clock)))\n"
+                       #:beside (list (cons "a.rkt" "#lang racket/base\n")
+                                      (cons "b.rkt" "#lang racket/base\n"))))
+    (check-true (string-contains? (message r) "an override inside an override")))
+
+  (test-case "a declaration that is fine says so by loading"
+    (define r (refusal (string-append "(clock settling)\n"
+                                      "(owns)\n"
+                                      "(concept keys \"mint-*\")\n"
+                                      "(override \"a.rkt\" (clock stable) (owns (filesystem \"read-it\")))\n")
+                       #:beside (list (cons "a.rkt" "#lang racket/base\n"))))
+    (check-equal? (message r) "no refusal")))

--- a/arch/tests/tree.rkt
+++ b/arch/tests/tree.rkt
@@ -10,10 +10,9 @@
 
 (require racket/contract
          racket/file
-         racket/list
          racket/path
-         racket/port
-         racket/string)
+         racket/string
+         racket/system)
 
 (provide (contract-out
           [call-with-tree (-> (listof (cons/c string? string?)) (-> path? any) any)]
@@ -59,12 +58,9 @@
 (define (git! dir . args)
   (define git (find-executable-path "git"))
   (unless git (error 'git-history! "no git on PATH"))
-  (define-values (sp out in err)
-    (apply subprocess #f #f #f git "-C" (path->string dir) args))
-  (close-output-port in)
-  (define trouble (string-append (port->string out) (port->string err)))
-  (subprocess-wait sp)
-  (close-input-port out)
-  (close-input-port err)
-  (unless (zero? (subprocess-status sp))
-    (error 'git-history! "git ~a failed: ~a" (string-join args " ") trouble)))
+  (define said (open-output-string))
+  (define code
+    (parameterize ([current-output-port said] [current-error-port said])
+      (apply system*/exit-code git "-C" (path->string dir) args)))
+  (unless (zero? code)
+    (error 'git-history! "git ~a failed: ~a" (string-join args " ") (get-output-string said))))

--- a/arch/tests/tree.rkt
+++ b/arch/tests/tree.rkt
@@ -1,0 +1,70 @@
+#lang racket/base
+
+;; A whole repository, three files long.
+;;
+;; The checker's subject is a DIRECTORY: declarations beside modules, modules
+;; requiring each other, sometimes a git history over the lot. So the fixtures
+;; are directories, written into a temp dir and deleted after — nothing
+;; committed, because a committed fixture that is meant to FAIL a check is a
+;; fixture the real `just arch` run would then trip over.
+
+(require racket/contract
+         racket/file
+         racket/list
+         racket/path
+         racket/port
+         racket/string)
+
+(provide (contract-out
+          [call-with-tree (-> (listof (cons/c string? string?)) (-> path? any) any)]
+          [git-history! (-> path? (listof (listof string?)) void?)]))
+
+;; files : ("olai/arch.rkt" . "#lang arch\n(clock stable)\n") — in order, so a
+;; declaration can name a module the list writes later.
+(define (call-with-tree files proc)
+  (define dir (make-temporary-directory))
+  (dynamic-wind
+   (λ ()
+     (for ([f (in-list files)])
+       (define target (build-path dir (car f)))
+       (make-parent-directory* target)
+       (display-to-file (cdr f) target #:exists 'replace)))
+   (λ () (proc dir))
+   (λ () (delete-directory/files dir #:must-exist? #f))))
+
+;; One commit per element, each naming the files it touched. The content it
+;; writes does not matter — the churn audit counts commits, not diffs — so this
+;; appends a line and commits.
+;;
+;; Identity comes from -c flags: a test must not depend on whose machine it is
+;; running on, and must not care whether that machine has a git identity at all.
+(define (git-history! dir commits)
+  (git! dir "init" "--quiet" "--initial-branch" "main")
+  ;; The tree as it stands goes in first, on its own. Otherwise the first
+  ;; listed commit would carry every fixture file along with it and every
+  ;; module in the fixture would show one change it did not ask for.
+  (git! dir "add" "--all")
+  (git! dir "-c" "user.email=arch@example.invalid" "-c" "user.name=arch"
+        "commit" "--quiet" "--message" "the tree")
+  (for ([touched (in-list commits)] [n (in-naturals)])
+    (for ([f (in-list touched)])
+      (define target (build-path dir f))
+      (make-parent-directory* target)
+      (call-with-output-file target #:exists 'append
+        (λ (out) (fprintf out "\n;; commit ~a\n" n))))
+    (git! dir "add" "--all")
+    (git! dir "-c" "user.email=arch@example.invalid" "-c" "user.name=arch"
+          "commit" "--quiet" "--message" (format "commit ~a" n))))
+
+(define (git! dir . args)
+  (define git (find-executable-path "git"))
+  (unless git (error 'git-history! "no git on PATH"))
+  (define-values (sp out in err)
+    (apply subprocess #f #f #f git "-C" (path->string dir) args))
+  (close-output-port in)
+  (define trouble (string-append (port->string out) (port->string err)))
+  (subprocess-wait sp)
+  (close-input-port out)
+  (close-input-port err)
+  (unless (zero? (subprocess-status sp))
+    (error 'git-history! "git ~a failed: ~a" (string-join args " ") trouble)))

--- a/arch/vocabulary.rkt
+++ b/arch/vocabulary.rkt
@@ -1,0 +1,168 @@
+#lang racket/base
+
+;; The closed words, and what each one MEANS to a check.
+;;
+;; Three clocks and seven authorities, and both lists are human-ratified: a new
+;; authority is a proposal on the roadmap, not an edit here. That is the point
+;; of keeping them in one small module — a vocabulary that anyone can extend in
+;; passing is a vocabulary that stops meaning anything, and the measured record
+;; on abstraction libraries is that they rot as they grow.
+;;
+;; A word is not just a name here; it carries the two things a check needs:
+;;
+;;   * a clock carries its RANK (which way a dependency may point) and its
+;;     CHURN CEILING (what history is allowed to say about a module wearing it)
+;;   * an authority carries its SPELLINGS — the identifiers that, if a module
+;;     imports and mentions one, mean the module reaches for that authority
+;;
+;; Keeping the word and its meaning in the same table is what makes "settling"
+;; a definition rather than a mood. Any check that needed to know what a word
+;; means and asked somewhere else would be a second definition.
+
+(require racket/contract
+         racket/list)
+
+(provide (contract-out
+          [clocks (listof symbol?)]
+          [clock? (-> any/c boolean?)]
+          [clock-rank (-> clock? exact-nonnegative-integer?)]
+          [clock-churn-ceiling (-> clock? (or/c #f (and/c real? (between/c 0 1))))]
+          [authorities (listof symbol?)]
+          [authority? (-> any/c boolean?)]
+          [authority-spellings (-> authority? (listof symbol?))]
+          [word-list (-> (listof symbol?) string?)]
+          [did-you-mean (-> symbol? (listof symbol?) (or/c symbol? #f))]))
+
+;; ---- clocks -----------------------------------------------------------------
+
+;; Least volatile first. The order IS the rank, and the rank is the whole of
+;; check 1: an edge may point at the same rank or lower, never higher.
+(define clocks '(stable settling volatile))
+
+(define (clock? v) (and (memq v clocks) #t))
+
+(define (clock-rank c)
+  (- (length clocks) (length (memq c clocks))))
+
+;; What history may say about a module wearing this word, as a fraction of the
+;; audited window. Only the tight end is checked: a module that declares itself
+;; volatile and never changes is not lying about anything a reader could be
+;; misled by, and `volatile` is therefore uncapped.
+;;
+;; The numbers are deliberately loose. A window is a few dozen commits, a
+;; single feature can touch one file three times in an afternoon, and a check
+;; that fires on ordinary work is a check people learn to route around. They
+;; are tight enough to catch the case the audit is for — a module everybody
+;; edits every week, still declared stable.
+(define churn-ceilings
+  (hash 'stable   1/5      ; 6 of 30
+        'settling 1/2      ; 15 of 30
+        'volatile #f))
+
+(define (clock-churn-ceiling c) (hash-ref churn-ceilings c))
+
+;; ---- authorities ------------------------------------------------------------
+
+;; Ambient authority: what a module can reach for without being handed it. The
+;; set is the spec's, unchanged. `randomness` has no user in this repo yet and
+;; is listed anyway — the vocabulary is ratified as a whole, and a word nobody
+;; needs today is cheaper than one nobody may add tomorrow.
+;;
+;; The spellings are a CURATED TABLE, not a search: an identifier is here
+;; because somebody decided it opens a door. Over-inclusion costs a declaration
+;; somebody has to write; under-inclusion costs a rule that quietly does not
+;; apply. When in doubt the table includes the name.
+(define authority-table
+  (hash
+   ;; What time is it, and blocking until it is later. `sleep` is here because
+   ;; a module that waits on wall time is as untestable as one that reads it.
+   'clock
+   '(today today/utc now now/utc now/moment now/moment/utc
+     current-date current-seconds current-milliseconds
+     current-inexact-milliseconds current-inexact-monotonic-milliseconds
+     current-process-milliseconds current-gc-milliseconds
+     current-clock
+     sleep)
+
+   ;; Bytes on a disk, and the ambient cursor that says where relative paths
+   ;; land. `current-directory` counts: a function whose answer depends on the
+   ;; directory it was called from is reading the world.
+   'filesystem
+   '(open-input-file open-output-file open-input-output-file
+     call-with-input-file call-with-input-file* call-with-output-file call-with-output-file*
+     with-input-from-file with-output-to-file
+     file->string file->bytes file->lines file->list file->value
+     display-to-file write-to-file
+     directory-list in-directory find-files
+     file-exists? directory-exists? link-exists?
+     make-directory make-directory* make-parent-directory*
+     delete-file delete-directory delete-directory/files
+     rename-file-or-directory copy-file copy-directory/files
+     file-or-directory-modify-seconds file-or-directory-permissions
+     file-or-directory-identity file-size
+     make-temporary-file make-temporary-directory
+     current-directory current-directory-for-user current-load-relative-directory)
+
+   ;; Being told that they changed, which is a different power from reading
+   ;; them and belongs to a different module.
+   'filesystem-events
+   '(filesystem-change-evt filesystem-change-evt? filesystem-change-evt-cancel)
+
+   'network
+   '(tcp-listen tcp-connect tcp-connect/enable-break tcp-accept tcp-accept/enable-break
+     udp-open-socket
+     serve serve/servlet serve/launch/wait
+     get-pure-port get-impure-port call/input-url)
+
+   'subprocess
+   '(subprocess subprocess-wait subprocess-kill subprocess-status
+     process process* process/ports process*/ports
+     system system* system/exit-code system*/exit-code)
+
+   'threads
+   '(thread thread/suspend-to-kill kill-thread break-thread
+     thread-send thread-receive thread-suspend thread-resume thread-wait
+     make-thread-group)
+
+   'randomness
+   '(random random-seed make-pseudo-random-generator current-pseudo-random-generator
+     crypto-random-bytes)))
+
+(define authorities (sort (hash-keys authority-table) symbol<?))
+
+(define (authority? v) (and (memq v authorities) #t))
+
+(define (authority-spellings a) (hash-ref authority-table a))
+
+;; ---- saying a list of words --------------------------------------------------
+
+(define (word-list names)
+  (if (null? names)
+      "(none)"
+      (apply string-append
+             (add-between (for/list ([n (in-list names)]) (format "~a" n)) ", "))))
+
+;; ---- did you mean ------------------------------------------------------------
+
+;; Zero dependencies is a rule here and the distribution ships no edit distance,
+;; so this is the textbook two-row Levenshtein — over a handful of candidates,
+;; in a branch that only runs when the compile is already failing.
+(define (edit-distance a b)
+  (define m (string-length b))
+  (for/fold ([row (build-list (add1 m) values)] #:result (last row))
+            ([i (in-range 1 (add1 (string-length a)))])
+    (for/fold ([out (list i)] #:result (reverse out))
+              ([j (in-range 1 (add1 m))])
+      (cons (min (add1 (car out))                       ; delete
+                 (add1 (list-ref row j))                ; insert
+                 (+ (list-ref row (sub1 j))             ; substitute
+                    (if (char=? (string-ref a (sub1 i)) (string-ref b (sub1 j))) 0 1)))
+            out))))
+
+;; Two edits: enough for a transposition (`stabel`) or a dropped letter
+;; (`filesystem-event`), tight enough that an unrelated word is never offered.
+(define (did-you-mean name candidates)
+  (define scored (for/list ([c (in-list candidates)])
+                   (cons (edit-distance (symbol->string name) (symbol->string c)) c)))
+  (define best (and (pair? scored) (argmin car scored)))
+  (and best (<= (car best) 2) (cdr best)))

--- a/arch/vocabulary.rkt
+++ b/arch/vocabulary.rkt
@@ -11,13 +11,17 @@
 ;; A word is not just a name here; it carries the two things a check needs:
 ;;
 ;;   * a clock carries its RANK (which way a dependency may point) and its
-;;     CHURN CEILING (what history is allowed to say about a module wearing it)
+;;     ALLOWANCE (how many changes, out of a window of commits, history may
+;;     show for a module wearing it)
 ;;   * an authority carries its SPELLINGS — the identifiers that, if a module
-;;     imports and mentions one, mean the module reaches for that authority
+;;     imports and calls one, mean the module reaches for that authority
 ;;
 ;; Keeping the word and its meaning in the same table is what makes "settling"
 ;; a definition rather than a mood. Any check that needed to know what a word
-;; means and asked somewhere else would be a second definition.
+;; means and asked somewhere else would be a second definition — which is why
+;; `clock-allows` answers in COMMITS and not in a fraction somebody downstream
+;; has to turn into one: the checker and `--explain` were doing that
+;; arithmetic separately, and two spellings of one rule is one too many.
 
 (require racket/contract
          racket/list)
@@ -26,12 +30,11 @@
           [clocks (listof symbol?)]
           [clock? (-> any/c boolean?)]
           [clock-rank (-> clock? exact-nonnegative-integer?)]
-          [clock-churn-ceiling (-> clock? (or/c #f (and/c real? (between/c 0 1))))]
+          [clock-allows (-> clock? exact-positive-integer?
+                            (or/c #f exact-nonnegative-integer?))]
           [authorities (listof symbol?)]
           [authority? (-> any/c boolean?)]
-          [authority-spellings (-> authority? (listof symbol?))]
-          [word-list (-> (listof symbol?) string?)]
-          [did-you-mean (-> symbol? (listof symbol?) (or/c symbol? #f))]))
+          [authority-spellings (-> authority? (listof symbol?))]))
 
 ;; ---- clocks -----------------------------------------------------------------
 
@@ -44,28 +47,31 @@
 (define (clock-rank c)
   (- (length clocks) (length (memq c clocks))))
 
-;; What history may say about a module wearing this word, as a fraction of the
-;; audited window. Only the tight end is checked: a module that declares itself
-;; volatile and never changes is not lying about anything a reader could be
-;; misled by, and `volatile` is therefore uncapped.
+;; How many of the last `window` commits may have touched a module wearing this
+;; word — or #f for no ceiling at all.
 ;;
-;; The numbers are deliberately loose. A window is a few dozen commits, a
+;; Only the tight end is checked: a module that declares itself volatile and
+;; never changes misleads nobody, and `volatile` is therefore uncapped.
+;;
+;; The fractions are deliberately loose. A window is a few dozen commits, a
 ;; single feature can touch one file three times in an afternoon, and a check
 ;; that fires on ordinary work is a check people learn to route around. They
 ;; are tight enough to catch the case the audit is for — a module everybody
 ;; edits every week, still declared stable.
-(define churn-ceilings
+(define ceilings
   (hash 'stable   1/5      ; 6 of 30
         'settling 1/2      ; 15 of 30
         'volatile #f))
 
-(define (clock-churn-ceiling c) (hash-ref churn-ceilings c))
+(define (clock-allows c window)
+  (define ceiling (hash-ref ceilings c))
+  (and ceiling (inexact->exact (floor (* ceiling window)))))
 
 ;; ---- authorities ------------------------------------------------------------
 
 ;; Ambient authority: what a module can reach for without being handed it. The
-;; set is the spec's, unchanged. `randomness` has no user in this repo yet and
-;; is listed anyway — the vocabulary is ratified as a whole, and a word nobody
+;; set is the spec's, unchanged. `randomness` has no user in olai yet and is
+;; listed anyway — the vocabulary is ratified as a whole, and a word nobody
 ;; needs today is cheaper than one nobody may add tomorrow.
 ;;
 ;; The spellings are a CURATED TABLE, not a search: an identifier is here
@@ -133,36 +139,3 @@
 (define (authority? v) (and (memq v authorities) #t))
 
 (define (authority-spellings a) (hash-ref authority-table a))
-
-;; ---- saying a list of words --------------------------------------------------
-
-(define (word-list names)
-  (if (null? names)
-      "(none)"
-      (apply string-append
-             (add-between (for/list ([n (in-list names)]) (format "~a" n)) ", "))))
-
-;; ---- did you mean ------------------------------------------------------------
-
-;; Zero dependencies is a rule here and the distribution ships no edit distance,
-;; so this is the textbook two-row Levenshtein — over a handful of candidates,
-;; in a branch that only runs when the compile is already failing.
-(define (edit-distance a b)
-  (define m (string-length b))
-  (for/fold ([row (build-list (add1 m) values)] #:result (last row))
-            ([i (in-range 1 (add1 (string-length a)))])
-    (for/fold ([out (list i)] #:result (reverse out))
-              ([j (in-range 1 (add1 m))])
-      (cons (min (add1 (car out))                       ; delete
-                 (add1 (list-ref row j))                ; insert
-                 (+ (list-ref row (sub1 j))             ; substitute
-                    (if (char=? (string-ref a (sub1 i)) (string-ref b (sub1 j))) 0 1)))
-            out))))
-
-;; Two edits: enough for a transposition (`stabel`) or a dropped letter
-;; (`filesystem-event`), tight enough that an unrelated word is never offered.
-(define (did-you-mean name candidates)
-  (define scored (for/list ([c (in-list candidates)])
-                   (cons (edit-distance (symbol->string name) (symbol->string c)) c)))
-  (define best (and (pair? scored) (argmin car scored)))
-  (and best (<= (car best) 2) (cdr best)))

--- a/arch/wording.rkt
+++ b/arch/wording.rkt
@@ -1,0 +1,50 @@
+#lang racket/base
+
+;; How a list of words is said, and what a misspelling was probably reaching
+;; for.
+;;
+;; Split out of arch/vocabulary because the two change for different reasons.
+;; The vocabulary changes when a human ratifies a word — rarely, deliberately,
+;; and the whole point of keeping it small is that it does not move. This moves
+;; whenever a message is reworded, which is whenever somebody watches an agent
+;; misread one. Two axes behind one module is a module modified for two
+;; unrelated reasons.
+;;
+;; It is required at phase 1 by the expander and at phase 0 by the checker, so
+;; both halves of the tool say a candidate list the same way.
+
+(require racket/contract
+         racket/list
+         racket/string)
+
+(provide (contract-out
+          [word-list (-> (listof symbol?) string?)]
+          [did-you-mean (-> symbol? (listof symbol?) (or/c symbol? #f))]))
+
+(define (word-list names)
+  (if (null? names)
+      "(none)"
+      (string-join (for/list ([n (in-list names)]) (format "~a" n)) ", ")))
+
+;; Zero dependencies is a rule here and the distribution ships no edit distance,
+;; so this is the textbook two-row Levenshtein — over a handful of candidates,
+;; in a branch that only runs when the compile is already failing.
+(define (edit-distance a b)
+  (define m (string-length b))
+  (for/fold ([row (build-list (add1 m) values)] #:result (last row))
+            ([i (in-range 1 (add1 (string-length a)))])
+    (for/fold ([out (list i)] #:result (reverse out))
+              ([j (in-range 1 (add1 m))])
+      (cons (min (add1 (car out))                       ; delete
+                 (add1 (list-ref row j))                ; insert
+                 (+ (list-ref row (sub1 j))             ; substitute
+                    (if (char=? (string-ref a (sub1 i)) (string-ref b (sub1 j))) 0 1)))
+            out))))
+
+;; Two edits: enough for a transposition (`stabel`) or a dropped letter
+;; (`filesystem-event`), tight enough that an unrelated word is never offered.
+(define (did-you-mean name candidates)
+  (define scored (for/list ([c (in-list candidates)])
+                   (cons (edit-distance (symbol->string name) (symbol->string c)) c)))
+  (define best (and (pair? scored) (argmin car scored)))
+  (and best (<= (car best) 2) (cdr best)))

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -27,7 +27,7 @@ nix_shell := if env('IN_NIX_SHELL', '') != '' { '' } else { 'nix develop --accep
 [macos]
 [parallel]
 [metadata("ci")]
-default: smoke test test-integration e2e counters::check
+default: smoke arch test test-integration e2e counters::check
 
 # One install + raco setup per lane — funnel every racket test through this.
 build:
@@ -41,9 +41,18 @@ nix:
 smoke: nix
     ./result/bin/olai check examples/Example.rkt Roadmap.rkt e2e/fixtures/Tasks.rkt
 
-# Unit tests: in-process (live/tests/ + olai/tests/*.rkt).
+# The declared architecture, checked against the code (arch/README.md). Its own
+# node and not part of `test`: a layering violation and a failing test are
+# different failure classes, and a lane that reported them together would make
+# a red build say less than it does now. It reads `git log`, so it needs the
+# history — a lane that fetched only one commit gets the audit's "no history
+# here" note and the other three checks.
+arch: build
+    {{ nix_shell }} racket arch/main.rkt .
+
+# Unit tests: in-process (arch/tests/ + live/tests/ + olai/tests/*.rkt).
 test: build
-    {{ nix_shell }} raco test -j {{ num_cpus() }} live/tests/*.rkt olai/tests/*.rkt
+    {{ nix_shell }} raco test -j {{ num_cpus() }} arch/tests/*.rkt live/tests/*.rkt olai/tests/*.rkt
 
 # Integration tests: subprocess CLI + real servers (olai/tests/integration/).
 test-integration: build

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -2,14 +2,16 @@
 
 Facts an agent cannot infer from the code and would otherwise probe for. Not a tutorial. Read [README](../README.md) and [docs/cli.md](cli.md) first.
 
-## Two collections
+## Three collections
 
-The repo holds two Racket packages, and the order between them is the dependency:
+The repo holds three Racket packages, and the order between them is the dependency:
 
+* `arch/` — `#lang arch`, the language every package writes its `arch.rkt` in, and the checker `just arch` runs over the lot ([arch/README.md](../arch/README.md)). It depends on `base` and nothing else, which is what lets both collections below carry a declaration without either of them depending on the other.
 * `live/` — the live-view framework: an SSE hub with reconnect catch-up, an htmx + idiomorph browser runtime, and `live/dsl`'s declare-and-check forms over both (`just expand FILE` prints what they become). It imports NOTHING from olai and never will; olai is its first consumer, not its definition. Its own README is the consumer contract ([live/README.md](../live/README.md)), and [docs/live.md](live.md) is what olai puts through it.
 * `olai/` — everything else.
 
-So `just install` links `live` before `olai`, and `just build` is `raco setup --pkgs live olai`. A change to `live/` that only makes sense for olai is a change in the wrong place.
+So `just install` links `arch`, then `live`, then `olai`, and `just build` is `raco setup --pkgs arch live olai`. A change to `live/` that only makes sense for olai is a change in the wrong place — and since 
+`live/arch.rkt` declares the framework stable and `olai/arch.rkt` declares the core settling, `just arch` now says so rather than a reviewer.
 
 `live/examples/*` is in neither package. Each example is its own derivation (`nix run .#counters`) and runs its own test as `installCheckPhase`, so CI builds it and nothing else touches it. `live`'s source is a `lib.fileset` that excludes it, so installing the framework never carries an example and editing one rebuilds neither `live` nor olai. `raco` has no such split — it refuses to link a package inside another package's directory — so `just build` compiles examples along with `live`, and a broken one fails it.
 
@@ -24,9 +26,9 @@ So `just install` links `live` before `olai`, and `just build` is `raco setup --
 ## Toolchain
 
 * Racket comes from `nix develop` (nixpkgs 9.2). `just` recipes set `PLTUSERHOME` to `$PWD/.plt-user` so user packages and the two links live in the worktree, not `~`. That directory must be writable.
-* `just install` — deps + `raco pkg install --skip-installed --link` for `live/` then `olai/`. Cheap to repeat. Does **not** recompile after you edit sources.
-* `just build` — `raco setup --pkgs live olai`. Writes `compiled/*.zo` for both collections and their tests, and keeps them coherent after edits. Incremental when nothing changed. `just test` / `test-integration` / `test-all` depend on it.
-* `just clean` — delete every `olai/**/compiled`. Escape hatch only.
+* `just install` — deps + `raco pkg install --skip-installed --link` for `arch/`, `live/` then `olai/`. Cheap to repeat. Does **not** recompile after you edit sources.
+* `just build` — `raco setup --pkgs arch live olai`. Writes `compiled/*.zo` for all three collections and their tests, and keeps them coherent after edits. Incremental when nothing changed. `just test` / `test-integration` / `test-all` / `arch` depend on it.
+* `just clean` — delete every `compiled/` under the three. Escape hatch only.
 
 ### Why build exists
 
@@ -82,7 +84,8 @@ Class-name renames: run `just css-classes` to regenerate `olai/tests/classes.gol
 
 ## Tests
 
-* `just test` — unit, in-process: `live/tests/*.rkt` + `olai/tests/*.rkt`, and every example's own test (a dependency, so the command stays one)
+* `just test` — unit, in-process: `arch/tests/*.rkt` + `live/tests/*.rkt` + `olai/tests/*.rkt`, and every example's own test (a dependency, so the command stays one)
+* `just arch` — the declared architecture against the code. NOT a test and not in `just test`: a layering violation and a failing test are different failure classes, and it is its own CI node for the same reason. About two seconds ([arch/README.md](../arch/README.md))
 * `just test-integration` — spawns `olai`, boots servers
 * `just test-all` — both, one `-j` pool
 * `just e2e` — browser journeys (see below); never in `just test`

--- a/e2e/features/chat.feature
+++ b/e2e/features/chat.feature
@@ -39,7 +39,7 @@ Feature: the agent panel
     And the chat panel is idle
 
   # Issue #14: the gutter the panel needs was PADDING on .ol-main, and .ol-main
-  # is border-box under `max-width: 56rem` — so --chat-w came out of the reading
+  # is border-box under `max-width: 56rem` — so --panel-w came out of the reading
   # column's own cap instead of out of the free space beside it. The outline
   # kept its full border box (right edge under the panel), and the text wrapped
   # into whatever the padding left, three words to a line, with the gutter

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,11 @@
           # package-lock.json it builds from.
           acpAgent = pkgs.callPackage ./acp { };
 
+          # The declaration language every package here writes its arch.rkt in
+          # (arch/README.md). Under both of the collections below, so it is
+          # built first and installed first everywhere they are.
+          arch = pkgs.callPackage ./arch { };
+
           # The live-view collection with its vendored browser runtime staged
           # in. Which upstream, which artifact, which name lives in
           # live/default.nix, next to the collection it is about.
@@ -100,19 +105,19 @@
           # The framework's worked example, as its own artifact: it consumes
           # `live` and is not part of it. Its nix, its just module and its
           # test all live in that directory — this line is the mount.
-          counters = pkgs.callPackage ./live/examples/counters { inherit live; };
+          counters = pkgs.callPackage ./live/examples/counters { inherit arch live; };
 
           # The build (racket build, TZDIR dance, raco exe stub, ACP
           # default) lives in nix/olai.nix; src is a flake-level decision.
           olai = pkgs.callPackage ./nix/olai.nix {
             inherit (racketDepsPkg) racketPkgs racketDeps;
-            inherit acpAgent live highlightJs;
+            inherit acpAgent arch live highlightJs;
             src = ./.;
           };
         in
         {
           default = olai;
-          inherit olai live counters;
+          inherit olai arch live counters;
           highlight-js = highlightJs;
           racket-deps = racketDepsPkg.racketDeps;
           acp-agent = acpAgent;

--- a/justfile
+++ b/justfile
@@ -21,10 +21,11 @@ mod ci 'ci/mod.just'
 default:
     @just --list
 
-# Two collections, and the order is the dependency: `live` is the live-view
+# Three collections, and the order is the dependency: `arch` is the declaration
+# language every package here writes its arch.rkt in, `live` is the live-view
 # framework (its own package, no olai imports), `olai` is its first consumer.
-# Linking live first is what keeps olai's declared dep on it from sending raco
-# to a catalog for a package that lives in this repo.
+# Linking them in that order is what keeps a declared dep from sending raco to
+# a catalog for a package that lives in this repo.
 
 # The browser runtime `live/` ships is pinned upstream (npins) and built by
 # live/default.nix, not committed. The devShell exports where it landed; this
@@ -47,22 +48,25 @@ vendor:
     install -d {{justfile_directory()}}/olai/web/static/hljs
     install -m 0644 "$OLAI_HLJS_ASSETS"/* {{justfile_directory()}}/olai/web/static/hljs/
 
-# Deps + raco link ./live and ./olai (cheap; does not recompile — use `just build`)
+# Deps + raco link ./arch, ./live and ./olai (cheap; does not recompile — use `just build`)
+# `arch` first: every package here carries arch.rkt declarations, and those are
+# `#lang arch` modules the other two cannot compile without it (arch/README.md).
 install: vendor
     mkdir -p "{{PLTUSERHOME}}"
     raco pkg install --auto --skip-installed gregor markdown css-expr
+    raco pkg install --auto --skip-installed --link {{justfile_directory()}}/arch
     raco pkg install --auto --skip-installed --link {{justfile_directory()}}/live
     raco pkg install --auto --skip-installed --link {{justfile_directory()}}/olai
 
 # raco setup: write .zo and keep them coherent (see docs/hacking.md)
 build: install
-    raco setup --pkgs live olai
+    raco setup --pkgs arch live olai
 
-# Drop olai/**/compiled (linklet-mismatch escape hatch; prefer `just build`)
+# Drop every compiled/ (linklet-mismatch escape hatch; prefer `just build`)
 clean:
     #!/usr/bin/env bash
     set -euo pipefail
-    find olai -type d -name compiled -print0 | xargs -0 rm -rf
+    find arch live olai -type d -name compiled -print0 | xargs -0 rm -rf
 
 # The CLI answers in JSON (the human view is `just serve`); these recipes only
 # spell the default outlines.
@@ -87,6 +91,23 @@ serve *args: install
 expand file: build
     racket {{justfile_directory()}}/live/expand.rkt {{file}}
 
+# The layering, checked against the arch.rkt declarations beside the code:
+# which way dependencies point, who owns which ambient authority, one owner per
+# tagged concept, and whether `git log` agrees with the clocks (arch/README.md).
+#
+# `build` first, for the same reason `test` does it: the checker asks compiled
+# modules what they import and export, and with .zo on disk the whole tree is
+# about two seconds — the edit loop's cost class, not CI's.
+#
+# Arguments are the checker's: `--explain FILE` prints one module's effective
+# declaration after defaults and overrides, `--window N` audits N commits.
+# The checker is only worth having if you can see what it thinks, so --explain
+# is interface and not a debug aid.
+
+# Check the declared architecture (args: --explain FILE, --window N)
+arch *args: build
+    racket {{justfile_directory()}}/arch/main.rkt {{args}} {{justfile_directory()}}
+
 # The two sets differ in what they cost: unit tests run in this VM, the
 # integration ones spawn `olai` subprocesses and boot real servers. Both are
 # parallel-safe (ephemeral ports, temp dirs), so -j is free speed.
@@ -98,9 +119,9 @@ expand file: build
 css-classes: install
     racket -e '(require olai/web/skin (only-in olai/web/style class-names)) (for-each displayln (sort (class-names) string<?))' > olai/tests/classes.golden
 
-# Unit tests: in-process, no subprocesses (live/tests/ + olai/tests/*.rkt)
+# Unit tests: in-process, no subprocesses (arch/tests/ + live/tests/ + olai/tests/*.rkt)
 test: build
-    raco test -j {{ num_cpus() }} live/tests/*.rkt olai/tests/*.rkt
+    raco test -j {{ num_cpus() }} arch/tests/*.rkt live/tests/*.rkt olai/tests/*.rkt
 
 # Integration tests: subprocess CLI + real servers (olai/tests/integration/)
 test-integration: build
@@ -108,7 +129,7 @@ test-integration: build
 
 # Everything, in one -j pool so the slow files start first
 test-all: build
-    raco test -j {{ num_cpus() }} olai/tests/integration/ live/tests/*.rkt olai/tests/*.rkt
+    raco test -j {{ num_cpus() }} olai/tests/integration/ arch/tests/*.rkt live/tests/*.rkt olai/tests/*.rkt
 
 # Browser journeys: what the wire tests cannot see, because no JS runs there
 # (folding, prefs, the live swap, the chat panel). NEVER part of `just test` —

--- a/live/arch.rkt
+++ b/live/arch.rkt
@@ -1,0 +1,23 @@
+#lang arch
+
+;; The live-view framework. It imports nothing from olai and never will, and
+;; that is not a sentence any more: olai is declared settling and volatile, so
+;; an edge from here to there points the wrong way and the checker says so.
+(clock stable)
+(owns)
+
+;; The hub is where the concurrency is, and it is the only place: a broadcast
+;; goes to every subscriber on a thread of the hub's making.
+(override "hub.rkt" (owns threads) (concept sse-hub "hub-*" "make-hub" "subscriber*"))
+
+;; A frame carries a monotonic id, which is a clock read — the one in the
+;; framework, on purpose, so the app never mints one.
+(override "frame.rkt" (owns clock) (concept sse-frame "frame*" "make-frame"))
+
+;; `just expand` is a program, not part of the framework: it reads a file off
+;; the disk and prints what the forms in it became.
+(override "expand.rkt" (clock settling) (owns filesystem))
+
+;; The forms, and the checks under them. One declarer per name is the rule the
+;; whole module exists for; this says it about the module itself.
+(override "dsl.rkt" (concept live-forms "define-stream" "define-live-region" "stream-*"))

--- a/live/examples/counters/arch.rkt
+++ b/live/examples/counters/arch.rkt
@@ -1,0 +1,11 @@
+#lang arch
+
+;; The framework's worked example, as a program: it consumes `live` and is not
+;; part of it, which is why it declares itself here rather than riding on
+;; live/arch.rkt. It is an app, so it owns what an app owns — a port, a thread
+;; that ticks, the clock it ticks against.
+;;
+;; Settling and not stable: an example follows the framework, and every change
+;; to the forms it demonstrates lands in it.
+(clock settling)
+(owns clock network threads randomness)

--- a/live/examples/counters/default.nix
+++ b/live/examples/counters/default.nix
@@ -5,21 +5,23 @@
 #
 # The Nix file lives beside what it is about, like acp/, e2e/ and live/ do;
 # flake.nix only callPackages it (`nix run .#counters`).
-{ lib, stdenv, racket, live }:
+{ lib, stdenv, racket, arch, live }:
 
 stdenv.mkDerivation {
   pname = "counters";
   version = "0.1";
 
-  # The program is these five modules and the test that says they work,
-  # stated positively: the README, this file and the just module are about the
-  # example without being part of it, so editing any of them rebuilds nothing.
-  # A sixth module is one line here — the right amount of ceremony for a
-  # directory whose whole point is that a human reads all of it.
+  # The program is these five modules, the declaration that says what they may
+  # depend on and reach for, and the test that says they work — stated
+  # positively: the README, this file and the just module are about the example
+  # without being part of it, so editing any of them rebuilds nothing. A sixth
+  # module is one line here — the right amount of ceremony for a directory
+  # whose whole point is that a human reads all of it.
   src = lib.fileset.toSource {
     root = ./.;
     fileset = lib.fileset.unions [
       ./app.rkt
+      ./arch.rkt
       ./clock.rkt
       ./counters.rkt
       ./header.rkt
@@ -48,8 +50,10 @@ stdenv.mkDerivation {
     # --copy, not --link: a link would leave /build paths in the catalog for
     # raco exe to bake in. The framework comes from its own derivation, with
     # its vendored static/ already staged (live/default.nix).
+    cp -a "${arch}" ./arch-pkg
     cp -a "${live}" ./live-pkg
-    chmod -R u+w ./live-pkg
+    chmod -R u+w ./arch-pkg ./live-pkg
+    raco pkg install --copy --no-docs --deps force ./arch-pkg
     raco pkg install --copy --no-docs --deps force ./live-pkg
 
     mkdir -p $out/bin

--- a/live/info.rkt
+++ b/live/info.rkt
@@ -1,7 +1,12 @@
 #lang info
 
 (define collection "live")
-(define deps '("base" "web-server-lib"))
+;; "arch" is the declaration language this repo's arch.rkt files are written
+;; in — its own package (repo root, arch/), not a catalog one, for the same
+;; reason `live` is: a collection with its own reason to be built. live/arch.rkt
+;; is a `#lang arch` module, so it is a real compile-time dependency. It is NOT
+;; a dependency on olai, which this package still has none of.
+(define deps '("arch" "base" "web-server-lib"))
 (define build-deps '("rackunit-lib"))
 (define pkg-desc
   (string-append "Live views for Racket web apps: an SSE hub with reconnect"

--- a/live/tests/arch.rkt
+++ b/live/tests/arch.rkt
@@ -1,0 +1,7 @@
+#lang arch
+
+;; The framework's tests: same terms as olai's. They boot hubs, open sockets
+;; and read the vendored runtime off the disk, and they follow the framework
+;; rather than leading it.
+(clock volatile)
+(owns clock filesystem filesystem-events network subprocess threads randomness)

--- a/nix/olai.nix
+++ b/nix/olai.nix
@@ -13,6 +13,10 @@
 #     ELF patcher arity-mismatches (compiler/private/elf.rkt).
 { lib, stdenv, racket, makeWrapper, tzdata, racketDeps, racketPkgs, src
 , acpAgent
+# the declaration language the arch.rkt files beside every package are written
+# in (arch/default.nix). Installed BEFORE the two collections below, because
+# each of them carries `#lang arch` modules that will not compile without it
+, arch
 # the live-view collection with its vendored browser runtime already staged
 # (live/default.nix) — a drop-in for $src/live
 , live
@@ -54,10 +58,12 @@ stdenv.mkDerivation {
       "$PLTUSERHOME/.local/share/racket/9.2/share/tzdata/zoneinfo"
 
     # live comes from its own derivation, not from $src: the browser runtime
-    # under its static/ is pinned upstream rather than committed.
+    # under its static/ is pinned upstream rather than committed. arch is its
+    # own derivation for the ordinary reason — its own package.
+    cp -a "${arch}" ./arch-pkg
     cp -a "${live}" ./live-pkg
     cp -a "$src/olai" ./olai-pkg
-    chmod -R u+w ./live-pkg ./olai-pkg
+    chmod -R u+w ./arch-pkg ./live-pkg ./olai-pkg
 
     # …and the highlighter under olai's own static/, for the same reason: the
     # bytes are a pin, not a file in the repo, so they join the collection
@@ -77,8 +83,10 @@ stdenv.mkDerivation {
 
     # --copy, not --link: a link would keep $src (or /build) paths in the
     # package catalog and raco exe would bake those into the stub.
-    # `live` before `olai`: the live-view framework is a package of its own
-    # (this repo's live/), and olai declares a dependency on it.
+    # The order is the dependency: `arch` is the declaration language both of
+    # the others carry a `#lang arch` file in, and `live` is the live-view
+    # framework olai declares a dependency on.
+    raco pkg install --copy --no-docs --deps force ./arch-pkg
     raco pkg install --copy --no-docs --deps force ./live-pkg
     raco pkg install --copy --no-docs --deps force ./olai-pkg
 

--- a/olai/arch.rkt
+++ b/olai/arch.rkt
@@ -1,0 +1,72 @@
+#lang arch
+
+;; The core: the data model, the queries over it, the writes, and the two
+;; programs at the top. It settles — a feature adds a query or an op here every
+;; few weeks — and it sits above `lang/` and below `web/`.
+(clock settling)
+
+;; Nothing ambient by default. Everything below that reaches for the world says
+;; so, which is what makes "pure logic takes what it needs as an argument" a
+;; check rather than a hope.
+(owns)
+
+;; ---- the pieces that hold still ----------------------------------------------
+
+;; Where the clock enters this codebase, and the only place. `today-iso-string`
+;; is a clock read wearing a different name, so it is declared as one: every
+;; module that calls it is reading the clock as surely as one calling gregor's
+;; `(today)`, and check 2 knows it.
+(override "dates.rkt" (clock stable) (owns (clock "today-iso-string")))
+
+;; What a @doc path means, and what a failure a person reads looks like.
+;; Neither has changed since it was written, and the language depends on the
+;; first of them.
+(override "doc.rkt" (clock stable) (owns filesystem))
+(override "fail.rkt" (clock stable))
+
+;; A node's name on disk and in a URL: one owner, so a renderer never grows its
+;; own copy and the core keeps building without web/.
+(override "paths.rkt" (owns filesystem) (concept file-naming "file-label" "key-label"))
+
+;; ---- the load layer ------------------------------------------------------------
+
+;; Node keys are minted HERE. A module cannot mint its own: it knows only its
+;; own entry point, and the same node reached through a different root has to
+;; key the same.
+(override "load.rkt" (concept node-key-minting "mint-*"))
+
+;; Snapshots, and the namespace an outline is loaded in. Addressing is not
+;; snapshotting — the index is olai/index.rkt's — so the concept here is the
+;; snapshot and what holds it.
+(override "store.rkt"
+          (owns filesystem)
+          (concept outline-snapshots "snapshot*" "store-*" "make-store"))
+
+;; ---- the writes ------------------------------------------------------------------
+
+;; Every write goes through a file on disk, and one of them also goes through
+;; git.
+(override "edit.rkt" (owns filesystem subprocess))
+(override "ops.rkt" (owns filesystem))
+(override "daily.rkt" (owns filesystem))
+(override "resolve.rkt" (owns filesystem))
+
+;; ---- the agent -------------------------------------------------------------------
+
+;; One subprocess, one protocol, no browser. Nothing else spells ACP: the
+;; concept is the whole `acp-` surface, and a name in it appearing anywhere
+;; else is the check, not a convention.
+(override "acp.rkt"
+          (owns filesystem subprocess threads)
+          (concept acp-protocol "acp-*" "make-acp-client"))
+
+;; ---- the two programs --------------------------------------------------------------
+
+;; The CLI is app code, not library: it computes `today` and hands it down, it
+;; reads and writes files, and it mounts the server — which is what makes it
+;; volatile whatever its own churn says.
+(override "cli.rkt" (clock volatile) (owns clock filesystem))
+
+;; The facade. It re-exports the data model, the pure queries AND the web
+;; render, so it moves with the fastest thing it names.
+(override "main.rkt" (clock volatile))

--- a/olai/info.rkt
+++ b/olai/info.rkt
@@ -1,11 +1,13 @@
 #lang info
 
 (define collection "olai")
-;; "live" is the live-view framework in this repo's own live/ directory, not a
-;; catalog package: olai is its first consumer, and the two are installed
-;; together (justfile, nix/olai.nix). It is listed anyway — a dependency the
-;; package file does not name is one a build can forget.
-(define deps '("base" "css-expr" "gregor" "live" "markdown" "web-server-lib"))
+;; "live" is the live-view framework in this repo's own live/ directory, and
+;; "arch" is the language the arch.rkt declarations beside every package are
+;; written in — neither is a catalog package. olai is live's first consumer,
+;; arch is under both of them, and all three are installed together (justfile,
+;; nix/olai.nix). They are listed anyway — a dependency the package file does
+;; not name is one a build can forget.
+(define deps '("arch" "base" "css-expr" "gregor" "live" "markdown" "web-server-lib"))
 (define build-deps '("rackunit-lib"))
 (define pkg-desc "Self-hosted outliner: #lang olai + CLI")
 (define version "0.1")

--- a/olai/json/arch.rkt
+++ b/olai/json/arch.rkt
@@ -1,0 +1,7 @@
+#lang arch
+
+;; The two JSON modules, and two version counters: what a node IS (durable) and
+;; what a command answered (envelopes). Both are append-only within a version,
+;; so they move with the core rather than with the view.
+(clock settling)
+(owns)

--- a/olai/lang/arch.rkt
+++ b/olai/lang/arch.rkt
@@ -1,0 +1,20 @@
+#lang arch
+
+;; The language: readers, the expander, and the one graph checker. Changes here
+;; are deliberate and rare — a new form is a grammar change, and the outlines
+;; already written have to keep loading.
+;;
+;; Stable, which is the whole of "the language depends on nothing above it":
+;; an edge from here to the core or to the web view points the wrong way and
+;; the checker refuses it.
+(clock stable)
+(owns)
+
+;; @doc and @include name files, and the language checks that they are there —
+;; a path that resolves to nothing is a form that is wrong, not a document with
+;; a problem. That is the one door to the world this package opens.
+(override "expander.rkt" (owns filesystem))
+
+;; One checker for the anchor/mirror rules, over a node protocol the caller
+;; supplies — compile time and run time go through this and nowhere else.
+(override "graph.rkt" (concept anchor-graph "check-anchor-graph"))

--- a/olai/tests/arch.rkt
+++ b/olai/tests/arch.rkt
@@ -1,0 +1,12 @@
+#lang arch
+
+;; The tests. They move with whatever they are about, they reach across every
+;; layer on purpose, and they own every authority there is — a test that could
+;; not spawn a process, bind a port or write a file would not be testing this
+;; program.
+;;
+;; Declared rather than skipped. A directory the checker steps over is a
+;; directory anything can be hidden in; a directory that declares itself
+;; volatile and omnipotent says exactly what it is, in a file somebody can read.
+(clock volatile)
+(owns clock filesystem filesystem-events network subprocess threads randomness)

--- a/olai/tests/integration/chat.rkt
+++ b/olai/tests/integration/chat.rkt
@@ -790,7 +790,7 @@
     ;; the subscription and the reading of this state under one lock
     (check-equal? subscribed 1)
     (for/list ([f (in-list fs)])
-      (check-equal? (car f) acp-event-name)
+      (check-equal? (car f) chat-event-name)
       (string->jsexpr (cdr f))))
 
   (test-case "a new connection is told the conversation: the header, then the turns"

--- a/olai/tests/style.rkt
+++ b/olai/tests/style.rkt
@@ -371,14 +371,14 @@
   ;; The chat panel is position:fixed, so it takes no flow space and the reading
   ;; column reserves the gutter itself. WHICH box that gutter lands in is the
   ;; whole question: .ol-main is border-box with `max-width: 56rem`, so padding
-  ;; comes out of the cap — with --chat-w at max(21rem, 33vw) a wide screen left
+  ;; comes out of the cap — with --panel-w at max(21rem, 33vw) a wide screen left
   ;; ~13rem of text and a gutter of dead space beside it. A margin is outside the
   ;; box, so the cap still measures the text. A property question, not a
   ;; serialization one: the canary above owns css-expr's output text.
   (test-case "the chat gutter is reserved outside the reading column's box"
     (define overlay
       (fragment->css (cdr (list-ref ordered-fragments (last (class-positions ol-main))))))
-    (check-true (regexp-match? #px"margin-right\\s*:\\s*calc\\(\\s*var\\(--chat-w\\)" overlay)
+    (check-true (regexp-match? #px"margin-right\\s*:\\s*calc\\(\\s*var\\(--panel-w\\)" overlay)
                 "the panel's gutter is no longer a margin on the reading column")
     (check-false (regexp-match? #px"padding-right" overlay)
                  "the gutter is padding again: border-box takes it out of max-width"))
@@ -640,7 +640,7 @@
   ;; of the VOCABULARY, the way the theme tests are: the token lists are what
   ;; the skin has to say on the subject, and the sheet is downstream of them.
   (test-case "every custom property the scripts spell is one of the skin's tokens"
-    (define tokens (list->set (append palette-tokens layout-tokens chat-viewport-tokens)))
+    (define tokens (list->set (append palette-tokens layout-tokens viewport-tokens)))
     (for* ([js (in-list script-names)]
            [property (in-list (js-custom-properties (build-path (web-static-dir) js)))])
       (check-true (set-member? tokens property)

--- a/olai/web/arch.rkt
+++ b/olai/web/arch.rkt
@@ -24,11 +24,15 @@
 (override "serve.rkt" (owns clock filesystem network))
 
 ;; A conversation, one turn at a time: what the agent's typed events become for
-;; a reader. Nothing else spells it, and the patterns are what "it" is — the
-;; verbs that move a turn, the questions you ask a conversation, the session it
-;; is in, the transcript it leaves. `chat-w` is a layout token in theme.rkt and
-;; not a conversation, which is why the patterns are these and not `chat-*`.
+;; a reader. Nothing else spells it — the whole `chat-` surface, so a name this
+;; module has not got yet is covered before anybody writes it.
+;;
+;; Getting to say `chat-*` cost two renames: the skin's layout token was
+;; `chat-w` and the panel's viewport list was `chat-viewport-tokens`, and
+;; neither is a conversation — one is a width and one is a browser's reading of
+;; the screen. Enumerating the conversation's verbs instead would have left
+;; every export added after today outside its own concept, which is the same
+;; rot in a different place.
 (override "chat.rkt"
           (owns clock threads)
-          (concept chat-conversation
-                   "chat-*!" "chat-*?" "chat?" "chat-session*" "chat-transcript" "make-chat"))
+          (concept chat-conversation "chat-*" "make-chat"))

--- a/olai/web/arch.rkt
+++ b/olai/web/arch.rkt
@@ -1,0 +1,34 @@
+#lang arch
+
+;; Drawing. Every feature lands here, and the two busiest files in the repo are
+;; in this directory — so volatile is not an insult, it is the measurement.
+;;
+;; Volatile may depend on anything: that is what makes this the place the store,
+;; the watcher and the SSE hub are allowed to meet. Nothing declared stable or
+;; settling may depend on anything here, which is "core must build without
+;; web/" with a check under it.
+(clock volatile)
+
+;; Drawing is pure. The three exceptions declare themselves.
+(owns)
+
+;; When the outline changed, and when the day rolls over. Its own thread, its
+;; own filesystem watch, and a clock read for midnight — it knows WHEN and
+;; nothing about what or how.
+(override "watch.rkt"
+          (owns clock filesystem-events threads)
+          (concept outline-watching "start-watcher" "seconds-until-midnight"))
+
+;; The one place a socket is bound and a request is answered. It reads today's
+;; date, serves static files off the disk, and mounts everything else.
+(override "serve.rkt" (owns clock filesystem network))
+
+;; A conversation, one turn at a time: what the agent's typed events become for
+;; a reader. Nothing else spells it, and the patterns are what "it" is — the
+;; verbs that move a turn, the questions you ask a conversation, the session it
+;; is in, the transcript it leaves. `chat-w` is a layout token in theme.rkt and
+;; not a conversation, which is why the patterns are these and not `chat-*`.
+(override "chat.rkt"
+          (owns clock threads)
+          (concept chat-conversation
+                   "chat-*!" "chat-*?" "chat?" "chat-session*" "chat-transcript" "make-chat"))

--- a/olai/web/chat-panel.rkt
+++ b/olai/web/chat-panel.rkt
@@ -116,7 +116,7 @@
 ;; are what a page whose scripts have not run gets, and where a desktop browser
 ;; stays — the whole viewport, flush with the bottom, which is what the side
 ;; panel always was.
-(define-tokens chat-viewport-tokens visible-h visible-bottom)
+(define-tokens viewport-tokens visible-h visible-bottom)
 
 (register-fragment!
  #:layer 'base
@@ -126,7 +126,7 @@
   #:position fixed
   #:right 0
   #:z-index 19
-  #:width ,chat-w
+  #:width ,panel-w
   #:bottom ,visible-bottom
   #:height ,visible-h
   #:display none
@@ -151,7 +151,7 @@
 ;;
 ;; MARGIN, not padding. .ol-main is border-box with `max-width: 56rem`, so a
 ;; padding gutter is taken out of that cap rather than out of the free space
-;; beside it: --chat-w is max(21rem, 33vw), so on a 1920px screen the gutter ate
+;; beside it: --panel-w is max(21rem, 33vw), so on a 1920px screen the gutter ate
 ;; 41rem of the 56rem and the text wrapped into what was left, three words to a
 ;; line, with the gutter sitting empty next to it. A margin is outside the
 ;; border box, so the cap still measures the reading column and the flex box
@@ -160,7 +160,7 @@
  #:layer 'overlay
  (css-expr
   [((: ,(sel 'body ol-body) (apply has ,(sel ol-chat is-open))) ,(sel ol-main))
-   #:margin-right (apply calc (+ ,chat-w 1.5rem))
+   #:margin-right (apply calc (+ ,panel-w 1.5rem))
    ;; The other half of sheet mode (see the block at the end of this module):
    ;; below phone-max the panel covers the outline instead of sitting beside it,
    ;; so there is nothing to make room for — and a gutter the width of the

--- a/olai/web/chat.rkt
+++ b/olai/web/chat.rkt
@@ -51,7 +51,7 @@
 ;; command, a directory) and where to put frames, and nothing else; every other
 ;; export is a verb or a read.
 (provide (contract-out
-          [acp-event-name string?]
+          [chat-event-name string?]
           ;; the words a transcript is written in (see "the vocabulary")
           [tool-pending string?]
           [tool-in-progress string?]
@@ -94,7 +94,7 @@
 ;; The SSE event name chat frames ride under, as the string the wire and the
 ;; page's data- attribute both want. One owner, and now one declaration behind
 ;; it: a typo here does not compile.
-(define acp-event-name (stream-event chat-events 'chat))
+(define chat-event-name (stream-event chat-events 'chat))
 
 ;; A wedged turn must not make "new chat" hang: cancel, wait this long, then
 ;; take the subprocess away from it.
@@ -197,7 +197,7 @@
 
 ;; ---- frames ----------------------------------------------------------------
 ;;
-;; A frame is one line of JSON under `acp-event-name`. Callers hold `sema`:
+;; A frame is one line of JSON under `chat-event-name`. Callers hold `sema`:
 ;; broadcasting inside the lock is what keeps the stream and the transcript
 ;; telling the same story in the same order.
 ;;
@@ -279,7 +279,7 @@
 
 (define (broadcast! ch js)
   (with-handlers ([exn:fail? (λ (e) (log! ch (format "broadcast failed: ~a" (exn-message e))))])
-    ((conversation-broadcast ch) acp-event-name (jsexpr->string js))))
+    ((conversation-broadcast ch) chat-event-name (jsexpr->string js))))
 
 ;; The agent's log is the server's log: one sink, one prefix, and the client
 ;; owns both because it owns the process filling them.
@@ -358,7 +358,7 @@
          (header-frames ch)
          (append* (map entry-frames (reverse (conversation-entries ch))))))))
   (for/list ([js (in-list frames)])
-    (cons acp-event-name (jsexpr->string js))))
+    (cons chat-event-name (jsexpr->string js))))
 
 ;; What the header says, for a header that has heard none of it said. Each of
 ;; these is a fact or it is nothing: an unknown model, an unnamed conversation

--- a/olai/web/serve.rkt
+++ b/olai/web/serve.rkt
@@ -276,7 +276,7 @@
                      #:cancel-href chat-cancel-href
                      #:sessions-href chat-sessions-href
                      #:load-href chat-load-href
-                     #:event acp-event-name))
+                     #:event chat-event-name))
 
 ;; The conversation's failure kinds, as statuses: 'busy is a second prompt
 ;; while a turn runs, 'validation is an agent that has been stopped. Terse

--- a/olai/web/theme.rkt
+++ b/olai/web/theme.rkt
@@ -81,7 +81,7 @@
 ;; The rest of the vocabulary: shape and type, which do not change with the
 ;; theme, so they are declared once and never mapped.
 (define-tokens layout-tokens
-  sans mono sidebar-w chat-w indent radius)
+  sans mono sidebar-w panel-w indent radius)
 
 ;; Four constants that are not custom properties because CSS cannot read one
 ;; where they are used — a media query's width, and three values a rule repeats
@@ -511,7 +511,7 @@
             "Liberation Mono" monospace
 
    #:--sidebar-w 15rem
-   #:--chat-w (apply max 21rem 33vw)
+   #:--panel-w (apply max 21rem 33vw)
    #:--indent 1.375rem
    #:--radius 0.375rem]))
 


### PR DESCRIPTION
## What it is

Architecture as data. One `arch.rkt` per package says how fast the code under
it moves, what ambient authority it may reach for, and which concepts it owns.
`just arch` holds the tree to it.

```
$ just arch
arch: 120 modules in 10 declared packages — the tree agrees with itself
```

```racket
;; olai/web/arch.rkt
#lang arch
(clock volatile)
(owns)                                        ; drawing is pure
(override "watch.rkt" (owns clock filesystem-events threads)
                      (concept outline-watching "start-watcher" "seconds-until-midnight"))
(override "serve.rkt" (owns clock filesystem network))
```

Four forms, closed vocabulary, srcloc'd refusals at compile time, the house
pattern. `arch/README.md` is the grammar and the caveats.

## The checks, and what each one replaced

Spec: [docs/brainstorming/architecture-as-data.md](docs/brainstorming/architecture-as-data.md).

| # | check | spec § | CLAUDE.md line it replaces |
|---|---|---|---|
| 1 | dependencies point volatile → stable, never back | *The checks* 1 | "Core must build without `web/`"; "`olai/acp.rkt` … no `web/`"; "they meet only in `serve.rkt`" |
| 2 | ambient authority used only where owned | *The checks* 2 | "Pure logic takes `today` as an argument (testable, no clocks)." |
| 3 | one owner per tagged concept | *The checks* 3 | "Node keys are minted in the load layer, not the expander"; "Nothing else spells either." |
| 4 | declarations audited against `git log` | *The checks* 4 | nothing — new |

Two smaller checks ride along, each auditing a declaration rather than the
code (*The declarations*): an authority spelling has to be a name its module
really exports, and a concept has to have exactly one claimant. Without them
the check they serve would quietly apply to nobody.

**Every CLAUDE.md line deleted**, verbatim:

1. `* Core must build without `web/`: file naming is `olai/paths` (`file-label`, `key-label`), not a renderer helper.` — the rule goes (check 1); the file-naming fact stays as its own bullet, and is also `(concept file-naming …)` on `olai/paths.rkt`.
2. `no `web/`` — from the acp bullet (check 1).
3. `they meet only in `serve.rkt`` — from the live-view bullet (check 1). See *Coverage*, below.
4. `Pure logic takes `today` as an argument (testable, no clocks).` — from the `main.rkt` bullet (check 2).
5. `Node keys are minted in the load layer, not the expander (see docs/cli.md)` — from the store/index bullet (check 3); the `docs/cli.md` pointer survives as "see docs/cli.md for what a key is".
6. `Nothing else spells either.` — from the acp/chat bullet (check 3).

The block gains one pointer line naming `arch/README.md`, `just arch` and the
six rules that are checks now. That is the only CLAUDE.md edit.

One correction rode along in the same block, because the bullet was being
rewritten anyway: the live-view line named `web/events.rkt`, which has not
existed since the hub moved to `live/hub.rkt`.

## Bootstrapped from truth

Per the spec's open question — declare what git and the imports say, not what
anyone wishes:

* `olai/web/` is **volatile** because `render.rkt` and `serve.rkt` each changed
  in 8 of the last 30 commits. Declared stable, check 4 says so.
* `olai/cli.rkt` and `olai/main.rkt` are **volatile** overrides inside a
  settling package: one mounts the server, the other re-exports the web render.
  Their own churn is low; what they import decides.
* `olai/lang/expander.rkt` **owns the filesystem**. `@doc` and `@include` check
  that a file is there, in the language. That is not what anyone would have
  written down in advance.
* `olai/dates.rkt` owns the clock and hands it on as `today-iso-string`, so
  `cli.rkt` and `web/serve.rkt` own the clock too — exactly the list the spec
  predicted.
* `olai/tests/`, `live/tests/` and `arch/tests/` declare themselves volatile
  and omnipotent rather than being skipped. A directory the checker steps over
  is a directory anything can be hidden in.

## What the checks found in olai, on day one

Three renames, each one the checker refusing a name that was in the wrong place:

* `olai/web/chat.rkt` exported **`acp-event-name`**, which is not an ACP name —
  it is the SSE event the chat panel rides — and it sat inside `olai/acp.rkt`'s
  `acp-*` concept. Now `chat-event-name`.
* the skin's **`chat-w`** (a width) and the panel's **`chat-viewport-tokens`**
  (a browser's reading of the screen) are not conversations, and they were the
  only reason the `chat-conversation` concept could not just be `chat-*`. Now
  `panel-w` and `viewport-tokens`.

That is the whole of the olai-side code change. Everything else in the diff is
new files.

## Coverage, stated honestly

Check 1 enforces the *direction* of every declared edge. For row 3 of the table
that means store (settling) cannot import watch (volatile), and nothing stable
or settling may import either — which is the part that used to fail silently.
It does **not** forbid `web/watch.rkt` importing `live/hub.rkt`: both ends are
legal under the clocks, and a "sole consumer" rule is not in the spec's
vocabulary. The prose said more than four checks can; the four checks cover the
failure that stayed green.

The other honest limits are in `arch/README.md`: reading rather than expanding
misses a macro-introduced dependency; an authority counts when its name is in
operator position (or right after `apply`) and binding positions do not count,
which is what keeps the rule from punishing `(define (agenda-groups tasks
today) …)` and `(for ([today days]) …)` — the code that obeys it; and `only-in`
is not modelled, so the error is on the side of declaring.

## Why `arch/` is its own package

`live/` imports nothing from olai and never will. Its declaration is a `#lang
arch` module, so the language cannot live inside `olai` without inverting that
— and a package cycle is not a thing raco will build. So `arch` is a collection
of its own under both, depending on `base` and nothing else. It is packaged for
Nix for the same reason: `live/arch.rkt` and `olai/**/arch.rkt` are modules,
and any build installing those collections has to compile them.

The spec's sketch writes `#lang olai/arch`; that spelling is the one thing here
that could not be built.

## Seeing what it thinks

```
$ just arch --explain olai/web/watch.rkt
olai/web/watch.rkt
  governed by  olai/web/arch.rkt
  clock        volatile           olai/web/arch.rkt:10 (package default)
  owns         clock              olai/web/arch.rkt:19 (override "watch.rkt")
               filesystem-events  olai/web/arch.rkt:19 (override "watch.rkt")
               threads            olai/web/arch.rkt:19 (override "watch.rkt")
  churn        0 of the last 30 commits — volatile has no ceiling
  requires     olai/store.rkt (settling)
```

## Tested

33 tests in `arch/tests/`, message text **and** srcloc for every refusal and
every finding: 12 grammar refusals, the four checks against repositories three
files long (written into temp dirs, `git init`-ed for the churn audit — nothing
committed, because a fixture meant to fail a check is one the real run would
trip over), and `--explain`'s output.

`just test` 372 · `just test-integration` 118 · `just e2e` 68 scenarios ·
`nix build` · `nix build .#arch .#counters` — all green locally.

## Mechanics

* `just arch`, `just arch --explain FILE`, `just arch --window N`. ~1.2s with
  `.zo` on disk, so it lives in the edit loop.
* Its own CI node (`ci/mod.just`), not part of `test`: a layering violation and
  a failing test are different failure classes.
* No new dependencies. `arch` is `base` only.

## The three commits

1. **the checker** — language, checks, declarations, wiring, CLAUDE.md.
2. **hickey + lowy** — the effective declaration was derived twice by two
   paths; "what a clock allows" was spelled three ways; `arch/vocabulary` held
   both the ratified words and how words are printed, two axes behind one
   module.
3. **/simplify** (four reviewers) — check 3 was built on a different model than
   the other three, so a package-level concept reached into a deeper package;
   `(provide (struct-out task))` recorded `task` at the *provide's* line;
   `(for ([today days]) …)` would have read as a clock call. Plus the renames
   above, 1.50s → 1.21s, and five struct fields and twelve requires nothing
   read. Each commit message says what was skipped and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
