### PR TITLE
just run: auto-reload on source change

### DIFF
--- a/justfile
+++ b/justfile
@@ -107,14 +107,17 @@ serve dir="docs" *args: build-client
     OLAI_DIST_DIR={{ dist }} \
       {{ nix_shell }} bun --watch packages/server/src/main.ts web {{ dir }} {{ args }}
 
-# Anything else the binary takes, without the watchers. Defaults to the same
-# pinned agent `just serve` and the packaged binary do: no documented way of
-# starting olai may land in the no-agent state by accident.
+# Anything else the binary takes, with the server under `bun --watch` so a
+# source change restarts it. Distinct from `serve`: that one is the web edit
+# loop (client bundler watch + server watch, default docs/); this one is the
+# general entrypoint (`web`, `mcp`, …) with only the server watched. Defaults
+# to the same pinned agent `just serve` and the packaged binary do: no
+# documented way of starting olai may land in the no-agent state by accident.
 run *args: build-client
     #!/usr/bin/env bash
     set -euo pipefail
     export OLAI_ACP_AGENT="$(sh scripts/acp-agent.sh)"
-    OLAI_DIST_DIR={{ dist }} {{ nix_shell }} bun packages/server/src/main.ts {{ args }}
+    OLAI_DIST_DIR={{ dist }} {{ nix_shell }} bun --watch packages/server/src/main.ts {{ args }}
 
 # Build the binary with nix, then run it. Both halves earn their place: the
 # build is where the hydrated @kolu/* sources and the bun.nix-derived

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -199,11 +199,13 @@ just serve docs              # build the client, serve this repo's own roadmap
 just run mcp docs            # the tool surface over stdio, from the working tree
 ```
 
-The first is the edit loop: two `bun --watch` processes, so a validator rule you
-change is live on the next reload. `just nix` is the other path — the packaged
-binary, built from tracked files only, which is what CI and `just e2e` prove.
+The first is the web edit loop: two `bun --watch` processes (client bundler and
+server), so a validator rule you change is live on the next reload. `just run`
+is the general entrypoint — any args the binary takes — with the server alone
+under `bun --watch`. `just nix` is the packaged path: the binary, built from
+tracked files only, which is what CI and `just e2e` prove.
 
-The second takes JSON-RPC on stdin, one message per line, which makes it
+`just run mcp` takes JSON-RPC on stdin, one message per line, which makes it
 pipeable — the fastest way to see what an agent is actually offered:
 
 ```sh


### PR DESCRIPTION
## Summary

- `just run` now starts the server under `bun --watch`, so a source change restarts it.
- `just serve` stays the web edit loop (client bundler watch + server watch, default `docs/`); `run` stays the general entrypoint (`web`, `mcp`, …) with only the server watched — they do not collapse into accidental duplicates.
- Recipe comment and `packages/server/README.md` updated to the new truth.
- SIGINT story unchanged: the real-process regression in `shutdown.test.ts` still passes; process-group SIGINT still tears down `just run` (same as a terminal Ctrl+C).

## Evidence (auto-reload)

```
$ just run web docs --port 17716 --no-commit
# ... install + build-client elided ...
timestamp=2026-08-11T14:38:41.969Z level=Info fiber=#2 message=serving serve=24ms root=.../docs url=http://127.0.0.1:17716

$ # edit packages/server/src/main.ts (source change)
# bun --watch restarts the server — second serving line:
timestamp=2026-08-11T14:38:41.969Z level=Info fiber=#2 message=serving serve=24ms root=.../docs url=http://127.0.0.1:17716
timestamp=2026-08-11T14:38:42.285Z level=Info fiber=#2 message=serving serve=27ms root=.../docs url=http://127.0.0.1:17716
```

## Test plan

- [x] `bun test packages/server/src/shutdown.test.ts` (SIGINT stops a connected server)
- [x] Manual: `just run web docs --port …`, edit server source, second `serving` line
- [x] Manual: process-group SIGINT exits `just run` and frees the port
- [ ] CI green via odu (`gh pr checks --required`)