### PR TITLE
daily: a fragment a glob already reaches is not included twice

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -502,10 +502,21 @@ Creates the month fragment and `@include` line on first use in a month; idempote
 
 ```json
 {"version":1,"ok":true,"day":"2026-08-04","file":".../Daily/2026-08.rkt",
- "created_month":true,"created_day":true,"line":2,"committed":true}
+ "created_month":true,"created_day":true,"covered_by_glob":null,
+ "line":2,"committed":true}
 ```
 
 Both `created_*` are `false` on every run after the first for that day, and `committed` is `false` when there was nothing to write (or `--no-commit`).
+
+**A root that [globs](syntax.md#globs) its fragments is left alone.** `@include Daily/*.rkt` already names `Daily/2026-08.rkt` the moment that file exists, so writing the literal line as well would splice the fragment **twice** — every day node in the month duplicated in the tree. Asked of the pattern, not of the line: any `@include` in the root whose pattern matches the fragment's path covers it, wherever in the root it was written, and then this command creates the fragment and the day node and touches nothing else — not the `@include` line, and not the `year > MonthName` nodes it would have hung under. The shape above a glob is the outline's own.
+
+```json
+{"version":1,"ok":true,"day":"2026-08-04","file":".../Daily/2026-08.rkt",
+ "created_month":true,"created_day":true,"covered_by_glob":"Daily/*.rkt",
+ "line":2,"committed":true}
+```
+
+`covered_by_glob` is that pattern, verbatim as the outline wrote it, and `null` on the run that writes the literal line. The other fields stay what they always were — what was actually written: `created_month` is still the month arriving (the fragment created, or the root gaining the line and the nodes above it), and a run that only created the fragment commits only the fragment.
 
 ## Write routing: the defining file
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -164,6 +164,12 @@ Daily notes ^daily
   This is the one thing in the module graph that can move without any file the
   server already read being touched.
 
+- **A pattern that covers a fragment is the include.** `olai daily` writes a
+  literal `@include Daily/YYYY-MM.rkt` into `Daily.rkt` — unless a pattern
+  already there names that file, in which case it writes the fragment and
+  leaves the root alone. Two includes of one file are that file spliced twice
+  ([docs/cli.md](cli.md#daily---date-yyyy-mm-dd---home-dir---no-commit)).
+
 `olai check`'s `includes` lists the files a glob matched, one entry each — a
 glob is not visible downstream, only its answer is.
 

--- a/olai/arch.rkt
+++ b/olai/arch.rkt
@@ -24,12 +24,19 @@
 (override "doc.rkt" (clock stable) (owns filesystem))
 (override "fail.rkt" (clock stable))
 
-;; What a starred @include path names, and the directory it reads to answer.
-;; Same standing as doc.rkt and for the same two reasons: it is a closed
-;; pattern grammar that changes when the grammar does, and `lang/` — which is
-;; stable — depends on it, so it cannot be less stable than its caller. The
-;; reading is the whole of what it does, so it says so.
-(override "glob.rkt" (clock stable) (owns filesystem))
+;; What an @include path names — where a relative one resolves to, whether a
+;; starred one names a given file, and the directory it reads to answer. Same
+;; standing as doc.rkt and for the same two reasons: it is a closed pattern
+;; grammar that changes when the grammar does, and `lang/` — which is stable —
+;; depends on it, so it cannot be less stable than its caller. The reading is
+;; the whole of what it does, so it says so.
+;;
+;; The resolution is a concept because it had been written twice: the expander
+;; splices what it names, and `daily` asks whether a root already includes the
+;; fragment it is about to write. Two answers to that is two ideas of which
+;; file an outline means.
+(override "glob.rkt" (clock stable) (owns filesystem)
+          (concept include-resolution "include-absolute"))
 
 ;; A node's name on disk and in a URL: one owner, so a renderer never grows its
 ;; own copy and the core keeps building without web/.

--- a/olai/cli.rkt
+++ b/olai/cli.rkt
@@ -315,6 +315,9 @@
             'file (daily-result-file r)
             'created_month (daily-result-created-month? r)
             'created_day (daily-result-created-day? r)
+            ;; the pattern that already reached the fragment, so the root was
+            ;; left alone — null on the run that wrote the @include line
+            'covered_by_glob (nullish (daily-result-covered-by-glob r))
             'line (daily-result-line r)
             'committed (daily-result-committed? r))))
 

--- a/olai/daily.rkt
+++ b/olai/daily.rkt
@@ -10,6 +10,9 @@
          racket/format
          olai/dates
          olai/edit
+         ;; what a starred @include NAMES: the one question "is this fragment
+         ;; already covered" is, and not one to answer twice
+         (only-in olai/glob include-glob? glob-match?)
          olai/lang/line
          ;; where a section ends and which line is a given title: the same two
          ;; questions `capture` and `subtree` ask, asked of the same module
@@ -125,57 +128,106 @@
     (error 'daily "Daily.rkt must be #lang olai"))
   (define root-lines (text-lines root-text))
 
-  (define root-lines*
-    (if (find-title-line root-lines year-title 0)
-        root-lines
-        (append root-lines
-                (if (or (null? root-lines)
-                        (blank-line? (last root-lines)))
-                    (list year-title)
-                    (list "" year-title)))))
+  ;; A pattern the root already wrote may NAME this fragment, and then there
+  ;; is nothing to write into the root at all — not the @include line, and not
+  ;; the year and month nodes it would hang under. The shape above a glob is
+  ;; the outline's own; what this command owns is the fragment.
+  (define covered-by (covering-glob root-lines home-path rel))
 
-  (define year-i (find-title-line root-lines* year-title 0))
-  (unless year-i (error 'daily "internal: year node missing"))
-
-  (define year-end (section-end root-lines* year-i))
-  (define mon-i
-    (find-title-line root-lines* mon-title 2 #:from (add1 year-i) #:to year-end))
-
-  (define root-lines**
-    (if mon-i
-        root-lines*
-        (append (take root-lines* year-end)
-                (list (string-append "  " mon-title))
-                (drop root-lines* year-end))))
-
-  (define mon-i* (or mon-i (find-title-line root-lines** mon-title 2)))
-  (unless mon-i* (error 'daily "internal: month node missing"))
-
-  (define include-line (string-append "    @include " rel))
-  (define mon-end (section-end root-lines** mon-i*))
-  (define has-include?
-    (for/or ([i (in-range (add1 mon-i*) mon-end)])
-      (regexp-match?
-       (pregexp (string-append "^\\s*@include\\s+" (regexp-quote rel) "\\s*$"))
-       (list-ref root-lines** i))))
-
-  (define added-include? (not has-include?))
-  (define root-lines***
-    (if has-include?
-        root-lines**
-        (append (take root-lines** mon-end)
-                (list include-line)
-                (drop root-lines** mon-end))))
-
-  (define root-text* (lines->text root-lines*** root-text))
-  (unless (equal? root-text* root-text)
+  (define root-text*
+    (if covered-by
+        root-text
+        (lines->text
+         (root-lines-with-include root-lines year-title mon-title rel)
+         root-text)))
+  (define wrote-root? (not (equal? root-text* root-text)))
+  (when wrote-root?
     (edit! root root-text*))
 
   (hash 'day day
         'file (path->string (simple-form-path frag))
-        'created_month (or created-month? added-include?)
+        ;; The root gains the line and the nodes above it exactly when the
+        ;; month is new to it, so what was written IS the answer.
+        'created_month (or created-month? wrote-root?)
         'created_day created-day?
+        'covered_by_glob covered-by
         'line day-line))
+
+;; The root's lines with `year > Month > @include rel` in them, adding only
+;; what is missing — and nothing at all when the line is already there. Pure:
+;; the caller decides whether the answer is worth writing, and never asks when
+;; a glob already covers the fragment.
+(define (root-lines-with-include lines year-title mon-title rel)
+  (define lines*
+    (if (find-title-line lines year-title 0)
+        lines
+        (append lines
+                (if (or (null? lines)
+                        (blank-line? (last lines)))
+                    (list year-title)
+                    (list "" year-title)))))
+
+  (define year-i (find-title-line lines* year-title 0))
+  (unless year-i (error 'daily "internal: year node missing"))
+
+  (define year-end (section-end lines* year-i))
+  (define mon-i
+    (find-title-line lines* mon-title 2 #:from (add1 year-i) #:to year-end))
+
+  (define lines**
+    (if mon-i
+        lines*
+        (append (take lines* year-end)
+                (list (string-append "  " mon-title))
+                (drop lines* year-end))))
+
+  (define mon-i* (or mon-i (find-title-line lines** mon-title 2)))
+  (unless mon-i* (error 'daily "internal: month node missing"))
+
+  (define mon-end (section-end lines** mon-i*))
+  (cond
+    [(member rel (include-paths lines** (add1 mon-i*) mon-end)) lines**]
+    [else (append (take lines** mon-end)
+                  (list (string-append "    @include " rel))
+                  (drop lines** mon-end))]))
+
+;; The @include pattern the root ALREADY wrote that names this fragment, or
+;; #f. Verbatim, as the source wrote it: it is what the reply reports.
+;;
+;; A literal @include is a claim about one file; a glob is a query over one
+;; directory (olai/glob), and a fragment that lands in that directory is
+;; spliced by it the moment it exists. Adding the literal line as well would
+;; splice the fragment TWICE — every day node in the month duplicated in the
+;; tree — which is the bug this answers.
+;;
+;; The WHOLE root is asked, not the month's section: a glob's answer is about
+;; the directory it reads, and where the line was written says nothing about
+;; it.
+(define (covering-glob lines dir rel)
+  (define target (include-target dir rel))
+  (for/or ([p (in-list (include-paths lines 0 (length lines)))])
+    (and (include-glob? p)
+         (glob-match? (include-target dir p) target)
+         p)))
+
+;; What an @include path names from the file that wrote it — the resolution
+;; lang/expander does when it splices one, asked here of a fragment that may
+;; not exist yet, so nothing is read.
+(define (include-target dir rel)
+  (simplify-path (path->complete-path rel dir) #f))
+
+;; The paths the @include lines in [from, to) name, in order. What a line SAYS
+;; is the line grammar's answer (olai/lang/line), never a regexp of our own.
+(define (include-paths lines from to)
+  (for*/list ([i (in-range from to)]
+              [s (in-value (list-ref lines i))]
+              [k (in-value (classify-line (line-content s)))]
+              #:when (line-include? k))
+    (include-path k)))
+
+(define (line-content s)
+  (define-values (_indent content) (line-indent+content s))
+  content)
 
 ;; Migrate monolithic Daily.rkt (year>month>days) into Daily/YYYY-MM.rkt.
 ;; Returns (list task-count-before task-count-after).

--- a/olai/daily.rkt
+++ b/olai/daily.rkt
@@ -10,9 +10,10 @@
          racket/format
          olai/dates
          olai/edit
-         ;; what a starred @include NAMES: the one question "is this fragment
-         ;; already covered" is, and not one to answer twice
-         (only-in olai/glob include-glob? glob-match?)
+         ;; what an @include path names, and whether a starred one names this
+         ;; fragment: the one question "is it already covered" is, asked of
+         ;; the module that answers it for the language too
+         (only-in olai/glob include-glob? include-absolute glob-match?)
          olai/lang/line
          ;; where a section ends and which line is a given title: the same two
          ;; questions `capture` and `subtree` ask, asked of the same module
@@ -203,18 +204,16 @@
 ;; The WHOLE root is asked, not the month's section: a glob's answer is about
 ;; the directory it reads, and where the line was written says nothing about
 ;; it.
+;;
+;; A pattern that is not relative to the root is one the include form cannot
+;; resolve either, so it names nothing here and covers nothing.
 (define (covering-glob lines dir rel)
-  (define target (include-target dir rel))
+  (define target (include-absolute rel dir))
   (for/or ([p (in-list (include-paths lines 0 (length lines)))])
     (and (include-glob? p)
-         (glob-match? (include-target dir p) target)
+         (relative-path? p)
+         (glob-match? (include-absolute p dir) target)
          p)))
-
-;; What an @include path names from the file that wrote it — the resolution
-;; lang/expander does when it splices one, asked here of a fragment that may
-;; not exist yet, so nothing is read.
-(define (include-target dir rel)
-  (simplify-path (path->complete-path rel dir) #f))
 
 ;; The paths the @include lines in [from, to) name, in order. What a line SAYS
 ;; is the line grammar's answer (olai/lang/line), never a regexp of our own.

--- a/olai/glob.rkt
+++ b/olai/glob.rkt
@@ -37,6 +37,7 @@
           [include-glob? (-> string? boolean?)]
           [include-glob-problem (-> string? (or/c string? #f))]
           [glob-dir (-> path? path?)]
+          [glob-match? (-> path? path? boolean?)]
           [glob-expand (-> path? (listof path?))]))
 
 ;; A path the source wrote is a glob when it stars something. Nothing else
@@ -85,6 +86,35 @@
                   (string-join (map regexp-quote (string-split name "*" #:trim? #f))
                                ".*")
                   "$")))
+
+;; Two spellings of one directory are one directory. Reads nothing: the
+;; filesystem is glob-expand's to touch, not a comparison's.
+(define (dir-key dir)
+  (path->directory-path (simplify-path dir #f)))
+
+;; Does a pattern NAME this path? The question glob-expand answers by reading
+;; a directory, asked of ONE path and reading nothing.
+;;
+;; A WRITER is who needs it that way round: `olai daily` is about to add an
+;; @include line for a month fragment, and a pattern the outline already
+;; wrote may cover it — in which case the line would splice that file a
+;; SECOND time (olai/daily). The path it asks about is a name, not yet
+;; necessarily a file, and a directory listing cannot answer about a name.
+;;
+;; The rules are the expansion's, spelled once for both: the directory part
+;; is literal and must be the path's own, `*` matches inside the one file
+;; name, and a leading dot is not something it matches.
+(define (glob-match? pattern path)
+  (define pname (file-name-from-path pattern))
+  (define-values (base name dir?) (split-path path))
+  (and (path? pname)
+       (path? name)
+       (not dir?)
+       (path? base)
+       (equal? (dir-key base) (dir-key (glob-dir pattern)))
+       (let ([n (path->string name)])
+         (and (not (string-prefix? n "."))
+              (regexp-match? (name-rx (path->string pname)) n)))))
 
 ;; What the pattern matches, right now, sorted lexicographically — which is
 ;; what makes date-named fragments (2026-01.rkt, 2026-02.rkt, ...) splice in

--- a/olai/glob.rkt
+++ b/olai/glob.rkt
@@ -29,16 +29,29 @@
          racket/path
          racket/string)
 
-;; Everything below the grammar takes an ABSOLUTE pattern. Resolving one
-;; against the file that wrote it is the include form's business, not the
-;; pattern's — it is the same resolution a literal @include gets, and the
-;; expander does it once for both (lang/expander, include-absolute).
+;; Everything below the grammar takes an ABSOLUTE pattern, and
+;; `include-absolute` is how one gets that way: the resolution a literal
+;; @include and a pattern both get, spelled once so the two layers that need
+;; it — the expander when it splices, `daily` when it asks what a root
+;; already includes — cannot answer differently.
 (provide (contract-out
           [include-glob? (-> string? boolean?)]
           [include-glob-problem (-> string? (or/c string? #f))]
+          [include-absolute (-> path-string? path? path?)]
           [glob-dir (-> path? path?)]
           [glob-match? (-> path? path? boolean?)]
           [glob-expand (-> path? (listof path?))]))
+
+;; What an @include path NAMES, from the directory of the file that wrote it.
+;; A pattern resolves the way a file name does — relative to the DEFINING
+;; file, so a fragment spliced into two roots reads the same directory from
+;; either one.
+;;
+;; `build-path` is what refuses an absolute @include: the path is relative to
+;; a file, and a claim on the whole filesystem is not something this grammar
+;; makes. Callers that hold text a person wrote ask `relative-path?` first.
+(define (include-absolute rel dir)
+  (simplify-path (path->complete-path (build-path dir rel) dir)))
 
 ;; A path the source wrote is a glob when it stars something. Nothing else
 ;; promotes one: a file really called `notes[1].rkt` is a file, and an

--- a/olai/glob.rkt
+++ b/olai/glob.rkt
@@ -79,13 +79,34 @@
 (define (glob-dir pattern)
   (or (path-only pattern) pattern))
 
-;; `*` is any run of characters; everything else in the name is itself.
-(define (name-rx name)
-  (pregexp
-   (string-append "^"
-                  (string-join (map regexp-quote (string-split name "*" #:trim? #f))
-                               ".*")
-                  "$")))
+;; Which FILE NAMES a pattern accepts, as a predicate over one name — the
+;; half of a match that is not about the directory, and the whole of what `*`
+;; means. `#f` for a pattern that ends in a separator: it names a directory,
+;; and no file name is the answer to it.
+;;
+;; A closure, so the regexp is compiled once per caller rather than once per
+;; name: glob-expand asks this of every file in a directory on every
+;; staleness check (olai/store), and glob-match? asks it once.
+;;
+;; A leading dot is not something `*` matches, exactly as in a shell — and
+;; here that is load-bearing rather than a convention: `.#2026-08.rkt` is the
+;; lock file Emacs leaves beside a file it is editing, it is a dangling
+;; symlink, and globbing it in would break an outline nobody had touched. It
+;; is part of what the pattern MEANS, so it lives with the rest of the
+;; meaning and neither caller gets to remember it.
+(define (name-matcher pattern)
+  (define name (file-name-from-path pattern))
+  (and (path? name)
+       (let ([rx (pregexp
+                  (string-append
+                   "^"
+                   (string-join
+                    (map regexp-quote (string-split (path->string name) "*"
+                                                    #:trim? #f))
+                    ".*")
+                   "$"))])
+         (λ (n) (and (not (string-prefix? n "."))
+                     (regexp-match? rx n))))))
 
 ;; Two spellings of one directory are one directory. Reads nothing: the
 ;; filesystem is glob-expand's to touch, not a comparison's.
@@ -101,20 +122,17 @@
 ;; SECOND time (olai/daily). The path it asks about is a name, not yet
 ;; necessarily a file, and a directory listing cannot answer about a name.
 ;;
-;; The rules are the expansion's, spelled once for both: the directory part
-;; is literal and must be the path's own, `*` matches inside the one file
-;; name, and a leading dot is not something it matches.
+;; The two halves are the expansion's own: the directory part is literal and
+;; must be the path's own, and the file name is name-matcher's business.
 (define (glob-match? pattern path)
-  (define pname (file-name-from-path pattern))
+  (define name-ok? (name-matcher pattern))
   (define-values (base name dir?) (split-path path))
-  (and (path? pname)
+  (and name-ok?
        (path? name)
        (not dir?)
        (path? base)
        (equal? (dir-key base) (dir-key (glob-dir pattern)))
-       (let ([n (path->string name)])
-         (and (not (string-prefix? n "."))
-              (regexp-match? (name-rx (path->string pname)) n)))))
+       (name-ok? (path->string name))))
 
 ;; What the pattern matches, right now, sorted lexicographically — which is
 ;; what makes date-named fragments (2026-01.rkt, 2026-02.rkt, ...) splice in
@@ -124,12 +142,9 @@
 ;; A missing directory answers with the empty list rather than raising: this
 ;; is the function the store calls on every staleness check, and a directory
 ;; that went away between two loads is a reload, not a crash. The LANGUAGE is
-;; where a pattern with no directory to read is rejected (lang/expander).
-;;
-;; A leading dot is not something `*` matches, exactly as in a shell — and
-;; here that is load-bearing rather than a convention: `.#2026-08.rkt` is the
-;; lock file Emacs leaves beside a file it is editing, it is a dangling
-;; symlink, and globbing it in would break an outline nobody had touched.
+;; where a pattern with no directory to read is rejected (lang/expander), and
+;; a pattern that names no file at all matches nothing, for the same reason
+;; an empty directory does.
 ;;
 ;; Names are sorted as STRINGS and only then turned back into paths: within
 ;; one directory the two orders are the same, and `sort #:key path->string`
@@ -137,15 +152,14 @@
 ;; check (olai/store), so the allocation is not theoretical.
 (define (glob-expand pattern)
   (define dir (glob-dir pattern))
-  (define rx (name-rx (path->string (file-name-from-path pattern))))
+  (define name-ok? (name-matcher pattern))
   (cond
-    [(not (directory-exists? dir)) '()]
+    [(or (not name-ok?) (not (directory-exists? dir))) '()]
     [else
      (define names
        (sort (for*/list ([p (in-list (directory-list dir))]
                          [name (in-value (path->string p))]
-                         #:unless (string-prefix? name ".")
-                         #:when (regexp-match? rx name))
+                         #:when (name-ok? name))
                name)
              string<?))
      (for*/list ([name (in-list names)]

--- a/olai/lang/expander.rkt
+++ b/olai/lang/expander.rkt
@@ -629,17 +629,15 @@
     [(string? src) (path-only (string->path src))]
     [else #f]))
 
-;; What an @include path names, wherever it is written. A pattern resolves the
-;; same way a file name does — relative to the DEFINING file, so a fragment
-;; spliced into two roots reads the same directory from either one — which is
-;; why both branches below go through here and not through two spellings of
-;; it.
-(define-for-syntax (include-absolute rel dir)
-  (define base (or dir (current-directory)))
-  (simplify-path (path->complete-path (build-path base rel) base)))
+;; What an @include path names, wherever it is written — olai/glob's answer,
+;; because a pattern and a file name resolve the same way and `daily` asks the
+;; same question of a root it is about to write. All this adds is the
+;; directory a source with no path of its own falls back to.
+(define-for-syntax (include-target rel dir)
+  (include-absolute rel (or dir (current-directory))))
 
 (define-for-syntax (expand-literal-include stx rel dir)
-  (define full (include-absolute rel dir))
+  (define full (include-target rel dir))
   (unless (file-exists? full)
     (raise-syntax-error 'include (format "file not found: ~a" rel) stx))
   #`(load-include-splice #f (list (cons #,(path->string full) #,rel))))
@@ -661,7 +659,7 @@
   (define problem (include-glob-problem rel))
   (when problem
     (raise-syntax-error 'include problem stx))
-  (define pattern (include-absolute rel dir))
+  (define pattern (include-target rel dir))
   (define gdir (glob-dir pattern))
   (unless (directory-exists? gdir)
     (raise-syntax-error 'include

--- a/olai/lang/line.rkt
+++ b/olai/lang/line.rkt
@@ -62,6 +62,7 @@
           [title-text (-> classification/c (or/c string? #f))]
           [title-flag (-> classification/c (or/c 'done 'doing 'open #f))]
           [title-anchor (-> classification/c (or/c string? #f))]
+          [include-path (-> classification/c (or/c string? #f))]
           [strip-checkbox-prefix (-> string? any)]
           [strip-trailing-anchor (-> string? any)]))
 
@@ -215,3 +216,11 @@
 
 (define (title-anchor k)
   (match k [(list 'title _ _ anchor) anchor] [_ #f]))
+
+;; The path an @include line names — a file or a glob pattern, as the source
+;; wrote it — and #f when the line is not one. Same standing as the three
+;; above: `daily` asks what a root already includes before it writes another
+;; one, and a module that edits outline text does not get to spell where in a
+;; classification the answer sits.
+(define (include-path k)
+  (match k [(list 'include rel) rel] [_ #f]))

--- a/olai/ops.rkt
+++ b/olai/ops.rkt
@@ -69,6 +69,7 @@
                                 [line exact-positive-integer?]
                                 [created-month? boolean?]
                                 [created-day? boolean?]
+                                [covered-by-glob (or/c string? #f)]
                                 [committed? boolean?])]
           [ops-add! (->* ((or/c path? string?) string?)
                          (#:date (or/c string? #f)
@@ -335,7 +336,12 @@
 
 ;; ---- daily ----------------------------------------------------------------
 
-(struct daily-result (file day line created-month? created-day? committed?)
+;; covered-by-glob: the @include pattern the root had already written that
+;; names this month's fragment, verbatim — #f when none does, which is the run
+;; that writes the literal line. A covered fragment leaves the root alone: it
+;; is already spliced, and a second include is the same days twice.
+(struct daily-result (file day line created-month? created-day? covered-by-glob
+                           committed?)
   #:transparent)
 
 ;; Ensures today's day node (and the month fragment + @include that hold it).
@@ -362,4 +368,5 @@
                 (hash-ref result 'line)
                 (hash-ref result 'created_month)
                 (hash-ref result 'created_day)
+                (hash-ref result 'covered_by_glob)
                 committed?))

--- a/olai/tests/include.rkt
+++ b/olai/tests/include.rkt
@@ -9,6 +9,7 @@
          olai/load
          olai/json/model
          olai/json/reply
+         (only-in olai/glob glob-match?)
          (only-in olai/paths file-label)
          (only-in olai/query count-tasks)
          olai/status
@@ -385,6 +386,24 @@
        (check-equal? (map task-title (task-children (car (load-tasks root))))
                      '("Jan")))
      (λ () (delete-directory/files dir))))
+
+  ;; The other direction: a WRITER holds one path and asks whether a pattern
+  ;; already names it. `olai daily` is about to create Daily/2026-08.rkt, and
+  ;; a root that globs the directory already reaches it — so nothing is read
+  ;; here (the file need not exist yet) and the rules are the expansion's.
+  (test-case "a pattern answers about one path, reading nothing"
+    (define (m? pattern path)
+      (glob-match? (string->path pattern) (string->path path)))
+    (check-true (m? "/o/Daily/*.rkt" "/o/Daily/2026-08.rkt"))
+    (check-true (m? "/o/Daily/2026-*.rkt" "/o/Daily/2026-08.rkt"))
+    (check-false (m? "/o/Daily/2025-*.rkt" "/o/Daily/2026-08.rkt"))
+    ;; the directory part is literal, and it is the path's own
+    (check-false (m? "/o/Daily/*.rkt" "/o/Weekly/2026-08.rkt"))
+    (check-false (m? "/o/*.rkt" "/o/Daily/2026-08.rkt"))
+    ;; two spellings of one directory are one directory
+    (check-true (m? "/o/./Daily/*.rkt" "/o/Daily/2026-08.rkt"))
+    ;; and a leading dot is not something `*` matches, here either
+    (check-false (m? "/o/Daily/*.rkt" "/o/Daily/.#2026-08.rkt")))
 
   ;; Nothing about a matched file is special: it defines its own nodes, brings
   ;; its own includes, and declares anchors the whole tree can mirror.

--- a/olai/tests/integration/cli-archive.rkt
+++ b/olai/tests/integration/cli-archive.rkt
@@ -30,15 +30,6 @@
     (display-to-file body p #:exists 'truncate/replace)
     p)
 
-  ;; What the last commit touched. A move is ONE change in two files, and a
-  ;; commit that carried only one of them would leave the outline mid-move in
-  ;; the history it is supposed to be the record of.
-  (define (last-commit-files dir)
-    (with-output-to-string
-      (λ ()
-        (parameterize ([current-directory dir])
-          (git "show" "--name-only" "--pretty=format:")))))
-
   (define (commit-all dir)
     (parameterize ([current-directory dir])
       (git "add" "-A")
@@ -83,9 +74,9 @@
        (check-true (string-contains? (git-subject dir) "archive: install")
                    (git-subject dir))
        ;; and both files are in it
-       (define touched (last-commit-files dir))
-       (check-true (string-contains? touched "Tasks.rkt") touched)
-       (check-true (string-contains? touched "Archive.rkt") touched)
+       (define touched (committed-files dir))
+       (check-true (and (member "Tasks.rkt" touched) #t) (format "~a" touched))
+       (check-true (and (member "Archive.rkt" touched) #t) (format "~a" touched))
        (define-values (c2 o2 e2)
          (run-olai (list "check" (path->string tasks) archive)))
        (check-equal? c2 0 (string-append o2 e2))

--- a/olai/tests/integration/cli-multi.rkt
+++ b/olai/tests/integration/cli-multi.rkt
@@ -4,7 +4,8 @@
 ;; that writes across two of them at once. Real subprocess (cli-util.rkt),
 ;; temp dirs only.
 
-(require racket/file
+(require json
+         racket/file
          racket/port
          racket/string
          racket/system
@@ -14,6 +15,26 @@
   (require rackunit))
 
 (module+ test
+  ;; How many nodes the spliced tree titles this — which is what a fragment
+  ;; included twice answers with two of. Asked through `tree`, so the count is
+  ;; over the set a reader loads, not over the file the write touched.
+  (define (day-node-count root title)
+    (define-values (code out err) (run-olai (list "tree" root)))
+    (check-equal? code 0 (string-append out err))
+    (let count ([ts (hash-ref (parse-json out) 'tasks)])
+      (for/sum ([t (in-list ts)])
+        (+ (if (equal? (hash-ref t 'title #f) title) 1 0)
+           (count (hash-ref t 'children '()))))))
+
+  ;; What the last commit actually carried, as git names the paths.
+  (define (committed-files dir)
+    (string-split
+     (with-output-to-string
+       (λ ()
+         (parameterize ([current-directory dir])
+           (git "show" "--pretty=format:" "--name-only" "HEAD"))))
+     "\n"))
+
   (test-case "multi-file check: both ok + one-good-one-bad"
     (define dir (make-temporary-file "sfmulti~a" 'directory))
     (define good (build-path dir "good.rkt"))
@@ -241,4 +262,83 @@
                 "--date" "2026-08-05")))
        (check-equal? c3 0 (string-append o3 e3))
        (check-equal? (hash-ref (parse-json o3) 'committed) #f))
+     (λ () (delete-directory/files home))))
+
+  ;; A root that GLOBS its fragments already reaches the one this command is
+  ;; about to create. Writing the @include line as well would splice it twice
+  ;; — every day node in the month duplicated in the tree — so the root is
+  ;; left exactly as it was, scaffolding included, and the reply says which
+  ;; pattern covered it.
+  (test-case "daily: a covering glob in the root, and the root untouched"
+    (define home (make-temporary-file "sfdailyglob~a" 'directory))
+    (define root (build-path home "Daily.rkt"))
+    (define root-text "#lang olai\n2026\n  @include Daily/*.rkt\n")
+    (dynamic-wind
+     void
+     (λ ()
+       (parameterize ([current-directory home])
+         (git "init" "-q")
+         (git "config" "user.email" "t@t.test")
+         (git "config" "user.name" "t")
+         (display-to-file root-text root #:exists 'truncate)
+         (git "add" "Daily.rkt")
+         (git "commit" "-q" "-m" "init"))
+       (define-values (code out err)
+         (run-olai (list "daily" "--home" (path->string home)
+                         "--date" "2026-08-04")))
+       (check-equal? code 0 (string-append out err))
+       (define j (parse-json out))
+       (check-equal? (hash-ref j 'covered_by_glob) "Daily/*.rkt")
+       (check-equal? (hash-ref j 'created_month) #t)
+       (check-equal? (hash-ref j 'created_day) #t)
+       (check-equal? (hash-ref j 'line) 2)
+       (check-true (string-suffix? (hash-ref j 'file) "Daily/2026-08.rkt")
+                   (hash-ref j 'file))
+
+       ;; the fragment is there with the day in it, and the root is the same
+       ;; bytes it was committed as
+       (check-true (file-exists? (build-path home "Daily" "2026-08.rkt")))
+       (check-equal? (file->string root) root-text)
+
+       ;; only the fragment was written, so only the fragment was committed
+       (check-equal? (hash-ref j 'committed) #t)
+       (check-equal? (committed-files home) '("Daily/2026-08.rkt"))
+
+       ;; and the set says the day node exists ONCE, which is the whole bug
+       (check-equal? (day-node-count (path->string root) "2026-08-04") 1)
+
+       ;; a second day in the same month: still nothing to say to the root
+       (define-values (c2 o2 e2)
+         (run-olai (list "daily" "--home" (path->string home)
+                         "--date" "2026-08-05")))
+       (check-equal? c2 0 (string-append o2 e2))
+       (define j2 (parse-json o2))
+       (check-equal? (hash-ref j2 'covered_by_glob) "Daily/*.rkt")
+       (check-equal? (hash-ref j2 'created_month) #f)
+       (check-equal? (file->string root) root-text)
+       (check-equal? (day-node-count (path->string root) "2026-08-05") 1))
+     (λ () (delete-directory/files home))))
+
+  ;; The pattern has to actually NAME the fragment. One that reads the same
+  ;; directory and does not match it covers nothing, and the literal line is
+  ;; written exactly as it always was.
+  (test-case "daily: a glob that does not cover the fragment still gets the line"
+    (define home (make-temporary-file "sfdailyglobn~a" 'directory))
+    (define root (build-path home "Daily.rkt"))
+    (dynamic-wind
+     void
+     (λ ()
+       (display-to-file "#lang olai\n2025\n  @include Daily/2025-*.rkt\n"
+                        root #:exists 'truncate)
+       (define-values (code out err)
+         (run-olai (list "daily" "--no-commit" "--home" (path->string home)
+                         "--date" "2026-08-04")))
+       (check-equal? code 0 (string-append out err))
+       (define j (parse-json out))
+       (check-equal? (hash-ref j 'covered_by_glob) (json-null))
+       (check-equal? (hash-ref j 'created_month) #t)
+       (define text (file->string root))
+       (check-true (string-contains? text "  August") text)
+       (check-true (string-contains? text "    @include Daily/2026-08.rkt") text)
+       (check-equal? (day-node-count (path->string root) "2026-08-04") 1))
      (λ () (delete-directory/files home)))))

--- a/olai/tests/integration/cli-multi.rkt
+++ b/olai/tests/integration/cli-multi.rkt
@@ -26,15 +26,6 @@
         (+ (if (equal? (hash-ref t 'title #f) title) 1 0)
            (count (hash-ref t 'children '()))))))
 
-  ;; What the last commit actually carried, as git names the paths.
-  (define (committed-files dir)
-    (string-split
-     (with-output-to-string
-       (λ ()
-         (parameterize ([current-directory dir])
-           (git "show" "--pretty=format:" "--name-only" "HEAD"))))
-     "\n"))
-
   (test-case "multi-file check: both ok + one-good-one-bad"
     (define dir (make-temporary-file "sfmulti~a" 'directory))
     (define good (build-path dir "good.rkt"))

--- a/olai/tests/integration/cli-util.rkt
+++ b/olai/tests/integration/cli-util.rkt
@@ -7,9 +7,10 @@
 
 (require json
          racket/port
+         racket/string
          racket/system)
 
-(provide example run-olai parse-json git git-subject find-node)
+(provide example run-olai parse-json git git-subject committed-files find-node)
 
 (define root
   (simplify-path
@@ -48,6 +49,18 @@
 (define (git-subject dir)
   (with-output-to-string
     (λ () (parameterize ([current-directory dir]) (git "log" "-1" "--pretty=%s")))))
+
+;; And the paths it carried, as git names them. A write that lands in two
+;; files is ONE commit, and a commit carrying only one of them would leave the
+;; outline mid-change in the history it is supposed to be the record of — so a
+;; write test asks WHICH files moved, not just whether anything did.
+(define (committed-files dir)
+  (string-split
+   (with-output-to-string
+     (λ ()
+       (parameterize ([current-directory dir])
+         (git "show" "--name-only" "--pretty=format:"))))
+   "\n"))
 
 ;; The node titled `title` in a `tree` reply, wherever it sits. Drilling in by
 ;; index instead pins a test to the fixture's shape, and breaks when a sibling


### PR DESCRIPTION
Roadmap: **"daily + glob double-include #bug"** (writes section), flagged out of scope by the glob PR (#37).

## The bug

`olai daily` wrote `@include Daily/YYYY-MM.rkt` under the month node unconditionally. A root that already says `@include Daily/*.rkt` then includes the new fragment TWICE — once by the pattern, once by the line — so every day node in that month appears twice in the spliced tree.

## The fix

`daily` asks the pattern first: any `@include` in the root whose glob NAMES the fragment's path covers it, and then the command creates the fragment and the day node and leaves the root exactly as it was.

Not just the line — the `year > MonthName` scaffolding is skipped too. The shape above a glob is the outline's own, and a root that globs its months usually has no month nodes to hang anything under.

The whole root is asked, not the month's section: a literal `@include` is a claim about one file and belongs where the file belongs, but a glob is a query over a directory, and where the line was written says nothing about what it answers.

## Three small pieces

* **`glob-match?`** (`olai/glob`) — does a pattern NAME this path. The question `glob-expand` answers by reading a directory, asked of one path and reading nothing, because a writer holds a name and not yet a file. Same three rules as the expansion (literal directory part, `*` inside one file name, no leading dot), spelled once for both.
* **`include-path`** (`olai/lang/line`) — what an `@include` line names, beside `title-text` and friends. A module that edits outline text does not get to spell where in a classification the answer sits, and `daily` was about to grow a second regexp for include lines.
* **`covered_by_glob`** in the `daily` reply — the pattern, verbatim as the outline wrote it, `null` on the run that writes the literal line. A NEW field: `created_month` / `line` / `committed` go on meaning what was actually written, and a run that only creates the fragment commits only the fragment.

```json
{"version":1,"ok":true,"day":"2026-08-04","file":".../Daily/2026-08.rkt",
 "created_month":true,"created_day":true,"covered_by_glob":"Daily/*.rkt",
 "line":2,"committed":true}
```

## Tests

* `olai/tests/integration/cli-multi.rkt` — the covering case end to end through the CLI: fragment created with the day in it, root byte-identical to what was committed, one commit carrying one file, and exactly one node titled `2026-08-04` in the set. Then a second day in the same month, still saying nothing to the root.
* Same file — a pattern that reads the same directory and does NOT match the fragment (`Daily/2025-*.rkt`) still gets the literal line, as today.
* `olai/tests/include.rkt` — `glob-match?` on its own: directory part literal, `*` inside one name, dotfiles, two spellings of one directory.

Docs: `docs/cli.md` (the `daily` section) and one bullet in `docs/syntax.md`'s Globs list.

`just test` (480), `just arch`, and `raco test olai/tests/integration/cli-multi.rkt` all green locally.