### PR TITLE
web: the note opens on a click, not on a pointer going past

### DIFF
--- a/e2e/features/note.feature
+++ b/e2e/features/note.feature
@@ -1,53 +1,64 @@
 Feature: a note folded to one line
 
-  A node's note is drawn one line tall, ellipsized, with the whole of it still
-  in the page: pointing at the node opens it, and pointing away folds it back.
-  The fold is a box, not a shorter string, so nothing a reader could search for
-  is missing while it is folded.
+  A node's note is drawn one line tall, with the whole of it still in the page.
+  The "…" beside it opens it and folds it again — a click, never a hover: a
+  note that answered the pointer moved the page under the cursor, and crossing
+  the outline opened whatever was on the way.
 
-  A note that already fits on one line has nothing to open, and shows nothing
-  saying it has.
+  A note that already fits on one line carries no "…" at all: there is nothing
+  to open, and nothing says there is.
 
-  Scenario: a long note is one line until you point at the node
+  Scenario: a long note is one line, and says there is more
     When I open the home page
-    Then the note under "Ship the server" is folded to one line
+    Then the note under "Ship the server" is folded
+    And the note under "Ship the server" offers to open
     And the note under "Ship the server" still says "only the first is on it"
-    When I point at "Ship the server"
-    Then the note under "Ship the server" shows all of it
-    When I point away
-    Then the note under "Ship the server" is folded to one line
 
-  # A node opens its OWN note. Were it the whole subtree's, pointing at a leaf
-  # would open every note above it at once — the page moving under the cursor
-  # to say something about nodes it is nowhere near.
-  Scenario: pointing at a child does not open its parent's note
-    When I open the home page
-    And I point at "Write the tests"
-    Then the note under "Ship the server" is folded to one line
-
-  Scenario: a note that fits on one line has nothing to open
+  Scenario: a note that fits on one line offers nothing
     When I open the home page
     Then the note under "Inbox" shows all of it
-    And the note under "Inbox" is one line tall
+    And the note under "Inbox" offers nothing to open
 
-  # The note is focusable, so a tap is what opens it where there is no pointer
-  # to hover with. The pointer is taken off the note afterwards: on a desktop
-  # browser the click hovers it too, and hover is the mechanism this scenario
-  # is not about.
-  @phone
-  Scenario: a tap opens the note where there is no hover
+  Scenario: the button opens the note, and folds it again
     When I open the home page
-    Then the note under "Ship the server" is folded to one line
-    When I tap the note under "Ship the server"
-    And I point away
+    And I open the note under "Ship the server"
+    Then the note under "Ship the server" shows all of it
+    When I fold the note under "Ship the server"
+    Then the note under "Ship the server" is folded
+
+  # Travelling over the outline is not a decision. This is the scenario the
+  # hover version failed.
+  Scenario: pointing at a note does nothing
+    When I open the home page
+    And I point at the note under "Ship the server"
+    Then the note under "Ship the server" is folded
+
+  @phone
+  Scenario: the button is a target for a finger
+    When I open the home page
+    Then the note under "Ship the server" is folded
+    When I tap the note's button under "Ship the server"
     Then the note under "Ship the server" shows all of it
 
-  Scenario: an open note is still open after the live view re-swaps it
+  Scenario: an open note outlives a reload
     When I open the home page
-    And I tap the note under "Ship the server"
-    And I point away
+    And I open the note under "Ship the server"
+    And I reload the page
+    Then the note under "Ship the server" shows all of it
+
+  Scenario: an open note outlives the live view's re-swap
+    When I open the home page
+    And I open the note under "Ship the server"
     And I mark this page load
     And I add the title "Feed the cat" to the outline
     Then I see the title "Feed the cat"
     And the page has not reloaded
     And the note under "Ship the server" shows all of it
+
+  # The same node at two SITES is two notes, and each is opened on its own —
+  # the way the fold is keyed per site.
+  Scenario: opening a note leaves its mirror folded
+    When I open the home page
+    And I open the note under "Ship the server"
+    Then the note under "Ship the server" shows all of it
+    And the mirrored note under "This week" is folded

--- a/e2e/steps/note_steps.js
+++ b/e2e/steps/note_steps.js
@@ -1,10 +1,10 @@
-// The note's fold: how tall the box is, and whether anything is being cut off
-// by it.
+// The note's fold: how tall the box is, whether anything is being cut off by
+// it, and the button that decides.
 //
-// Both questions are asked of the ELEMENT rather than of a class, because
-// there is no class to ask — the fold is CSS over a hover and a focus
-// (web/node), and nothing writes any state down. So "folded" is the box being
-// shorter than what is in it, and "open" is it no longer being so.
+// "Folded" is asked of the ELEMENT — the box being shorter than what is in it
+// — because that is what a reader sees; the class and the ARIA state are
+// asserted beside it, the way collapse_steps does, so a fold that stopped
+// saying what it is to a screen reader fails here too.
 //
 // A note is addressed through the node it belongs to, like every other part of
 // a node in this suite.
@@ -12,86 +12,143 @@
 import assert from "node:assert/strict";
 import { Then, When } from "@cucumber/cucumber";
 
-// The note of a node's OWN row: a descendant's is another node's.
-function note(world, title) {
-  return world.node(title).first().locator(":scope > .ol-row .ol-note").first();
+import { hasClass } from "../support/dom.js";
+
+// The note block of a node's OWN row: a descendant's is another node's.
+function block(world, title) {
+  return world
+    .node(title)
+    .first()
+    .locator(":scope > .ol-row .ol-note-block")
+    .first();
 }
 
-/** How the box and its contents measure up, in one round trip: whether the
- *  box is cutting anything off, and how many lines tall it is. The line count
- *  is a ratio and not a pixel count — the note's own line-height is what a
- *  line IS, and a rounded font metric would make an assertion about type
- *  sizes out of an assertion about a fold. */
-async function measure(el) {
-  await el.waitFor();
-  return await el.evaluate((n) => {
-    const lineHeight = parseFloat(getComputedStyle(n).lineHeight);
-    return {
-      clipped: n.scrollHeight > n.clientHeight + 1,
-      lines: n.clientHeight / lineHeight,
-      text: n.textContent,
-    };
-  });
+// The same node drawn at a second site, under the node it hangs from.
+function mirrorBlock(world, parent) {
+  return world
+    .node(parent)
+    .first()
+    .locator(".ol-node")
+    .filter({ has: world.page.locator(".ol-mirror") })
+    .first()
+    .locator(":scope > .ol-row .ol-note-block")
+    .first();
 }
 
-// One line tall AND cutting something off: a box that is one line tall
-// because that is all there is would pass half of this and mean the opposite.
-// The line count is generous on purpose — a note's first block carries a
-// margin, so one line of text is a little more than one line-height of box,
-// and two lines are a great deal more than this.
-Then("the note under {string} is folded to one line", async function (title) {
-  const m = await measure(note(this, title));
-  assert.ok(m.clipped, `${title}: the note is showing everything it has`);
-  assert.ok(
-    m.lines < 1.75,
-    `${title}: the note is ${m.lines.toFixed(2)} lines tall, not one`,
-  );
+/** Whether the fold is cutting anything off, in one round trip. Nothing here
+ *  measures a line height: what "one line" is belongs to the stylesheet, and
+ *  the question a reader asks is only whether there is more than is showing. */
+async function clipped(blk) {
+  const note = blk.locator(".ol-note").first();
+  await note.waitFor();
+  return await note.evaluate((n) => n.scrollHeight > n.clientHeight + 1);
+}
+
+/** Wait until notes.js has had its pass over this page.
+ *
+ *  The button is drawn from a MEASUREMENT, so before that pass every note
+ *  looks like a note with nothing to open — which is exactly what half these
+ *  steps assert. The fixture guarantees one note that does have more in it, so
+ *  its button appearing is the honest signal that the pass has happened. */
+async function measured(world) {
+  await world.page.locator(".ol-note-block.has-more").first().waitFor();
+}
+
+// ---- what the fold is doing ------------------------------------------------
+
+Then("the note under {string} is folded", async function (title) {
+  await assertFolded(block(this, title), true, title);
 });
 
-Then("the note under {string} is one line tall", async function (title) {
-  const m = await measure(note(this, title));
-  assert.ok(
-    m.lines < 1.75,
-    `${title}: the note is ${m.lines.toFixed(2)} lines tall, not one`,
-  );
+Then("the mirrored note under {string} is folded", async function (parent) {
+  await assertFolded(mirrorBlock(this, parent), true, `the mirror under ${parent}`);
 });
 
 // Nothing cut off. For the note that is already one line this is the whole
-// assertion: there is no ellipsis, because there is nothing to ellipsize.
+// assertion: nothing was ever hidden, so there is nothing to open.
 Then("the note under {string} shows all of it", async function (title) {
-  const m = await measure(note(this, title));
-  assert.ok(!m.clipped, `${title}: the note is still cutting itself off`);
+  assert.equal(
+    await clipped(block(this, title)),
+    false,
+    `${title}: the note is still cutting itself off`,
+  );
 });
 
 // The point of a fold that is a BOX: folded or not, the text is in the page,
 // so find-in-page finds it and a morph has it to compare against.
 Then("the note under {string} still says {string}", async function (title, text) {
-  const m = await measure(note(this, title));
-  assert.ok(m.clipped, `${title}: the note is not folded, so this proves nothing`);
-  assert.ok(
-    m.text.includes(text),
-    `${title}: the folded note has lost "${text}"`,
+  const blk = block(this, title);
+  assert.equal(await clipped(blk), true, `${title}: the note is not folded`);
+  const said = await blk.locator(".ol-note").first().textContent();
+  assert.ok(said.includes(text), `${title}: the folded note has lost "${text}"`);
+});
+
+// ---- the affordance --------------------------------------------------------
+
+Then("the note under {string} offers to open", async function (title) {
+  await button(block(this, title)).waitFor({ state: "visible" });
+});
+
+Then("the note under {string} offers nothing to open", async function (title) {
+  await measured(this);
+  assert.equal(
+    await button(block(this, title)).isVisible(),
+    false,
+    `${title}: a note that fits on its line is offering to open`,
   );
 });
 
-// ---- the two ways to open one ----------------------------------------------
+// ---- opening and folding ---------------------------------------------------
 
-// The pointer goes on the node's own TITLE: anywhere in the node opens it, and
-// the title is the part of it every node has.
-When("I point at {string}", async function (title) {
-  await this.node(title)
-    .first()
-    .locator(":scope > .ol-row .ol-title")
-    .first()
-    .hover();
+When("I open the note under {string}", async function (title) {
+  await setOpen(this, block(this, title), true);
 });
 
-// Off every node, without leaving the page: the top-left corner is the
-// sidebar's, which has no notes in it.
-When("I point away", async function () {
-  await this.page.mouse.move(0, 0);
+When("I fold the note under {string}", async function (title) {
+  await setOpen(this, block(this, title), false);
 });
 
-When("I tap the note under {string}", async function (title) {
-  await note(this, title).click();
+// The button and nothing else. Named as a tap because the scenario that uses
+// it runs on a phone screen, where it is the whole of the interaction.
+When("I tap the note's button under {string}", async function (title) {
+  await measured(this);
+  await button(block(this, title)).click();
 });
+
+// A pointer that is only passing through. The step exists to be followed by an
+// assertion that nothing happened.
+When("I point at the note under {string}", async function (title) {
+  await measured(this);
+  await block(this, title).locator(".ol-note").first().hover();
+});
+
+// ---- helpers ---------------------------------------------------------------
+
+function button(blk) {
+  return blk.locator(".ol-note-more").first();
+}
+
+/** Press the button only when it is pointing the wrong way: it is a toggle, so
+ *  a step that always clicked would mean "open" or "fold" by luck. */
+async function setOpen(world, blk, want) {
+  await measured(world);
+  if ((await hasClass(blk, "is-expanded")) === want) return;
+  await button(blk).click();
+}
+
+async function assertFolded(blk, want, what) {
+  assert.equal(await clipped(blk), want, `${what}: the fold is the wrong way round`);
+  assert.equal(
+    await hasClass(blk, "is-expanded"),
+    !want,
+    `${what}: the class disagrees with what is on screen`,
+  );
+  const btn = button(blk);
+  if (await btn.isVisible()) {
+    assert.equal(
+      await btn.getAttribute("aria-expanded"),
+      want ? "false" : "true",
+      `${what}: aria-expanded disagrees with the fold`,
+    );
+  }
+}

--- a/olai/tests/classes.golden
+++ b/olai/tests/classes.golden
@@ -1,11 +1,13 @@
 has-children
 has-commands
+has-more
 is-agent
 is-busy
 is-collapsed
 is-doing
 is-done
 is-error
+is-expanded
 is-on
 is-open
 is-picked
@@ -81,6 +83,8 @@ ol-nav-icon
 ol-nav-item
 ol-node
 ol-note
+ol-note-block
+ol-note-more
 ol-outline
 ol-pane
 ol-pill

--- a/olai/tests/render.rkt
+++ b/olai/tests/render.rkt
@@ -216,6 +216,31 @@
     (check-true (string-contains? s "☐") s)
     (check-false (string-contains? s "is-done") s))
 
+  ;; A note is drawn folded, with the button that opens it and the key the
+  ;; browser remembers that by. Everything about it that MOVES is the script's
+  ;; (olai/web/static/notes.js) — the page is drawn one way, every time.
+  (test-case "a note carries its opener, folded, keyed, and pointing at itself"
+    (define s (xstr (render-node-fragment (tk "T" #f "a note" '() #:key "k1")
+                                          #:today "2026-08-04")))
+    (check-true (string-contains? s "data-note-key=\"k1\"") s)
+    (check-true (string-contains? s "ol-note-more") s)
+    (check-true (string-contains? s "aria-expanded=\"false\"") s)
+    ;; the control names what it opens, and that is the note's own element
+    (check-true (string-contains? s "class=\"ol-note\" id=\"ol-live-k1-note\"") s)
+    (check-true (string-contains? s "aria-controls=\"ol-live-k1-note\"") s)
+    ;; nothing is expanded, and nothing has more, until the browser says so
+    (check-false (string-contains? s "is-expanded") s)
+    (check-false (string-contains? s "has-more") s))
+
+  ;; A mirror is the same note at a second SITE, and it opens on its own: the
+  ;; key the browser remembers it by is the site's, like the fold's.
+  (test-case "a mirrored note is keyed and identified by its site"
+    (define s (xstr (render-node-fragment (tk "T" #f "a note" '() #:key "k1")
+                                          #:today "2026-08-04"
+                                          #:site "holder")))
+    (check-true (string-contains? s "data-note-key=\"holder-k1\"") s)
+    (check-true (string-contains? s "aria-controls=\"ol-live-holder-k1-note\"") s))
+
   (test-case "today's date pill is ringed; timed dates keep the clock"
     (define s (xstr (render-node-fragment (tk "T" "2026-08-04T18:00" #f '())
                                           #:today "2026-08-04")))
@@ -742,6 +767,7 @@
     (check-true (< (string-index s "/live/htmx.min.js")
                    (string-index s "/static/chat.js")))
     (check-true (string-contains? s "src=\"/static/collapse.js\"") s)
+    (check-true (string-contains? s "src=\"/static/notes.js\"") s)
     (check-true (string-contains? s "src=\"/static/prefs.js\"") s)
     (check-true (string-contains? s "src=\"/static/chat.js\"") s)
     (check-true (string-contains? s "src=\"/static/pwa.js\"") s)
@@ -844,6 +870,15 @@
     (check-true (< (length (string-split js "\n")) 40) js)
     (check-false (string-contains? js "require") js)
     (check-true (string-contains? js "olai.collapsed") js)
+    (check-true (string-contains? js "localStorage") js))
+
+  ;; The note's opener is the same kind of script and holds to the same
+  ;; sentence: browser state, stored in the browser, keyed the way the fold is.
+  (test-case "notes script stays tiny and framework-free"
+    (define js (file->string (build-path (web-static-dir) "notes.js")))
+    (check-true (< (length (string-split js "\n")) 65) js)
+    (check-false (string-contains? js "require") js)
+    (check-true (string-contains? js "olai.notes") js)
     (check-true (string-contains? js "localStorage") js))
 
   ;; A pref is client state, like the collapse state: a value on <html>, stored

--- a/olai/tests/style.rkt
+++ b/olai/tests/style.rkt
@@ -237,7 +237,7 @@
 ;; are the language files beside it — they are vendored under static/hljs/,
 ;; and scanning a minified grammar for class-shaped names would find noise.)
 (define script-names
-  '("chat.js" "collapse.js" "prefs.js" "pwa.js" "highlight-init.js"))
+  '("chat.js" "collapse.js" "notes.js" "prefs.js" "pwa.js" "highlight-init.js"))
 
 (define scripted-classes
   (for/fold ([acc (set)]) ([js (in-list script-names)])
@@ -403,21 +403,34 @@
 
   ;; A note is FOLDED to one line by a box that is one line tall, never by a
   ;; shorter string: the whole note is in the markup, and find-in-page and the
-  ;; morph both see it. What opens it is the other half — the node the pointer
-  ;; is in (and not its ancestors, which is what the :not(:has()) is for), and
-  ;; the note's own focus, which is the door a touch screen has instead of a
-  ;; hover. Behaviour is e2e/features/note.feature's; this is the rule staying
-  ;; the shape those journeys are about.
-  (test-case "a note is one line until the node is pointed at, or it has focus"
+  ;; morph both see it. It opens on the class notes.js writes, and on nothing
+  ;; else — a note that answered a hover reflowed the page under the cursor,
+  ;; and crossing the outline opened whatever was on the way. Behaviour is
+  ;; e2e/features/note.feature's; this is the rule staying the shape those
+  ;; journeys are about.
+  (test-case "a note is one line until something says it is expanded"
     (define note (fragment->css (cdr (list-ref ordered-fragments (at "ol-note")))))
-    (check-true (regexp-match? #px"-webkit-line-clamp\\s*:\\s*1" note)
-                "the note is not clamped to its first line any more")
-    (check-false (regexp-match? #px"max-height|text-overflow" note)
-                 "the note is folded by something other than the line clamp")
-    (check-true (regexp-match? #px"\\.ol-node:hover:not\\(:has\\(\\.ol-node:hover\\)\\)" note)
-                "pointing into a subtree opens every ancestor's note too")
-    (check-true (regexp-match? #px"\\.ol-note:focus-within" note)
-                "the note does not open on focus: a touch screen has no other door"))
+    (check-true (regexp-match? #px"max-height\\s*:\\s*1lh" note)
+                "the note is not folded to one line any more")
+    (check-true (regexp-match? #px"\\.ol-note-block\\.is-expanded>\\.ol-note[^{]*\\{[^}]*max-height\\s*:\\s*none"
+                               note)
+                "nothing unfolds the note")
+    (check-false (regexp-match? #px":hover" note)
+                 "the note answers a hover again")
+    ;; the button is the only ellipsis: a line clamp would draw a second one
+    ;; right beside it
+    (check-false (regexp-match? #px"line-clamp|text-overflow" note)
+                 "the fold draws an ellipsis of its own again"))
+
+  ;; And the affordance is drawn for a note that HAS more only — which nothing
+  ;; here can measure, so the rule waits on the class the script writes.
+  (test-case "the note's button is drawn only where there is more to show"
+    (define more (fragment->css (cdr (list-ref ordered-fragments (at "ol-note-more")))))
+    (check-true (regexp-match? #px"\\.ol-note-more\\{[^}]*display\\s*:\\s*none" more)
+                "the button is drawn before anything has found more to show")
+    (check-true (regexp-match? #px"\\.ol-note-block\\.has-more>\\.ol-note-more[^{]*\\{[^}]*display\\s*:\\s*inline-flex"
+                               more)
+                "nothing draws the button once there is more to show"))
 
   ;; Sheet mode: below phone-max there is no room beside the outline, so the
   ;; panel covers it instead. That is ONE decision, and this is the test that

--- a/olai/web/address.rkt
+++ b/olai/web/address.rkt
@@ -22,6 +22,7 @@
 
 (provide (contract-out
           [node-element-id (->* (string?) (#:site (or/c string? #f)) string?)]
+          [note-element-id (->* (string?) (#:site (or/c string? #f)) string?)]
           [site-key (-> (or/c string? #f) string? string?)]
           [node-link-attributes (-> (or/c string? #f) string? list?)]
           [id-safe (-> string? string?)]))
@@ -39,6 +40,13 @@
 ;; Nothing here writes a prefix.
 (define (node-element-id key #:site [site #f])
   (live-id ol-live (site-key site key)))
+
+;; A node's NOTE is an element of its own, because a control has to name what
+;; it opens (aria-controls wants an id). Derived from the node's id rather than
+;; minted beside it: a mirror site's note is then its own element for the same
+;; reason the site's node is, and the two ids cannot drift apart.
+(define (note-element-id key #:site [site #f])
+  (string-append (node-element-id key #:site site) "-note"))
 
 (define (site-key site key)
   (if site (string-append site "-" key) key))

--- a/olai/web/assets.rkt
+++ b/olai/web/assets.rkt
@@ -43,7 +43,7 @@
 ;; The highlighter is under this prefix and not in this literal: which files
 ;; paint a fenced code block is web/markdown's to say (see the require above).
 (define web-scripts
-  (append '("collapse.js" "prefs.js" "chat.js" "pwa.js")
+  (append '("collapse.js" "notes.js" "prefs.js" "chat.js" "pwa.js")
           highlight-scripts))
 
 (define (static-href name) (string-append web-static-prefix name))

--- a/olai/web/node.rkt
+++ b/olai/web/node.rkt
@@ -29,7 +29,8 @@
          olai/web/markdown
          (only-in olai/web/states
                   is-done is-doing is-tree is-collapsed has-children state-class)
-         (only-in olai/web/address node-element-id site-key node-link-attributes)
+         (only-in olai/web/address
+                  node-element-id note-element-id site-key node-link-attributes)
          (only-in olai/web/pills day-pill-xexpr date-pill-xexpr doing-pill-xexpr)
          (only-in olai/web/checkbox checkbox-xexpr ol-check)
          (only-in olai/web/document doc-block))
@@ -226,51 +227,63 @@
 
 (define-style ol-dim #:color ,dim)
 
-;; THE NOTE, folded to one line.
+;; THE NOTE: one line of it, and the "…" that opens the rest.
 ;;
-;; Folded is what a note is drawn as, and the fold is a BOX one line tall —
-;; never a shorter string. The whole note is in the markup either way, so
-;; find-in-page still finds the rest of it and a live re-swap morphs the same
-;; text it always did. A note that IS one line overflows nothing, and so gets
-;; no ellipsis and has nothing to open: the overflow is the affordance, and
-;; only an overflow draws one.
+;; A note is drawn folded, and the fold is a BOX one line tall — never a
+;; shorter string. The whole note is in the markup either way, so find-in-page
+;; still finds the rest of it and a live re-swap morphs the same text it always
+;; did.
 ;;
-;; It opens while the pointer is in the NODE — its own row, and the gutter
-;; beside its children — rather than only while it is on the row. Opening
-;; pushes the page down under the cursor, and a note that folded again the
-;; moment the pointer wobbled off the line it had just moved would do that
-;; twice. A node UNDER this one opens its own note instead of its ancestors',
-;; which is what the :not(:has()) says.
+;; It opens on a CLICK and on nothing else. It opened on hover once, and a
+;; hover is not a decision: the page reflowed under the cursor, and crossing
+;; the outline on the way somewhere opened three notes that nobody asked for.
+;; So the affordance is a button, the state is a state, and travelling over a
+;; note does nothing at all.
 ;;
-;; And it opens on focus, which is the tap: a touch screen has no pointer to
-;; hover with, so the note is a focusable region (the tabindex the markup
-;; below puts on it) — a tap opens it, a tap elsewhere closes it, and a
-;; keyboard gets the same door for free. No script: a class a script toggled
-;; would be view state to put back after every morph, and this is state the
-;; browser is already keeping.
+;; Two of the three parts are CSS and the third cannot be. The fold is a
+;; max-height (here), and what it looks like open is a class on the block
+;; (notes.js). Whether there IS more than one line in a note is a MEASUREMENT
+;; — it depends on the note, the type and the width of the window — so the
+;; script asks the layout and says so with .has-more, and this file paints the
+;; answer. A note that fits on its line carries no button, no ellipsis and no
+;; tab stop: the overflow is the affordance, and only an overflow draws one.
+;;
+;; The clamp draws no ellipsis of its own (a max-height cuts at a line, and
+;; -webkit-line-clamp would put a "…" right beside the button's). The button IS
+;; the ellipsis, and it is the only one.
 ;;
 ;; The @doc lead (web/document) wears the same one-line look and is not the
 ;; same mechanism — that one is one line because the rest of the document is a
 ;; page away, and it does not open at all.
+
+;; Hooks the script writes and these rules read: what the measurement found,
+;; and what you did about it. notes.js is the only writer of either.
+(define-modifier has-more is-expanded)
+
+;; The note and its button, side by side: the button keeps to the first line's
+;; height, so opening the note grows the text and leaves the control where it
+;; was.
+(define-style ol-note-block
+  #:display flex
+  #:align-items flex-start
+  #:gap 0.25rem
+  #:min-width 0)
+
 (define-style ol-note
+  #:flex (1 1 auto)
+  #:min-width 0
   #:margin-top 0.125rem
   #:color ,dim
   #:font-size 0.875rem
-  ;; folded: the first rendered line, and the ellipsis that says there is more
-  #:display -webkit-box
-  #:-webkit-box-orient vertical
-  #:-webkit-line-clamp 1
+  ;; folded: one line tall, and everything else is behind the edge of the box
+  #:max-height 1lh
   #:overflow hidden
+  [(> ,(sel ol-note-block is-expanded) &) #:max-height none #:overflow visible]
   [,(sel '& is-done) #:opacity 0.65 #:text-decoration line-through]
-  ;; open: the pointer is in this node and in no node under it, or the note
-  ;; itself has the focus
-  [(> (: (: ,(sel ol-node) hover)
-         (apply not (: (apply has (: ,(sel ol-node) hover)))))
-      (,(sel ol-row) &))
-   (: & focus-within)
-   #:display block
-   #:-webkit-line-clamp none
-   #:overflow visible]
+  ;; the note's own margin is the space above it; a first block's would be a
+  ;; second one, and it would push the first line out of a one-line box
+  [(> & (: first-child)) #:margin-top 0]
+  [(> & (: last-child)) #:margin-bottom 0]
   ;; Markdown blocks inside a note: tightened, never the browser's defaults
   [(& p) #:margin (0.25rem 0)]
   [(& ul) (& ol) #:margin (0.25rem 0) #:padding-left 1.25rem]
@@ -278,6 +291,49 @@
    #:margin (0.25rem 0)
    #:padding-left 0.75rem
    #:border-left (2px solid ,line)])
+
+;; The "…", which is the whole affordance: one line's height beside the note,
+;; drawn only for a note with more in it than that.
+(define-style ol-note-more
+  #:flex (0 0 auto)
+  ;; nothing to open until the script has found something to open
+  #:display none
+  #:align-items center
+  #:justify-content center
+  #:height 1lh
+  #:margin-top 0.125rem
+  #:padding (0 0.25rem)
+  #:border 0
+  #:border-radius ,radius
+  #:background none
+  #:color ,dim
+  #:font-family ,mono
+  #:font-size 0.875rem
+  #:cursor pointer
+  [(> ,(sel ol-note-block has-more) &) #:display inline-flex]
+  ;; open, so the button is now the way back: it stays lit saying so
+  [(> ,(sel ol-note-block is-expanded) &) #:color ,ink]
+  [(: & hover) (: & focus-visible) #:color ,ink #:background ,pill-bg]
+  ;; a finger needs a bigger target than a mouse, the way the disclosure
+  ;; triangle above does
+  [@ media (#:max-width ,phone-max)
+     #:height 1.75rem
+     #:min-width 1.75rem
+     #:font-size 1rem])
+
+;; The note, and the control that opens it. `key` is this SITE's key — a
+;; mirror of a node opens and folds on its own, like its fold does.
+(define (note-block-xexpr tk key note-id done?)
+  `(div ((class ,ol-note-block) (data-note-key ,key))
+        (div ((class ,(classes ol-note (and done? is-done))) (id ,note-id))
+             ,@(note->xexprs (task-description tk)))
+        (button ((type "button")
+                 (class ,ol-note-more)
+                 (aria-expanded "false")
+                 (aria-controls ,note-id)
+                 (aria-label "show the whole note")
+                 (title "show the whole note"))
+                "…")))
 
 ;; A permalink target, not a thing to see.
 (define-style ol-anchor #:position absolute #:width 0 #:height 0 #:overflow hidden)
@@ -406,11 +462,9 @@
                           (list (date-pill-xexpr (task-date tk) today done?))
                           '()))
                ,@(if (task-description tk)
-                     ;; folded to one line, and focusable so a touch screen
-                     ;; has a way to open it (the styles above say why)
-                     (list `(div ((class ,(classes ol-note (and done? is-done)))
-                                  (tabindex "0"))
-                                 ,@(note->xexprs (task-description tk))))
+                     (list (note-block-xexpr tk qkey
+                                             (note-element-id key #:site site)
+                                             done?))
                      '())))
    #:after-row (doc-block tk docs doc-expanded? zoom-base)
    #:children (for/list ([c (in-list kids)])

--- a/olai/web/static/notes.js
+++ b/olai/web/static/notes.js
@@ -1,0 +1,60 @@
+// A note is one line until you open it: the "…" beside it toggles, and the
+// open ones are remembered per data-note-key, like the fold in collapse.js.
+// Unvisited keys stay the way the server drew them, which is folded.
+//
+// The script owns the two things CSS cannot answer. WHETHER a note has more in
+// it than its line is showing is a measurement — it moves with the window —
+// and it is what puts .has-more on the block, so a note that fits carries no
+// button at all. WHICH notes you opened is a fact about you, not about the
+// outline, so it is .is-expanded and localStorage and nothing on the wire.
+(function(){
+  var KEY='olai.notes',state={};
+  try{state=JSON.parse(localStorage.getItem(KEY)||'{}')||{}}catch(e){state={}}
+  function set(n,open){
+    n.classList.toggle('is-expanded',open);
+    var b=n.querySelector('.ol-note-more');
+    if(b)b.setAttribute('aria-expanded',open?'true':'false');
+  }
+  // Folded is the only state a measurement means anything in — an open note is
+  // as tall as its own contents, and overflows nothing — so every note is
+  // folded, then measured, then put back the way it was. Three passes and not
+  // one loop: a write between two reads is a layout per note.
+  function apply(){
+    var blocks=[].slice.call(document.querySelectorAll('[data-note-key]'));
+    blocks.forEach(function(n){n.classList.remove('is-expanded')});
+    var more=blocks.map(function(n){
+      var t=n.querySelector('.ol-note');
+      return !!t&&t.scrollHeight>t.clientHeight+1;
+    });
+    blocks.forEach(function(n,i){
+      n.classList.toggle('has-more',more[i]);
+      set(n,more[i]&&state[n.dataset.noteKey]===true);
+    });
+  }
+  document.addEventListener('click',function(e){
+    var b=e.target.closest('.ol-note-more');if(!b)return;
+    var n=b.closest('[data-note-key]');if(!n)return;
+    e.preventDefault();
+    var open=!n.classList.contains('is-expanded');
+    state[n.dataset.noteKey]=open;
+    set(n,open);
+    // same guard as the read above: storage can be full or forbidden, and a
+    // note that threw would be open with nothing remembering it
+    try{localStorage.setItem(KEY,JSON.stringify(state))}catch(e){}
+  });
+  // afterSETTLE, not afterSwap: the class attribute the server sent lands in
+  // the settle phase, and this pass is what goes back on top of it. Whole
+  // document, not e.target — an outerHTML swap replaces the element the event
+  // would name.
+  document.addEventListener('htmx:afterSettle',apply);
+  // A narrower window wraps a note that fitted before, so what has more in it
+  // is asked again whenever the layout is. Once per frame: a drag fires this
+  // by the dozen.
+  var pending=false;
+  addEventListener('resize',function(){
+    if(pending)return;
+    pending=true;
+    requestAnimationFrame(function(){pending=false;apply()});
+  });
+  apply();
+})();


### PR DESCRIPTION
Follow-up to #38, which made a note fold to one line and open on hover. The
hover was too jarring in use: the page reflowed under the cursor, and crossing
the outline on the way somewhere opened whatever was under the pointer. This
replaces it with an explicit toggle and keeps everything else.

## The interaction

A "…" button sits beside the folded note. Click (or tap) opens it; click folds
it. Nothing answers a hover any more — `just test` holds the rule to that
(`:hover` must not appear in the note's fragment).

## Three parts, and why one of them is a script

* **The fold is still CSS** — `max-height: 1lh` and `overflow: hidden`, the
  whole note inside the box, so find-in-page and the morph still see all of it.
  The clamp draws no ellipsis of its own (`-webkit-line-clamp` would put one
  right beside the button's): **the button is the only ellipsis**.
* **Whether a note HAS more than its line is a measurement.** It depends on the
  note, the type and the width of the window, so no stylesheet can answer it.
  `notes.js` folds every note, measures, and puts back what you opened — three
  passes, not one loop, so a write never lands between two reads. That is what
  `.has-more` means, and a note that fits on its line carries no button, no
  ellipsis and no tab stop.
* **Which notes you opened is yours** — `.is-expanded`, keyed per site in
  localStorage beside the fold's (`olai.notes`), re-applied on
  `htmx:afterSettle` like `collapse.js`. So an open note outlives a reload and
  a live re-swap, and a mirror of a node opens on its own.

Also re-measured on resize (once per frame): a narrower window wraps a note
that fitted before.

## Accessibility

The toggle is a real `<button>` with `aria-expanded`, `aria-controls`, and a
label. The note is an element of its own for the button to name — `web/address`
mints that id, like every other id in the view, so a mirror site's note is its
own element too.

## Tests

`e2e/features/note.feature` is rewritten around the new interaction: the hover
scenarios are gone, and in their place — folded-and-offering, a one-line note
offering nothing, open-then-fold, **pointing at a note does nothing** (the
scenario the hover version failed), a tap at phone viewport, an open note
outliving a reload, one outliving a re-swap, and a mirror staying folded while
its other site is open. The steps wait on the script's measuring pass rather
than assuming it, since "no button" is what a page looks like before it runs.

`olai/tests/render.rkt` gets the drawn shape (folded, keyed, pointing at
itself; nothing expanded until the browser says so) and the script's size;
`olai/tests/style.rkt` gets the fold and the button's visibility rule.

`just test` (344) and `just e2e` (71 scenarios) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)