### PR TITLE
The site catches up: dates and what is owed, preferences, the mark walk, the chat's diffs

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -31,9 +31,10 @@ outline, and it updates in place — and a pill in its header is green only
 while a server is actually answering; restart the server under an open tab
 and the page says so and offers a reload. It reads on a phone and installs as
 one (there is no offline mode, on purpose — a cached copy of an outline is a
-copy that has stopped being true). Fifteen named palettes sit behind a pill in
-the header, stored in the browser and sent nowhere; `⌘K` opens a command
-palette, where the keyboard-shortcut list also lives.
+copy that has stopped being true). A ⚙ in the header opens the preferences —
+one of the fifteen named palettes, and whether pages open with finished work
+shown — stored in the browser and sent nowhere; `⌘K` opens a command palette,
+where the keyboard-shortcut list also lives.
 
 ### Behind a reverse proxy
 

--- a/website/index.html
+++ b/website/index.html
@@ -63,6 +63,9 @@
     border: 1px solid var(--rule); border-radius: 10px; background: var(--paper);
     box-shadow: 0 1px 2px rgba(21,24,15,0.05), 0 8px 24px rgba(21,24,15,0.06);
     padding: 1rem 1.2rem 1.2rem; font-size: 0.92rem;
+    /* named, so a panel that overrides the eight tokens repaints its text too —
+       which is what the theme mocks below do */
+    color: var(--ink);
   }
   .panel .file { font-family: var(--mono); font-size: 0.75rem; color: var(--muted); border-bottom: 1px solid var(--rule); padding-bottom: 0.6rem; margin-bottom: 0.6rem; }
 
@@ -77,6 +80,12 @@
   .strike { text-decoration: line-through; text-decoration-color: var(--muted); color: var(--muted); }
   .rollup { font-family: var(--mono); font-size: 0.72rem; color: var(--muted); }
   .tagchip { color: var(--accent); }
+  .pill {
+    font-family: var(--mono); font-size: 0.72rem; line-height: 1.5;
+    border: 1px solid var(--rule); border-radius: 999px; padding: 0 0.5em;
+    color: var(--muted); white-space: nowrap; flex: none;
+  }
+  .pill.late { border-color: var(--alarm); color: var(--alarm); }
   .note { color: var(--muted); font-size: 0.85rem; padding-left: 2.8rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .docref { font-family: var(--mono); font-size: 0.75rem; color: var(--accent); padding-left: 2.8rem; margin-top: 0.1rem; }
   .mdoc h3 { font-size: 1.05rem; margin-bottom: 0.3rem; }
@@ -92,6 +101,9 @@
   .cols { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 2rem; align-items: start; margin-top: 1.5rem; }
   @media (max-width: 56rem) { .cols { grid-template-columns: minmax(0, 1fr); } }
 
+  /* a paragraph that follows another one, rather than a lead */
+  .then { margin-top: 0.9rem; }
+
   .diff .add { color: var(--done); }
   .diff .del { color: var(--alarm); }
   .diff .ctx { color: var(--muted); }
@@ -103,12 +115,66 @@
   table.keys td:first-child { white-space: nowrap; width: 1%; padding-right: 1.25rem; }
   kbd { font-size: 0.78rem; background: var(--well); border: 1px solid var(--rule); border-bottom-width: 2px; border-radius: 4px; padding: 0.1em 0.45em; }
 
+  /* agenda mock */
+  .sect { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.07em; color: var(--muted); margin-top: 1rem; }
+  .panel .sect:first-of-type { margin-top: 0; }
+  .grp { font-family: var(--mono); font-size: 0.72rem; color: var(--muted); margin: 0.5rem 0 0.2rem; }
+  .trail { font-size: 0.75rem; color: var(--muted); margin-top: 0.35rem; }
+  .row .t.grow { flex: 1; }
+
+  /* the date picker, open under a row */
+  .picker { display: flex; align-items: center; flex-wrap: wrap; gap: 0.5rem; padding: 0.4rem 0 0.1rem 2.8rem; font-size: 0.8rem; color: var(--muted); }
+  .field, .btn {
+    font-size: 0.78rem; border: 1px solid var(--rule); border-radius: 4px;
+    padding: 0.15rem 0.5rem; background: var(--paper); color: var(--ink);
+  }
+  .field { font-family: var(--mono); }
+  .btn.quiet { border-color: transparent; color: var(--muted); }
+
+  /* the mark walk */
+  .walk { display: flex; align-items: baseline; flex-wrap: wrap; gap: 0.65rem; font-size: 0.9rem; }
+  .walk .arw { color: var(--muted); }
+  .walk .stop { display: flex; align-items: baseline; gap: 0.4rem; }
+
   /* chat mock */
   .chat .msg { max-width: 85%; border-radius: 10px; padding: 0.5rem 0.8rem; margin-top: 0.7rem; }
   .chat .you { margin-left: auto; background: color-mix(in srgb, var(--accent) 10%, var(--paper)); border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--rule)); }
   .chat .op { font-family: var(--mono); font-size: 0.78rem; color: var(--muted); margin-top: 0.7rem; }
   .chat .op b { color: var(--done); font-weight: 600; }
   .chat .agent { background: var(--well); border: 1px solid var(--rule); }
+  /* what a call CHANGED: a node story for an olai write, a diff for a file */
+  .chat .wrote { display: flex; align-items: baseline; gap: 0.5rem; font-size: 0.82rem; margin-top: 0.35rem; padding-left: 1.1rem; }
+  .chat .wrote .said { margin-left: auto; color: var(--muted); font-size: 0.78rem; }
+  .chat .wrote .in { color: var(--muted); font-family: var(--mono); font-size: 0.7rem; }
+  .fdiff { border: 1px solid var(--rule); border-radius: 6px; margin-top: 0.4rem; overflow: hidden; font-family: var(--mono); font-size: 0.72rem; line-height: 1.6; }
+  .fdiff .path { display: flex; gap: 0.6rem; border-bottom: 1px solid var(--rule); padding: 0.2rem 0.5rem; color: var(--muted); }
+  .fdiff .path .n { margin-left: auto; }
+  .fdiff .path .plus { color: var(--done); }
+  .fdiff .path .minus { color: var(--alarm); }
+  .fdiff .body { overflow-x: auto; }
+  .fdiff .ln { display: flex; gap: 0.35rem; padding: 0 0.5rem; }
+  .fdiff .ln .no { width: 1.4rem; flex: none; text-align: right; color: var(--muted); opacity: 0.7; }
+  .fdiff .ln .mk { flex: none; }
+  .fdiff .ln .src { white-space: pre; }
+  .fdiff .ln.add { background: color-mix(in srgb, var(--done) 12%, transparent); }
+  .fdiff .ln.add .mk { color: var(--done); }
+  .fdiff .ln.del { background: color-mix(in srgb, var(--alarm) 12%, transparent); }
+  .fdiff .ln.del .mk { color: var(--alarm); }
+  .fdiff .ln.gap, .fdiff .more { color: var(--muted); }
+  .fdiff .more { border-top: 1px solid var(--rule); padding: 0.2rem 0.5rem; }
+
+  /* preferences mock */
+  .prefs .prow { border-top: 1px solid var(--rule); padding: 0.7rem 0; }
+  .prefs .prow:first-of-type { border-top: none; padding-top: 0.2rem; }
+  .prefs .lbl { font-weight: 600; font-size: 0.85rem; }
+  .prefs .hint { color: var(--muted); font-size: 0.78rem; margin-top: 0.35rem; }
+  .prefs .scope { border-top: 1px solid var(--rule); padding-top: 0.7rem; color: var(--muted); font-size: 0.78rem; }
+  .chips { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-top: 0.5rem; }
+  .chip { font-family: var(--mono); font-size: 0.68rem; line-height: 1.7; border: 1px solid; border-radius: 999px; padding: 0 0.5em; }
+  .chip.on { box-shadow: 0 0 0 1px var(--paper), 0 0 0 3px var(--accent); }
+  .seg { display: inline-flex; border: 1px solid var(--rule); border-radius: 6px; overflow: hidden; margin-top: 0.5rem; font-size: 0.78rem; }
+  .seg span { padding: 0.15rem 0.6rem; color: var(--muted); }
+  .seg span.on { background: var(--well); color: var(--ink); }
 
   /* comparison table */
   .tablewrap { overflow-x: auto; margin-top: 1.5rem; }
@@ -297,6 +363,119 @@ The corner unit is the **risky one** — see
         status is never computed from its children.</p>
       </div>
     </div>
+    <div class="cols">
+      <div class="panel">
+        <div class="file">⌘⇧Enter, on the row</div>
+        <p class="walk">
+          <span class="stop"><span class="bullet">●</span> no mark</span>
+          <span class="arw">→</span>
+          <span class="stop"><span class="box"></span> todo</span>
+          <span class="arw">→</span>
+          <span class="stop"><span class="box doing"></span> doing</span>
+          <span class="arw">→</span>
+          <span class="stop"><span class="bullet">●</span> no mark</span>
+        </p>
+        <p class="caption"><code>done</code> is not a stop on the ring.</p>
+      </div>
+      <div>
+        <p>Two keys write all three. <kbd>⌘</kbd>+<kbd>Enter</kbd> finishes
+        something, and takes that back: <code>done</code> is the mark with an
+        instant on it, which is what puts the work on that day’s page.
+        <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>Enter</kbd> walks the mark on, one step
+        round the answers a person gives about work they have <em>not</em>
+        finished. The last stop is an answer rather than a gap — a node
+        carrying no mark is not an unfinished one, and walking to it is how you
+        say a row was never a task.</p>
+        <p class="then">Finishing something is a thing you mean, not a thing to do on the
+        way past, so nothing stamps a completion while you are walking round —
+        and the walk will not take finished work backwards. Press it on a
+        finished row and the write is refused, in the same words an agent gets:
+        <em>nothing should decide on your behalf that finished work is not
+        finished</em>. ⌘Enter takes the <code>done</code> off, and the walk
+        carries on from there.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="agenda">
+  <div class="wrap">
+    <h2>Dates, and what is owed</h2>
+    <p class="lead">A node can carry a <code>date</code>: the day it is
+    scheduled for. The mark says whether it is work. Read together they answer
+    a third question, and no field stores the answer — <code>/agenda</code> is
+    that reading, taken of every outline at once.</p>
+    <div class="cols">
+      <div class="panel">
+        <div class="file">/agenda · 2026-08-12</div>
+
+        <p class="sect">overdue</p>
+        <p class="grp">kitchen.jsonl</p>
+        <p class="trail">Kitchen renovation ›</p>
+        <div class="row"><span class="box doing"></span><span class="t grow">Order the new cabinets <span class="tagchip">#blocking</span></span><span class="pill late">2026-08-07</span></div>
+
+        <p class="sect">today</p>
+        <p class="grp">kitchen.jsonl</p>
+        <p class="trail">Kitchen renovation ›</p>
+        <div class="row"><span class="box"></span><span class="t grow">Book the plumber</span><span class="pill">2026-08-12</span></div>
+        <p class="grp">trip.jsonl</p>
+        <div class="row"><span class="bullet">●</span><span class="t grow">Ferry tickets go on sale</span><span class="pill">2026-08-12</span></div>
+
+        <p class="sect">upcoming</p>
+        <p class="grp"><a href="#daily">2026-08-15</a></p>
+        <div class="row"><span class="box"></span><span class="t grow">Template the countertop</span><span class="pill">2026-08-15</span></div>
+      </div>
+      <div>
+        <pre><code>overdue(n) ⇔ n carries todo or doing
+             ∧ day(n.date) &lt; today</code></pre>
+        <p class="caption">Derived when the page is drawn, stored nowhere, and
+        spelled once — the agenda's first section and the tone of every date
+        badge are the same predicate. <code>day()</code> is the first ten
+        characters and the comparison is plain string order: dates are text.</p>
+        <p class="then"><strong>Overdue is a definition, not a
+        flag.</strong> Nobody sets it and nothing stores it. <code>done</code>
+        extinguishes it by construction — finished work is late at nothing —
+        and a date with no mark is an <em>occurrence</em>: a delivery, a
+        birthday, a ferry. It draws no checkbox, its pill never turns amber,
+        and when its day passes it simply leaves. A day going by is not a
+        failure of a bullet.</p>
+      </div>
+    </div>
+    <div class="cols">
+      <div>
+        <p><strong>Three sections, because they are three pieces of news.</strong>
+        <em>Overdue</em> is every slipped task in the directory, oldest first,
+        grouped by the outline it lives in — the one answer no day page can
+        give, because a slipped task is on a day nobody visits. <em>Today</em>
+        is what today's day page holds, minus what is finished. <em>Upcoming</em>
+        is the next seven days that have anything on them, each heading a link
+        to that day's own page; days with nothing do not appear.</p>
+        <p class="then">A task nobody dated is absent entirely: it has no <em>when</em> to be
+        late against, and inventing one is what this format refuses to do. An
+        empty agenda says <em>Nothing is due.</em> and offers nothing to press —
+        every row on it lives somewhere else, and that is where it is changed.</p>
+      </div>
+      <div>
+        <div class="panel">
+          <div class="file">kitchen.jsonl</div>
+          <div class="row"><span class="box"></span><span class="t grow">Book the plumber</span><span class="pill">2026-08-12</span></div>
+          <div class="picker">
+            <span>Scheduled for</span>
+            <span class="field">2026-08-19</span>
+            <span class="btn">Set date</span>
+            <span class="btn quiet">Cancel</span>
+          </div>
+        </div>
+        <p class="caption">Press the date beside a title and the picker opens in
+        place under the row. A row with no date has no pill to press, so its way
+        in is the <strong>•••</strong> menu: <em>Set date…</em>, or
+        <em>Change date…</em> on a row that has one. The control is the
+        browser's own <code>&lt;input type="date"&gt;</code>, so what is written
+        is the ten characters you picked, never a timestamp this app invented on
+        the way. Empty the box and the button becomes <em>Clear date</em> — the
+        menu's own verb, and the same write.</p>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -315,6 +494,7 @@ The corner unit is the **risky one** — see
       </table>
       <table class="keys">
         <tr><td><kbd>⌘</kbd>+<kbd>Enter</kbd></td><td>tick it off, or take that back</td></tr>
+        <tr><td><kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>Enter</kbd></td><td>walk the mark on: to do, then doing, then none</td></tr>
         <tr><td><kbd>Shift</kbd>+<kbd>Enter</kbd></td><td>write the note under it</td></tr>
         <tr><td><kbd>Esc</kbd></td><td>drop what you were typing</td></tr>
         <tr><td><kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>Z</kbd></td><td>put that edit back</td></tr>
@@ -325,7 +505,9 @@ The corner unit is the **risky one** — see
     never takes back what an agent or another tab did in the meantime, and one
     that no longer fits says why.</p>
     <p>Not everything has a key. Hover a row and the <strong>•••</strong> in the
-    gutter carries the rest: the three marks and clearing one, clearing a date,
+    gutter carries the rest: the three marks and clearing one, setting or
+    changing a date — which opens the same picker the row’s own pill does,
+    because a date is a value somebody has to choose — and clearing one,
     retiring one placement of a mirrored node, archiving a subtree — it asks
     first, and says how many rows go with it — and copying the subtree as
     tab-indented plain text. Those go on the same undo stack, so ⌘Z takes a
@@ -343,8 +525,11 @@ The corner unit is the **risky one** — see
     <p class="lead">The chat panel connects to any agent that speaks
     <a href="https://agentclientprotocol.com">ACP</a>. Claude Code is bundled as
     the default; set <code>OLAI_ACP_AGENT</code> to use a different agent CLI.
-    Agents get a fixed set of node tools and no file access, so every write is
-    validated before it lands.</p>
+    Olai hands an agent no filesystem — a fixed set of tools that can only name
+    nodes — so every write it asks olai for is validated before it lands. What a
+    coding assistant brings with it is its own: it edits files on the authority
+    it already has in a terminal, and olai neither grants that nor pretends it
+    away. It shows it.</p>
     <p>Files go in by paste, by drag, or by the picker: drag a screenshot, a
     PDF or a text file onto the conversation — several at once if you like —
     and the panel lights up the area that will take it while you are still
@@ -353,12 +538,42 @@ The corner unit is the **risky one** — see
     directory being served, and go away with it. A picture shows itself; a
     document shows its name and size. Anything olai will not take is refused
     where you dropped it, by name.</p>
+    <p class="then">A tool call is one folded line, and what the call <em>changed</em> is not
+    folded away. There are two kinds of change and the panel draws them
+    differently, because they are different things. A write through olai’s node
+    tools shows what changed about the <strong>node</strong>, in the same words
+    the commit panel uses for the same edit — <em>marked done</em>, <em>note
+    rewritten</em>, <em>moved</em> — and the outline it landed in. A file the
+    agent rewrote with its own tools shows a <strong>diff</strong>: the path,
+    how many lines came and went, and the change itself, with the unchanged
+    stretches collapsed so the first thing you read is what moved. It is
+    trimmed to a few rows and expands where it stands. An outline never gets a
+    text diff — one line per node means a text diff of one is a single enormous
+    line with everything on it changing at once.</p>
     <div class="cols">
       <div class="panel chat">
         <div class="file">chat · any ACP agent</div>
         <div class="msg you">plumber's booked — tick it off</div>
         <div class="op"><b>✓</b> set_done · book-plumber</div>
+        <div class="wrote"><span>✓</span><span>Book the plumber</span><span class="said">marked done</span></div>
+        <div class="wrote"><span class="in">kitchen.jsonl</span></div>
         <div class="msg agent">Done. Marked “Book the plumber” as done.</div>
+
+        <div class="msg you">the base units are carcass-only — say so in the doc</div>
+        <div class="op"><b>✓</b> Edit · cabinets.md</div>
+        <div class="fdiff">
+          <p class="path"><span>cabinets.md</span><span class="n plus">+3</span><span class="minus">−2</span></p>
+          <div class="body">
+            <div class="ln"><span class="no">1</span><span class="mk">&nbsp;</span><span class="src"># Cabinet specs</span></div>
+            <div class="ln gap"><span class="no"></span><span class="src">⋯ 3 unchanged</span></div>
+            <div class="ln del"><span class="no">6</span><span class="mk">-</span><span class="src">- 600&#8239;mm base × 4</span></div>
+            <div class="ln add"><span class="no">6</span><span class="mk">+</span><span class="src">- 600&#8239;mm base × 4, carcass only</span></div>
+            <div class="ln add"><span class="no">7</span><span class="mk">+</span><span class="src">- filler strip × 2</span></div>
+            <div class="ln"><span class="no">8</span><span class="mk">&nbsp;</span><span class="src">- corner carousel × 1</span></div>
+          </div>
+          <p class="more">+4 more lines</p>
+        </div>
+        <div class="msg agent">Added the carcass note and the filler strips.</div>
       </div>
       <div class="panel">
         <div class="file">kitchen.jsonl · live</div>
@@ -405,6 +620,93 @@ The corner unit is the **risky one** — see
         <pre><code>$ claude mcp add olai -- olai mcp ~/outlines</code></pre>
         <p class="caption">The same tools are available over MCP for agents
         running in a terminal. There is no write CLI.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="prefs">
+  <div class="wrap">
+    <h2>Preferences, and fifteen palettes</h2>
+    <p class="lead">One door in the app header, and two rows behind it: the
+    theme, and what a page does with finished work. Both are this browser’s —
+    stored here, carried into every other tab you have olai open in, and never
+    sent to the server. Two machines reading the same outlines are entitled to
+    look different, and the directory neither knows nor cares.</p>
+    <div class="cols">
+      <div class="panel prefs">
+        <div class="file">preferences</div>
+        <div class="prow">
+          <div class="lbl">Theme</div>
+          <div class="chips">
+            <span class="chip" style="background:#E4ECCA;color:#2C4222;border-color:#CDD8AB">leaf</span>
+            <span class="chip" style="background:#F0E7D2;color:#3D2F1B;border-color:#DCCEAC">manuscript</span>
+            <span class="chip on" style="background:#FAFAF6;color:#15180F;border-color:#C9CDBF">chalk</span>
+            <span class="chip" style="background:#000000;color:#C9D6B4;border-color:#242B1E">pitch</span>
+            <span class="chip" style="background:#FFFFFF;color:#2A3135;border-color:#DCE0E2">light</span>
+            <span class="chip" style="background:#2A3135;color:#FFFFFF;border-color:#5C6062">dark</span>
+            <span class="chip" style="background:#ECEEF0;color:#2A3135;border-color:#DCE0E2">vintage</span>
+            <span class="chip" style="background:#1E1E2E;color:#CDD6F4;border-color:#313244">catppuccin</span>
+            <span class="chip" style="background:#FFEFE2;color:#281603;border-color:#A1836B53">chocolate</span>
+            <span class="chip" style="background:#000000;color:#00FF00;border-color:#005500">hacker</span>
+            <span class="chip" style="background:#DDEABE;color:#415915;border-color:#85AC41">matcha</span>
+            <span class="chip" style="background:#FDF6F6;color:#615F7F;border-color:#E4D8EA">moon</span>
+            <span class="chip" style="background:#141414;color:#DCDBDB;border-color:#242424">neo</span>
+            <span class="chip" style="background:#282C33;color:#C8CCD4;border-color:#3B4048">one-dark</span>
+            <span class="chip" style="background:#000000;color:#FEA143;border-color:#E8393F">robot</span>
+          </div>
+          <p class="hint">chalk is in force. Every colour on the page is this
+          one table, so a pick repaints all of them at once.</p>
+        </div>
+        <div class="prow">
+          <div class="lbl">Done</div>
+          <div class="seg"><span class="on">Visible</span><span>Hidden</span></div>
+          <p class="hint">Pages open with finished work shown. Any page’s own
+          Done switch still overrides it.</p>
+        </div>
+        <p class="scope">These are this browser’s. They are stored here, reach
+        every tab you have olai open in, and are never sent to the server.</p>
+      </div>
+      <div>
+        <div class="panel" style="--paper:#000000;--ink:#C9D6B4;--muted:#77836A;--rule:#242B1E;--accent:#6FAECE;--done:#7FC97A;--doing:#D9A85A;--alarm:#D68B9A;--well:#12160F">
+          <div class="file">kitchen.jsonl · pitch</div>
+          <div class="row"><span class="bullet">●</span><span class="t"><strong>Kitchen renovation</strong> <span class="rollup">2/4</span></span></div>
+          <div class="row d1"><span class="box done"></span><span class="t strike">Demolition</span></div>
+          <div class="row d1"><span class="box doing"></span><span class="t grow">Order the new cabinets</span><span class="pill late">2026-08-07</span></div>
+          <div class="row d1"><span class="box"></span><span class="t">Book the plumber</span></div>
+        </div>
+        <div class="panel" style="--paper:#F0E7D2;--ink:#3D2F1B;--muted:#8C7B5C;--rule:#DCCEAC;--accent:#2F6580;--done:#5A7A34;--doing:#A05A16;--alarm:#9E4444;--well:#E7DBC0;margin-top:1rem">
+          <div class="file">kitchen.jsonl · manuscript</div>
+          <div class="row"><span class="bullet">●</span><span class="t"><strong>Kitchen renovation</strong> <span class="rollup">2/4</span></span></div>
+          <div class="row d1"><span class="box done"></span><span class="t strike">Demolition</span></div>
+          <div class="row d1"><span class="box doing"></span><span class="t grow">Order the new cabinets</span><span class="pill late">2026-08-07</span></div>
+          <div class="row d1"><span class="box"></span><span class="t">Book the plumber</span></div>
+        </div>
+        <p class="caption">The same rows, in two of the fifteen. A palette is
+        eight colours with a name; picking one writes <code>data-theme</code> on
+        <code>&lt;html&gt;</code>, and the stored pick lands there before the
+        first paint, so a reload never flashes the wrong one.</p>
+      </div>
+    </div>
+    <div class="cols">
+      <div>
+        <p><strong>Seven of the fifteen are dark grounds.</strong> There is no
+        <em>system</em> chip and no auto: the operating system’s preference is
+        not consulted at all, because two ways to be dark are two answers that
+        can disagree — with each other, and with the reader who already said
+        what they wanted. A page nobody has picked on reads in
+        <code>chalk</code>, which is the default and the one palette that
+        promises WCAG AA on every pair it paints; a unit test holds it to that,
+        pair by pair.</p>
+      </div>
+      <div>
+        <p><strong>Done: Visible or Hidden is a default, not a second
+        switch.</strong> A reading belongs to a page — folds start fresh when
+        you zoom — but “I do not want to look at finished work” is a claim about
+        the reader, and pressing it on every page opened is what a preference
+        exists to stop. So it moves the page you are on and leaves alone any
+        page whose own Done switch you have already pressed. Hiding finished
+        work is a row not drawn: never a node marked, never a file written.</p>
       </div>
     </div>
   </div>

--- a/website/index.html
+++ b/website/index.html
@@ -7,32 +7,28 @@
 <meta name="description" content="Outlines as one .jsonl line per node, prose as Markdown documents attached to them. Git merges and reviews all of it, and an agent edits it through the same gate your keyboard does.">
 <link rel="canonical" href="https://olai.kolu.dev/">
 <style>
-  /* chalk — olai's own default palette, the one that promises AA contrast */
+  /* what is not a palette's: the two faces, and the one surface this page
+     paints that a palette has no token for. */
   :root {
-    --paper:  #FAFAF6;
-    --ink:    #15180F;
-    --muted:  #555E4C;
-    --rule:   #C9CDBF;
-    --accent: #134F75;
-    --done:   #2A6626;
-    --doing:  #8F5200;
-    --alarm:  #8E3348;
     --well:   #F1F2EA;
     --mono: ui-monospace, "SF Mono", "Cascadia Mono", "JetBrains Mono", Menlo, Consolas, monospace;
     --sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   }
 
-  /* all fifteen, ported from web/src/client/theme/palettes.ts — one row per
+  /* all fifteen, ported from packages/web/src/client/theme/palettes.ts — one row per
      theme, because a theme IS eight colours with a name. A mock wears one by
      carrying `data-theme`, the attribute the app writes on <html>, so nothing
      below has to know a hex to be repainted. chalk is here as well as above
-     because a chip wears it by name like any other. `well` is this page's own
-     token rather than a palette's, so it is derived from the two that decide
-     everything else. */
-  [data-theme] { --well: color-mix(in srgb, var(--ink) 6%, var(--paper)); }
+     because chalk IS the default: the page reads in it, and its chip wears it
+     by name like any other, so the two are one block rather than two that can
+     drift — which is the rule `css.ts` keeps for the same pair. Only the
+     colours came across; the table's `scheme` says which way a BROWSER should
+     paint its own scrollbars and form controls, and nothing mocked here is
+     one. */
+  :root,
+  [data-theme="chalk"]      { --paper:#FAFAF6; --ink:#15180F; --muted:#555E4C; --rule:#C9CDBF; --accent:#134F75; --done:#2A6626; --doing:#8F5200; --alarm:#8E3348; }
   [data-theme="leaf"]       { --paper:#E4ECCA; --ink:#2C4222; --muted:#74855F; --rule:#CDD8AB; --accent:#2B6A8F; --done:#3E7A3A; --doing:#B9741B; --alarm:#A84A5E; }
   [data-theme="manuscript"] { --paper:#F0E7D2; --ink:#3D2F1B; --muted:#8C7B5C; --rule:#DCCEAC; --accent:#2F6580; --done:#5A7A34; --doing:#A05A16; --alarm:#9E4444; }
-  [data-theme="chalk"]      { --paper:#FAFAF6; --ink:#15180F; --muted:#555E4C; --rule:#C9CDBF; --accent:#134F75; --done:#2A6626; --doing:#8F5200; --alarm:#8E3348; }
   [data-theme="pitch"]      { --paper:#000000; --ink:#C9D6B4; --muted:#77836A; --rule:#242B1E; --accent:#6FAECE; --done:#7FC97A; --doing:#D9A85A; --alarm:#D68B9A; }
   [data-theme="light"]      { --paper:#FFFFFF; --ink:#2A3135; --muted:#868C90; --rule:#DCE0E2; --accent:#1C64F2; --done:#057A55; --doing:#9F580A; --alarm:#E02424; }
   [data-theme="dark"]       { --paper:#2A3135; --ink:#FFFFFF; --muted:#9EA1A2; --rule:#5C6062; --accent:#76A9FA; --done:#31C48D; --doing:#E3A008; --alarm:#F98080; }
@@ -91,10 +87,13 @@
        which is what the theme mocks below do */
     color: var(--ink);
   }
+  /* panels STACKED in one column — not two of them side by side in a .cols
+     cell, which are siblings too and must keep their tops level */
+  .stack .panel + .panel { margin-top: 1rem; }
   .panel .file { font-family: var(--mono); font-size: 0.75rem; color: var(--muted); border-bottom: 1px solid var(--rule); padding-bottom: 0.6rem; margin-bottom: 0.6rem; }
 
   .row { display: flex; align-items: baseline; gap: 0.55rem; padding: 0.18rem 0; }
-  .row .bullet { color: var(--muted); font-size: 0.7rem; position: relative; top: -0.1em; }
+  .bullet { color: var(--muted); font-size: 0.7rem; position: relative; top: -0.1em; }
   .d1 { padding-left: 1.4rem; }
   .box { width: 0.85rem; height: 0.85rem; border-radius: 3px; flex: none; border: 1.5px solid var(--muted); position: relative; top: 0.13rem; }
   .box.done { border-color: var(--done); background: var(--done); }
@@ -102,21 +101,24 @@
   .box.doing { border-color: var(--doing); background: linear-gradient(to right, var(--doing) 50%, transparent 50%); }
   .row .t { min-width: 0; }
   .strike { text-decoration: line-through; text-decoration-color: var(--muted); color: var(--muted); }
-  .rollup { font-family: var(--mono); font-size: 0.72rem; color: var(--muted); }
+  /* the quiet mono annotation, said once: a rollup, a mark's name, a date
+     badge, the outline a collected row came out of. */
+  .rollup, .marklbl, .pill, .grp { font-family: var(--mono); font-size: 0.72rem; color: var(--muted); }
   .tagchip { color: var(--accent); }
   .pill {
-    font-family: var(--mono); font-size: 0.72rem; line-height: 1.5;
-    border: 1px solid var(--rule); border-radius: 999px; padding: 0 0.5em;
-    color: var(--muted); white-space: nowrap; flex: none;
+    line-height: 1.5; border: 1px solid var(--rule); border-radius: 999px;
+    padding: 0 0.5em; white-space: nowrap; flex: none;
   }
   .pill.late { border-color: var(--alarm); color: var(--alarm); }
+  /* a row draws at most one, and it goes at the end — as .marklbl does */
+  .row .pill { margin-left: auto; }
   .note { color: var(--muted); font-size: 0.85rem; padding-left: 2.8rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .docref { font-family: var(--mono); font-size: 0.75rem; color: var(--accent); padding-left: 2.8rem; margin-top: 0.1rem; }
   .mdoc h3 { font-size: 1.05rem; margin-bottom: 0.3rem; }
   .mdoc p { font-size: 0.88rem; margin-top: 0.4rem; }
   .mdoc ul { margin: 0.5rem 0 0 1.3rem; font-size: 0.88rem; }
   .mdoc code { font-size: 0.78rem; }
-  .marklbl { margin-left: auto; font-family: var(--mono); font-size: 0.72rem; color: var(--muted); padding-left: 1rem; flex: none; }
+  .marklbl { margin-left: auto; padding-left: 1rem; flex: none; }
 
   /* ── sections ───────────────────────────────────────────── */
   section { padding: 2.8rem 0; border-top: 1px solid var(--rule); }
@@ -125,8 +127,9 @@
   .cols { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 2rem; align-items: start; margin-top: 1.5rem; }
   @media (max-width: 56rem) { .cols { grid-template-columns: minmax(0, 1fr); } }
 
-  /* a paragraph that follows another one, rather than a lead */
-  .then { margin-top: 0.9rem; }
+  /* prose that follows prose. Panels keep their own rhythm — a mock's
+     paragraphs are chrome, not copy. */
+  .wrap > p + p, .cols > div:not(.panel) > p + p { margin-top: 0.9rem; }
 
   .diff .add { color: var(--done); }
   .diff .del { color: var(--alarm); }
@@ -142,9 +145,8 @@
   /* agenda mock */
   .sect { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.07em; color: var(--muted); margin-top: 1rem; }
   .panel .file + .sect { margin-top: 0; }
-  .grp { font-family: var(--mono); font-size: 0.72rem; color: var(--muted); margin: 0.5rem 0 0.2rem; }
+  .grp { margin: 0.5rem 0 0.2rem; }
   .trail { font-size: 0.75rem; color: var(--muted); margin-top: 0.35rem; }
-  .grow { flex: 1; }
 
   /* the date picker, open under a row */
   .picker { display: flex; align-items: center; flex-wrap: wrap; gap: 0.5rem; padding: 0.4rem 0 0.1rem 2.8rem; font-size: 0.8rem; color: var(--muted); }
@@ -169,10 +171,10 @@
   /* what a call CHANGED: a node story for an olai write, a diff for a file */
   .chat .wrote { display: flex; align-items: baseline; gap: 0.5rem; font-size: 0.82rem; margin-top: 0.35rem; padding-left: 1.1rem; }
   .chat .wrote .said { margin-left: auto; color: var(--muted); font-size: 0.78rem; }
-  .chat .wrote .in { color: var(--muted); font-family: var(--mono); font-size: 0.7rem; }
+  .chat .in { padding-left: 1.1rem; margin-top: 0.15rem; color: var(--muted); font-family: var(--mono); font-size: 0.7rem; }
   .fdiff { border: 1px solid var(--rule); border-radius: 6px; margin-top: 0.4rem; overflow: hidden; font-family: var(--mono); font-size: 0.72rem; line-height: 1.6; }
   .fdiff .path { display: flex; gap: 0.6rem; border-bottom: 1px solid var(--rule); padding: 0.2rem 0.5rem; color: var(--muted); }
-  .fdiff .path .n { margin-left: auto; }
+  .fdiff .path .name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
   .fdiff .path .plus { color: var(--done); }
   .fdiff .path .minus { color: var(--alarm); }
   .fdiff .body { overflow-x: auto; }
@@ -189,17 +191,21 @@
 
   /* preferences mock */
   .prefs .prow { border-top: 1px solid var(--rule); padding: 0.7rem 0; }
-  .prefs .prow:first-of-type { border-top: none; padding-top: 0.2rem; }
+  .panel .file + .prow { border-top: none; padding-top: 0.2rem; }
   .prefs .lbl { font-weight: 600; font-size: 0.85rem; }
-  .prefs .hint { color: var(--muted); font-size: 0.78rem; margin-top: 0.35rem; }
-  .prefs .scope { border-top: 1px solid var(--rule); padding-top: 0.7rem; color: var(--muted); font-size: 0.78rem; }
-  .chips { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-top: 0.5rem; }
+  .prefs .hint, .prefs .scope { color: var(--muted); font-size: 0.78rem; }
+  .prefs .hint { margin-top: 0.35rem; }
+  .prefs .scope { border-top: 1px solid var(--rule); padding-top: 0.7rem; }
+  /* the ring is caught HERE, off the page, because every chip below
+     redefines both tokens to the palette it offers — and a ring drawn in a
+     chip's own colours is a ring you cannot see against it. */
+  .chips { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-top: 0.5rem; --ring: var(--accent); --ring-gap: var(--paper); }
   .chip {
     font-family: var(--mono); font-size: 0.68rem; line-height: 1.7;
     border: 1px solid var(--rule); border-radius: 999px; padding: 0 0.5em;
     background: var(--paper); color: var(--ink);
   }
-  .chip.on { box-shadow: 0 0 0 1px var(--paper), 0 0 0 3px var(--accent); }
+  .chip.on { box-shadow: 0 0 0 1px var(--ring-gap), 0 0 0 3px var(--ring); }
   .seg { display: inline-flex; border: 1px solid var(--rule); border-radius: 6px; overflow: hidden; margin-top: 0.5rem; font-size: 0.78rem; }
   .seg span { padding: 0.15rem 0.6rem; color: var(--muted); }
   .seg span.on { background: var(--well); color: var(--ink); }
@@ -243,7 +249,7 @@
       <div class="row"><span class="bullet">●</span><span class="t"><strong>Kitchen renovation</strong> <span class="rollup">2/4</span></span></div>
       <div class="row d1"><span class="box done"></span><span class="t strike">Demolition</span></div>
       <div class="row d1"><span class="box done"></span><span class="t strike">Pick the counter stone</span></div>
-      <div class="row d1"><span class="box doing"></span><span class="t">Order the new cabinets <span class="tagchip">#blocking</span></span></div>
+      <div class="row d1"><span class="box doing"></span><span class="t">Order the new cabinets <span class="tagchip">#blocking</span></span><span class="pill late">2026-08-07</span></div>
       <div class="note">Measure twice — the corner unit is the risky one.</div>
       <div class="docref">▤ cabinets.md</div>
       <div class="row d1"><span class="box"></span><span class="t">Book the plumber</span></div>
@@ -266,7 +272,8 @@
  "title":"Demolition","done":"2026-08-09T14:02:11-04:00"}
 {"id":"order","parent":"kitchen","ord":"a1",
  "title":"Order the new cabinets #blocking",
- "doing":true,"after":["demo"],"doc":"cabinets.md",
+ "doing":true,"date":"2026-08-07","after":["demo"],
+ "doc":"cabinets.md",
  "desc":"Measure twice — the corner unit is the risky one."}</code></pre>
         <p class="caption">The outline above, as stored on disk.</p>
       </div>
@@ -414,7 +421,7 @@ The corner unit is the **risky one** — see
         finished. The last stop is an answer rather than a gap — a node
         carrying no mark is not an unfinished one, and walking to it is how you
         say a row was never a task.</p>
-        <p class="then">Finishing something is a thing you mean, not a thing to do on the
+        <p>Finishing something is a thing you mean, not a thing to do on the
         way past, so nothing stamps a completion while you are walking round —
         and the walk will not take finished work backwards. Press it on a
         finished row and the write is refused, in the same words an agent gets:
@@ -440,18 +447,18 @@ The corner unit is the **risky one** — see
         <p class="sect">overdue</p>
         <p class="grp">kitchen.jsonl</p>
         <p class="trail">Kitchen renovation ›</p>
-        <div class="row"><span class="box doing"></span><span class="t grow">Order the new cabinets <span class="tagchip">#blocking</span></span><span class="pill late">2026-08-07</span></div>
+        <div class="row"><span class="box doing"></span><span class="t">Order the new cabinets <span class="tagchip">#blocking</span></span><span class="pill late">2026-08-07</span></div>
 
         <p class="sect">today</p>
         <p class="grp">kitchen.jsonl</p>
         <p class="trail">Kitchen renovation ›</p>
-        <div class="row"><span class="box"></span><span class="t grow">Book the plumber</span><span class="pill">2026-08-12</span></div>
+        <div class="row"><span class="box"></span><span class="t">Book the plumber</span><span class="pill">2026-08-12</span></div>
         <p class="grp">trip.jsonl</p>
-        <div class="row"><span class="bullet">●</span><span class="t grow">Ferry tickets go on sale</span><span class="pill">2026-08-12</span></div>
+        <div class="row"><span class="bullet">●</span><span class="t">Ferry tickets go on sale</span><span class="pill">2026-08-12</span></div>
 
         <p class="sect">upcoming</p>
         <p class="grp"><a href="#daily">2026-08-15</a></p>
-        <div class="row"><span class="box"></span><span class="t grow">Template the countertop</span><span class="pill">2026-08-15</span></div>
+        <div class="row"><span class="box"></span><span class="t">Template the countertop</span><span class="pill">2026-08-15</span></div>
       </div>
       <div>
         <pre><code>overdue(n) ⇔ n carries todo or doing
@@ -460,13 +467,13 @@ The corner unit is the **risky one** — see
         spelled once — the agenda's first section and the tone of every date
         badge are the same predicate. <code>day()</code> is the first ten
         characters and the comparison is plain string order: dates are text.</p>
-        <p class="then"><strong>Overdue is a definition, not a
+        <p><strong>Overdue is a definition, not a
         flag.</strong> Nobody sets it and nothing stores it. <code>done</code>
         extinguishes it by construction — finished work is late at nothing —
         and a date with no mark is an <em>occurrence</em>: a delivery, a
-        birthday, a ferry. It draws no checkbox, its pill never turns amber,
-        and when its day passes it simply leaves. A day going by is not a
-        failure of a bullet.</p>
+        birthday, a ferry. It draws no checkbox, its pill never takes the
+        attention tone, and when its day passes it simply leaves. A day going
+        by is not a failure of a bullet.</p>
       </div>
     </div>
     <div class="cols">
@@ -478,15 +485,22 @@ The corner unit is the **risky one** — see
         is what today's day page holds, minus what is finished. <em>Upcoming</em>
         is the next seven days that have anything on them, each heading a link
         to that day's own page; days with nothing do not appear.</p>
-        <p class="then">A task nobody dated is absent entirely: it has no <em>when</em> to be
+        <p>A task nobody dated is absent entirely: it has no <em>when</em> to be
         late against, and inventing one is what this format refuses to do. An
         empty agenda says <em>Nothing is due.</em> and offers nothing to press —
         every row on it lives somewhere else, and that is where it is changed.</p>
+        <p><strong>A date is set on the row.</strong> Press the date beside a
+        title and the picker opens in place under it; a row with no date has no
+        pill to press, so its way in is the <strong>•••</strong> menu —
+        <em>Set date…</em>, or <em>Change date…</em> on a row that has one. What
+        is written is the ten characters you picked, never a timestamp this app
+        invented on the way, because the control is the browser’s own
+        <code>&lt;input type="date"&gt;</code> and a date is text.</p>
       </div>
       <div>
         <div class="panel">
           <div class="file">kitchen.jsonl</div>
-          <div class="row"><span class="box"></span><span class="t grow">Book the plumber</span><span class="pill">2026-08-12</span></div>
+          <div class="row"><span class="box"></span><span class="t">Book the plumber</span><span class="pill">2026-08-12</span></div>
           <div class="picker">
             <span>Scheduled for</span>
             <span class="field">2026-08-19</span>
@@ -494,14 +508,9 @@ The corner unit is the **risky one** — see
             <span class="btn quiet">Cancel</span>
           </div>
         </div>
-        <p class="caption">Press the date beside a title and the picker opens in
-        place under the row. A row with no date has no pill to press, so its way
-        in is the <strong>•••</strong> menu: <em>Set date…</em>, or
-        <em>Change date…</em> on a row that has one. The control is the
-        browser's own <code>&lt;input type="date"&gt;</code>, so what is written
-        is the ten characters you picked, never a timestamp this app invented on
-        the way. Empty the box and the button becomes <em>Clear date</em> — the
-        menu's own verb, and the same write.</p>
+        <p class="caption">Empty the box and the button becomes <em>Clear
+        date</em> — the <strong>•••</strong> menu's own verb, and the same
+        write.</p>
       </div>
     </div>
   </div>
@@ -533,9 +542,8 @@ The corner unit is the **risky one** — see
     never takes back what an agent or another tab did in the meantime, and one
     that no longer fits says why.</p>
     <p>Not everything has a key. Hover a row and the <strong>•••</strong> in the
-    gutter carries the rest: the three marks and clearing one, setting or
-    changing a date — which opens the same picker the row’s own pill does,
-    because a date is a value somebody has to choose — and clearing one,
+    gutter carries the rest: the three marks and clearing one, setting,
+    changing or clearing a date — the same picker the row’s own pill opens —
     retiring one placement of a mirrored node, archiving a subtree — it asks
     first, and says how many rows go with it — and copying the subtree as
     tab-indented plain text. Those go on the same undo stack, so ⌘Z takes a
@@ -544,6 +552,93 @@ The corner unit is the **risky one** — see
     breaks. Every one of those is the same operation an agent would perform,
     which is a rule olai holds itself to: both faces can do the same things to a
     directory.</p>
+  </div>
+</section>
+
+<section id="prefs">
+  <div class="wrap">
+    <h2>Preferences, and fifteen palettes</h2>
+    <p class="lead">One door in the app header, and two rows behind it: the
+    theme, and what a page does with finished work. Both are this browser’s,
+    which is the panel’s own first claim about itself: two machines reading the
+    same outlines are entitled to look different, and the served directory
+    neither knows nor cares.</p>
+    <div class="cols">
+      <div class="panel prefs">
+        <div class="file">preferences</div>
+        <div class="prow">
+          <div class="lbl">Theme</div>
+          <div class="chips">
+            <span class="chip" data-theme="leaf">leaf</span>
+            <span class="chip" data-theme="manuscript">manuscript</span>
+            <span class="chip on" data-theme="chalk">chalk</span>
+            <span class="chip" data-theme="pitch">pitch</span>
+            <span class="chip" data-theme="light">light</span>
+            <span class="chip" data-theme="dark">dark</span>
+            <span class="chip" data-theme="vintage">vintage</span>
+            <span class="chip" data-theme="catppuccin">catppuccin</span>
+            <span class="chip" data-theme="chocolate">chocolate</span>
+            <span class="chip" data-theme="hacker">hacker</span>
+            <span class="chip" data-theme="matcha">matcha</span>
+            <span class="chip" data-theme="moon">moon</span>
+            <span class="chip" data-theme="neo">neo</span>
+            <span class="chip" data-theme="one-dark">one-dark</span>
+            <span class="chip" data-theme="robot">robot</span>
+          </div>
+          <p class="hint">chalk is in force. Every colour on the page is this
+          one table, so a pick repaints all of them at once.</p>
+        </div>
+        <div class="prow">
+          <div class="lbl">Done</div>
+          <div class="seg"><span class="on">Visible</span><span>Hidden</span></div>
+          <p class="hint">Pages open with finished work shown. Any page’s own
+          Done switch still overrides it.</p>
+        </div>
+        <p class="scope">These are this browser’s. They are stored here, reach
+        every tab you have olai open in, and are never sent to the server.</p>
+      </div>
+      <div class="stack">
+        <div class="panel" data-theme="pitch">
+          <div class="file">kitchen.jsonl · pitch</div>
+          <div class="row"><span class="bullet">●</span><span class="t"><strong>Kitchen renovation</strong> <span class="rollup">2/4</span></span></div>
+          <div class="row d1"><span class="box done"></span><span class="t strike">Demolition</span></div>
+          <div class="row d1"><span class="box doing"></span><span class="t">Order the new cabinets <span class="tagchip">#blocking</span></span><span class="pill late">2026-08-07</span></div>
+          <div class="row d1"><span class="box"></span><span class="t">Book the plumber</span></div>
+        </div>
+        <div class="panel" data-theme="manuscript">
+          <div class="file">kitchen.jsonl · manuscript</div>
+          <div class="row"><span class="bullet">●</span><span class="t"><strong>Kitchen renovation</strong> <span class="rollup">2/4</span></span></div>
+          <div class="row d1"><span class="box done"></span><span class="t strike">Demolition</span></div>
+          <div class="row d1"><span class="box doing"></span><span class="t">Order the new cabinets <span class="tagchip">#blocking</span></span><span class="pill late">2026-08-07</span></div>
+          <div class="row d1"><span class="box"></span><span class="t">Book the plumber</span></div>
+        </div>
+        <p class="caption">The same rows, in two of the fifteen. A palette is
+        eight colours with a name; picking one writes <code>data-theme</code> on
+        <code>&lt;html&gt;</code>, and the stored pick lands there before the
+        first paint, so a reload never flashes the wrong one.</p>
+      </div>
+    </div>
+    <div class="cols">
+      <div>
+        <p><strong>Seven of the fifteen are dark grounds.</strong> There is no
+        <em>system</em> chip and no auto: the operating system’s preference is
+        not consulted at all, because two ways to be dark are two answers that
+        can disagree — with each other, and with the reader who already said
+        what they wanted. A page nobody has picked on reads in
+        <code>chalk</code>, which is the default and the one palette that
+        promises WCAG AA on every pair it paints; a unit test holds it to that,
+        pair by pair.</p>
+      </div>
+      <div>
+        <p><strong>Done: Visible or Hidden is a default, not a second
+        switch.</strong> A reading belongs to a page — folds start fresh when
+        you zoom — but “I do not want to look at finished work” is a claim about
+        the reader, and pressing it on every page opened is what a preference
+        exists to stop. So it moves the page you are on and leaves alone any
+        page whose own Done switch you have already pressed. Hiding finished
+        work is a row not drawn: never a node marked, never a file written.</p>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -566,7 +661,7 @@ The corner unit is the **risky one** — see
     directory being served, and go away with it. A picture shows itself; a
     document shows its name and size. Anything olai will not take is refused
     where you dropped it, by name.</p>
-    <p class="then">A tool call is one folded line, and what the call <em>changed</em> is not
+    <p>A tool call is one folded line, and what the call <em>changed</em> is not
     folded away. There are two kinds of change and the panel draws them
     differently, because they are different things. A write through olai’s node
     tools shows what changed about the <strong>node</strong>, in the same words
@@ -584,13 +679,13 @@ The corner unit is the **risky one** — see
         <div class="msg you">plumber's booked — tick it off</div>
         <div class="op"><b>✓</b> set_done · book-plumber</div>
         <div class="wrote"><span>✓</span><span>Book the plumber</span><span class="said">marked done</span></div>
-        <div class="wrote"><span class="in">kitchen.jsonl</span></div>
+        <div class="in">kitchen.jsonl</div>
         <div class="msg agent">Done. Marked “Book the plumber” as done.</div>
 
         <div class="msg you">the base units are carcass-only — say so in the doc</div>
         <div class="op"><b>✓</b> Edit · cabinets.md</div>
         <div class="fdiff">
-          <p class="path"><span>cabinets.md</span><span class="n plus">+3</span><span class="minus">−2</span></p>
+          <p class="path"><span class="name">cabinets.md</span><span class="plus">+3</span><span class="minus">−2</span></p>
           <div class="body">
             <div class="ln"><span class="no">1</span><span class="mk">&nbsp;</span><span class="src"># Cabinet specs</span></div>
             <div class="ln gap"><span class="no"></span><span class="src">⋯ 3 unchanged</span></div>
@@ -648,93 +743,6 @@ The corner unit is the **risky one** — see
         <pre><code>$ claude mcp add olai -- olai mcp ~/outlines</code></pre>
         <p class="caption">The same tools are available over MCP for agents
         running in a terminal. There is no write CLI.</p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section id="prefs">
-  <div class="wrap">
-    <h2>Preferences, and fifteen palettes</h2>
-    <p class="lead">One door in the app header, and two rows behind it: the
-    theme, and what a page does with finished work. Both are this browser’s —
-    stored here, carried into every other tab you have olai open in, and never
-    sent to the server. Two machines reading the same outlines are entitled to
-    look different, and the directory neither knows nor cares.</p>
-    <div class="cols">
-      <div class="panel prefs">
-        <div class="file">preferences</div>
-        <div class="prow">
-          <div class="lbl">Theme</div>
-          <div class="chips">
-            <span class="chip" data-theme="leaf">leaf</span>
-            <span class="chip" data-theme="manuscript">manuscript</span>
-            <span class="chip on" data-theme="chalk">chalk</span>
-            <span class="chip" data-theme="pitch">pitch</span>
-            <span class="chip" data-theme="light">light</span>
-            <span class="chip" data-theme="dark">dark</span>
-            <span class="chip" data-theme="vintage">vintage</span>
-            <span class="chip" data-theme="catppuccin">catppuccin</span>
-            <span class="chip" data-theme="chocolate">chocolate</span>
-            <span class="chip" data-theme="hacker">hacker</span>
-            <span class="chip" data-theme="matcha">matcha</span>
-            <span class="chip" data-theme="moon">moon</span>
-            <span class="chip" data-theme="neo">neo</span>
-            <span class="chip" data-theme="one-dark">one-dark</span>
-            <span class="chip" data-theme="robot">robot</span>
-          </div>
-          <p class="hint">chalk is in force. Every colour on the page is this
-          one table, so a pick repaints all of them at once.</p>
-        </div>
-        <div class="prow">
-          <div class="lbl">Done</div>
-          <div class="seg"><span class="on">Visible</span><span>Hidden</span></div>
-          <p class="hint">Pages open with finished work shown. Any page’s own
-          Done switch still overrides it.</p>
-        </div>
-        <p class="scope">These are this browser’s. They are stored here, reach
-        every tab you have olai open in, and are never sent to the server.</p>
-      </div>
-      <div>
-        <div class="panel" data-theme="pitch">
-          <div class="file">kitchen.jsonl · pitch</div>
-          <div class="row"><span class="bullet">●</span><span class="t"><strong>Kitchen renovation</strong> <span class="rollup">2/4</span></span></div>
-          <div class="row d1"><span class="box done"></span><span class="t strike">Demolition</span></div>
-          <div class="row d1"><span class="box doing"></span><span class="t grow">Order the new cabinets</span><span class="pill late">2026-08-07</span></div>
-          <div class="row d1"><span class="box"></span><span class="t">Book the plumber</span></div>
-        </div>
-        <div class="panel" data-theme="manuscript" style="margin-top:1rem">
-          <div class="file">kitchen.jsonl · manuscript</div>
-          <div class="row"><span class="bullet">●</span><span class="t"><strong>Kitchen renovation</strong> <span class="rollup">2/4</span></span></div>
-          <div class="row d1"><span class="box done"></span><span class="t strike">Demolition</span></div>
-          <div class="row d1"><span class="box doing"></span><span class="t grow">Order the new cabinets</span><span class="pill late">2026-08-07</span></div>
-          <div class="row d1"><span class="box"></span><span class="t">Book the plumber</span></div>
-        </div>
-        <p class="caption">The same rows, in two of the fifteen. A palette is
-        eight colours with a name; picking one writes <code>data-theme</code> on
-        <code>&lt;html&gt;</code>, and the stored pick lands there before the
-        first paint, so a reload never flashes the wrong one.</p>
-      </div>
-    </div>
-    <div class="cols">
-      <div>
-        <p><strong>Seven of the fifteen are dark grounds.</strong> There is no
-        <em>system</em> chip and no auto: the operating system’s preference is
-        not consulted at all, because two ways to be dark are two answers that
-        can disagree — with each other, and with the reader who already said
-        what they wanted. A page nobody has picked on reads in
-        <code>chalk</code>, which is the default and the one palette that
-        promises WCAG AA on every pair it paints; a unit test holds it to that,
-        pair by pair.</p>
-      </div>
-      <div>
-        <p><strong>Done: Visible or Hidden is a default, not a second
-        switch.</strong> A reading belongs to a page — folds start fresh when
-        you zoom — but “I do not want to look at finished work” is a claim about
-        the reader, and pressing it on every page opened is what a preference
-        exists to stop. So it moves the page you are on and leaves alone any
-        page whose own Done switch you have already pressed. Hiding finished
-        work is a row not drawn: never a node marked, never a file written.</p>
       </div>
     </div>
   </div>

--- a/website/index.html
+++ b/website/index.html
@@ -22,6 +22,30 @@
     --sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   }
 
+  /* all fifteen, ported from web/src/client/theme/palettes.ts — one row per
+     theme, because a theme IS eight colours with a name. A mock wears one by
+     carrying `data-theme`, the attribute the app writes on <html>, so nothing
+     below has to know a hex to be repainted. chalk is here as well as above
+     because a chip wears it by name like any other. `well` is this page's own
+     token rather than a palette's, so it is derived from the two that decide
+     everything else. */
+  [data-theme] { --well: color-mix(in srgb, var(--ink) 6%, var(--paper)); }
+  [data-theme="leaf"]       { --paper:#E4ECCA; --ink:#2C4222; --muted:#74855F; --rule:#CDD8AB; --accent:#2B6A8F; --done:#3E7A3A; --doing:#B9741B; --alarm:#A84A5E; }
+  [data-theme="manuscript"] { --paper:#F0E7D2; --ink:#3D2F1B; --muted:#8C7B5C; --rule:#DCCEAC; --accent:#2F6580; --done:#5A7A34; --doing:#A05A16; --alarm:#9E4444; }
+  [data-theme="chalk"]      { --paper:#FAFAF6; --ink:#15180F; --muted:#555E4C; --rule:#C9CDBF; --accent:#134F75; --done:#2A6626; --doing:#8F5200; --alarm:#8E3348; }
+  [data-theme="pitch"]      { --paper:#000000; --ink:#C9D6B4; --muted:#77836A; --rule:#242B1E; --accent:#6FAECE; --done:#7FC97A; --doing:#D9A85A; --alarm:#D68B9A; }
+  [data-theme="light"]      { --paper:#FFFFFF; --ink:#2A3135; --muted:#868C90; --rule:#DCE0E2; --accent:#1C64F2; --done:#057A55; --doing:#9F580A; --alarm:#E02424; }
+  [data-theme="dark"]       { --paper:#2A3135; --ink:#FFFFFF; --muted:#9EA1A2; --rule:#5C6062; --accent:#76A9FA; --done:#31C48D; --doing:#E3A008; --alarm:#F98080; }
+  [data-theme="vintage"]    { --paper:#ECEEF0; --ink:#2A3135; --muted:#868C90; --rule:#DCE0E2; --accent:#1C64F2; --done:#057A55; --doing:#9F580A; --alarm:#E02424; }
+  [data-theme="catppuccin"] { --paper:#1E1E2E; --ink:#CDD6F4; --muted:#9399B2; --rule:#313244; --accent:#89B4FA; --done:#A6E3A1; --doing:#F9E2AF; --alarm:#F38BA8; }
+  [data-theme="chocolate"]  { --paper:#FFEFE2; --ink:#281603; --muted:#7D5E47; --rule:#A1836B53; --accent:#1A73E8; --done:#2DA044; --doing:#C99A00; --alarm:#D93636; }
+  [data-theme="hacker"]     { --paper:#000000; --ink:#00FF00; --muted:#009900; --rule:#005500; --accent:#76A9FA; --done:#31C48D; --doing:#E3A008; --alarm:#F98080; }
+  [data-theme="matcha"]     { --paper:#DDEABE; --ink:#415915; --muted:#85AC41; --rule:#85AC41; --accent:#2868A0; --done:#3D8828; --doing:#A88510; --alarm:#C43838; }
+  [data-theme="moon"]       { --paper:#FDF6F6; --ink:#615F7F; --muted:#8B6FA8; --rule:#E4D8EA; --accent:#6B8BC9; --done:#5FA876; --doing:#C9A84F; --alarm:#C85B5B; }
+  [data-theme="neo"]        { --paper:#141414; --ink:#DCDBDB; --muted:#9EA1A2; --rule:#242424; --accent:#76A9FA; --done:#8DBD6A; --doing:#F1C068; --alarm:#CF4653; }
+  [data-theme="one-dark"]   { --paper:#282C33; --ink:#C8CCD4; --muted:#5D636F; --rule:#3B4048; --accent:#73ADE9; --done:#A1C181; --doing:#DFC184; --alarm:#D07277; }
+  [data-theme="robot"]      { --paper:#000000; --ink:#FEA143; --muted:#7A8A8A; --rule:#E8393F; --accent:#3580D3; --done:#4ED8A3; --doing:#DFE361; --alarm:#E8393F; }
+
   * { margin: 0; padding: 0; box-sizing: border-box; }
   html { scroll-behavior: smooth; }
   body { background: var(--paper); color: var(--ink); font-family: var(--sans); font-size: 17px; line-height: 1.6; }
@@ -117,10 +141,10 @@
 
   /* agenda mock */
   .sect { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.07em; color: var(--muted); margin-top: 1rem; }
-  .panel .sect:first-of-type { margin-top: 0; }
+  .panel .file + .sect { margin-top: 0; }
   .grp { font-family: var(--mono); font-size: 0.72rem; color: var(--muted); margin: 0.5rem 0 0.2rem; }
   .trail { font-size: 0.75rem; color: var(--muted); margin-top: 0.35rem; }
-  .row .t.grow { flex: 1; }
+  .grow { flex: 1; }
 
   /* the date picker, open under a row */
   .picker { display: flex; align-items: center; flex-wrap: wrap; gap: 0.5rem; padding: 0.4rem 0 0.1rem 2.8rem; font-size: 0.8rem; color: var(--muted); }
@@ -170,7 +194,11 @@
   .prefs .hint { color: var(--muted); font-size: 0.78rem; margin-top: 0.35rem; }
   .prefs .scope { border-top: 1px solid var(--rule); padding-top: 0.7rem; color: var(--muted); font-size: 0.78rem; }
   .chips { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-top: 0.5rem; }
-  .chip { font-family: var(--mono); font-size: 0.68rem; line-height: 1.7; border: 1px solid; border-radius: 999px; padding: 0 0.5em; }
+  .chip {
+    font-family: var(--mono); font-size: 0.68rem; line-height: 1.7;
+    border: 1px solid var(--rule); border-radius: 999px; padding: 0 0.5em;
+    background: var(--paper); color: var(--ink);
+  }
   .chip.on { box-shadow: 0 0 0 1px var(--paper), 0 0 0 3px var(--accent); }
   .seg { display: inline-flex; border: 1px solid var(--rule); border-radius: 6px; overflow: hidden; margin-top: 0.5rem; font-size: 0.78rem; }
   .seg span { padding: 0.15rem 0.6rem; color: var(--muted); }
@@ -639,21 +667,21 @@ The corner unit is the **risky one** — see
         <div class="prow">
           <div class="lbl">Theme</div>
           <div class="chips">
-            <span class="chip" style="background:#E4ECCA;color:#2C4222;border-color:#CDD8AB">leaf</span>
-            <span class="chip" style="background:#F0E7D2;color:#3D2F1B;border-color:#DCCEAC">manuscript</span>
-            <span class="chip on" style="background:#FAFAF6;color:#15180F;border-color:#C9CDBF">chalk</span>
-            <span class="chip" style="background:#000000;color:#C9D6B4;border-color:#242B1E">pitch</span>
-            <span class="chip" style="background:#FFFFFF;color:#2A3135;border-color:#DCE0E2">light</span>
-            <span class="chip" style="background:#2A3135;color:#FFFFFF;border-color:#5C6062">dark</span>
-            <span class="chip" style="background:#ECEEF0;color:#2A3135;border-color:#DCE0E2">vintage</span>
-            <span class="chip" style="background:#1E1E2E;color:#CDD6F4;border-color:#313244">catppuccin</span>
-            <span class="chip" style="background:#FFEFE2;color:#281603;border-color:#A1836B53">chocolate</span>
-            <span class="chip" style="background:#000000;color:#00FF00;border-color:#005500">hacker</span>
-            <span class="chip" style="background:#DDEABE;color:#415915;border-color:#85AC41">matcha</span>
-            <span class="chip" style="background:#FDF6F6;color:#615F7F;border-color:#E4D8EA">moon</span>
-            <span class="chip" style="background:#141414;color:#DCDBDB;border-color:#242424">neo</span>
-            <span class="chip" style="background:#282C33;color:#C8CCD4;border-color:#3B4048">one-dark</span>
-            <span class="chip" style="background:#000000;color:#FEA143;border-color:#E8393F">robot</span>
+            <span class="chip" data-theme="leaf">leaf</span>
+            <span class="chip" data-theme="manuscript">manuscript</span>
+            <span class="chip on" data-theme="chalk">chalk</span>
+            <span class="chip" data-theme="pitch">pitch</span>
+            <span class="chip" data-theme="light">light</span>
+            <span class="chip" data-theme="dark">dark</span>
+            <span class="chip" data-theme="vintage">vintage</span>
+            <span class="chip" data-theme="catppuccin">catppuccin</span>
+            <span class="chip" data-theme="chocolate">chocolate</span>
+            <span class="chip" data-theme="hacker">hacker</span>
+            <span class="chip" data-theme="matcha">matcha</span>
+            <span class="chip" data-theme="moon">moon</span>
+            <span class="chip" data-theme="neo">neo</span>
+            <span class="chip" data-theme="one-dark">one-dark</span>
+            <span class="chip" data-theme="robot">robot</span>
           </div>
           <p class="hint">chalk is in force. Every colour on the page is this
           one table, so a pick repaints all of them at once.</p>
@@ -668,14 +696,14 @@ The corner unit is the **risky one** — see
         every tab you have olai open in, and are never sent to the server.</p>
       </div>
       <div>
-        <div class="panel" style="--paper:#000000;--ink:#C9D6B4;--muted:#77836A;--rule:#242B1E;--accent:#6FAECE;--done:#7FC97A;--doing:#D9A85A;--alarm:#D68B9A;--well:#12160F">
+        <div class="panel" data-theme="pitch">
           <div class="file">kitchen.jsonl · pitch</div>
           <div class="row"><span class="bullet">●</span><span class="t"><strong>Kitchen renovation</strong> <span class="rollup">2/4</span></span></div>
           <div class="row d1"><span class="box done"></span><span class="t strike">Demolition</span></div>
           <div class="row d1"><span class="box doing"></span><span class="t grow">Order the new cabinets</span><span class="pill late">2026-08-07</span></div>
           <div class="row d1"><span class="box"></span><span class="t">Book the plumber</span></div>
         </div>
-        <div class="panel" style="--paper:#F0E7D2;--ink:#3D2F1B;--muted:#8C7B5C;--rule:#DCCEAC;--accent:#2F6580;--done:#5A7A34;--doing:#A05A16;--alarm:#9E4444;--well:#E7DBC0;margin-top:1rem">
+        <div class="panel" data-theme="manuscript" style="margin-top:1rem">
           <div class="file">kitchen.jsonl · manuscript</div>
           <div class="row"><span class="bullet">●</span><span class="t"><strong>Kitchen renovation</strong> <span class="rollup">2/4</span></span></div>
           <div class="row d1"><span class="box done"></span><span class="t strike">Demolition</span></div>

--- a/website/index.html
+++ b/website/index.html
@@ -110,6 +110,10 @@
     padding: 0 0.5em; white-space: nowrap; flex: none;
   }
   .pill.late { border-color: var(--alarm); color: var(--alarm); }
+  /* WHICH of the node's dates this is — said inside the pill, quietly, and only
+     where a page collects both (a tree row draws the `date` field and needs no
+     saying). */
+  .pill .occ { margin-right: 0.4em; opacity: 0.7; }
   /* a row draws at most one, and it goes at the end — as .marklbl does */
   .row .pill { margin-left: auto; }
   .note { color: var(--muted); font-size: 0.85rem; padding-left: 2.8rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -369,8 +373,8 @@ The corner unit is the **risky one** — see
         <p>Fog on the water. Only the ferry has a deadline, so it went
         first.</p>
         <div class="file" style="margin-top:1rem">kitchen.jsonl</div>
-        <div class="row"><span class="box doing"></span><span class="t">Order the new cabinets</span></div>
-        <div class="row"><span class="box done"></span><span class="t strike">Pick the counter stone</span></div>
+        <div class="row"><span class="box"></span><span class="t">Book the plumber</span><span class="pill">2026-08-12</span></div>
+        <div class="row"><span class="box done"></span><span class="t strike">Pick the counter stone</span><span class="pill"><span class="occ">done</span>2026-08-12T16:20:03-04:00</span></div>
       </div>
     </div>
   </div>
@@ -446,12 +450,12 @@ The corner unit is the **risky one** — see
 
         <p class="sect">overdue</p>
         <p class="grp">kitchen.jsonl</p>
-        <p class="trail">Kitchen renovation ›</p>
+        <p class="trail">Kitchen renovation</p>
         <div class="row"><span class="box doing"></span><span class="t">Order the new cabinets <span class="tagchip">#blocking</span></span><span class="pill late">2026-08-07</span></div>
 
         <p class="sect">today</p>
         <p class="grp">kitchen.jsonl</p>
-        <p class="trail">Kitchen renovation ›</p>
+        <p class="trail">Kitchen renovation</p>
         <div class="row"><span class="box"></span><span class="t">Book the plumber</span><span class="pill">2026-08-12</span></div>
         <p class="grp">trip.jsonl</p>
         <div class="row"><span class="bullet">●</span><span class="t">Ferry tickets go on sale</span><span class="pill">2026-08-12</span></div>


### PR DESCRIPTION
The site was last true at **#127**. #128–#133 shipped and it said nothing about
any of them — a visitor today got no hint that olai has due dates at all. This
adds the missing content in the site's established voice and its own hand-built
CSS idiom: no redesign, no screenshots, no external assets, still one file. The
site describes **master**, so the unmerged depth/visual pass is not chased here.

Every claim below was read off the shipped code and its e2e, not guessed:
`packages/format/src/agenda.ts`, `web/src/client/{agenda,date,settings,theme,chat}/`,
`server/src/edit.ts`'s mark ring, and `features/{agenda,setting_a_date,preferences,theming}.feature`.

## What each section adds, and why

### Dates, and what is owed — a NEW section (#128, #133)

The loudest gap: the site never mentioned dates at all. It now says a node can
carry a `date`, that the mark says whether it is work, and that **overdue is
what the two answer together** — a definition, not a flag, spelled once and
derived when the page is drawn:

    overdue(n) ⇔ n carries todo or doing ∧ day(n.date) < today

with `day()` the first ten characters and the comparison plain string order,
because dates are text. `done` extinguishes it by construction; a dated node
with **no** mark is an occurrence — no checkbox, a pill that never turns amber,
and it leaves when its day passes.

The agenda mock draws the page as it draws itself: **Overdue** grouped by
outline with the pill in the attention tone, **Today** (with an occurrence in
it), and **Upcoming** with each day heading a link to that day's own page. The
prose carries the rest — the seven populated days Upcoming looks ahead for,
undated tasks being absent entirely, and the empty state that offers nothing to
press.

A second mock is **#133**: the date picker open in place under the row. The
row's own pill is the door, the ••• menu is the other one (*Set date…* /
*Change date…* / *Clear date*), the control is the browser's own
`<input type="date">`, so what lands is the ten characters you picked — and an
emptied box turns the button into *Clear date*.

### Preferences, and fifteen palettes — a NEW section (#131)

The site showed one look and said nothing about the panel. It now draws it: the
**Theme** row's fifteen chips, each wearing its own palette's real values, with
the default `chalk` ringed; the **Done** row as a stored default rather than a
second switch (any page's own switch still overrides it, and hiding finished
work is a row not drawn); and the sentence that says these are this browser's,
stored here, reaching every tab, never sent.

Beside it, the same outline repainted in `pitch` and `manuscript` — done by
overriding the eight tokens on the mock, which is exactly what the app does with
one attribute. Seven of the fifteen are dark grounds; there is no *system* chip,
and `chalk` is the one that promises AA.

### The mark walk (#132)

The Task status section explained the three marks and stopped there. It now
draws the ring as a ring — no mark → todo → doing → no mark — says why `done` is
not a stop on it, and quotes the refusal a walk on finished work meets.
`⌘⇧Enter` is in the keyboard table beside `⌘Enter`.

### Chat file diffs (#130)

The chat mock had one op line. It now shows both vocabularies: the olai write
keeps its op line and gains the **node-level story** under it (*Book the
plumber — marked done*, with the outline it landed in), and a second exchange
shows a **file the agent rewrote with its own tools** as the panel renders it —
path, `+3 −2`, the unchanged run collapsed to `⋯ 3 unchanged`, trimmed with a
`+4 more lines` expander. The prose says why an outline never gets a text diff.

### The sweep

- The ••• list now includes **setting and changing** a date, not just clearing
  one (#133).
- The agent lead said agents get "no file access" flatly. #130's diffs make that
  misleading, so it now draws the distinction `docs/chat.md` already draws: olai
  hands an agent no filesystem, and what a coding assistant brings with it is
  its own.
- **#129** was internal plumbing; nothing on the site was about it, as expected.
- `docs/running.md` named a theme **pill in the header** that #131 retired — now
  the ⚙ preferences, with what is behind them.

## Evidence

Rendered from a local static server and captured with headless Chrome
(`<worktree>/evidence/`, gitignored, not committed):

- `evidence/desktop-full.png` — the whole page, 1280 wide
- `evidence/desktop-agenda.png` — the new Agenda section
- `evidence/desktop-prefs.png` — the new Preferences section
- `evidence/desktop-agent.png` — the extended chat mock
- `evidence/desktop-marks.png` — the mark ring
- `evidence/narrow-full.png`, `narrow-agenda.png`, `narrow-prefs.png` — 390 wide

Checked: no horizontal page overflow at 1280 / 390 / 320, every internal anchor
resolves (`#markdown`, `#daily`), and no id is duplicated.

## The two passes on top

Commit 2 is the hickey+lowy pass, commit 3 is `/simplify` (four review agents:
reuse, simplification, efficiency, altitude). Neither changes what the site
claims; both change where the claims live.

- **The fifteen palettes are one table**, keyed by `data-theme` — the attribute
  the app writes on `<html>` — instead of seventeen `style` attributes carrying
  hexes. A mock is repainted by naming a theme. `chalk` is one row shared with
  `:root`, which is the rule `theme/css.ts` keeps for the same pair.
- **Two mock bugs the reviews caught**: the lit chip's ring was reading the
  chip's own palette rather than the page's (`Chips.tsx` says it must be the
  page's), and the mark-walk bullets sat outside any `.row`, so they drew at
  body size in ink. Also `:first-of-type` matched nothing where it was written
  to drop a border.
- **`#format`'s record now carries a `date`**, and the hero panel draws its
  pill. The section is captioned "the outline above, as stored on disk" and
  three of the new mocks show that same node dated and late — and it means a
  visitor sees a date in the first screenful, which is what this PR is about.
- **Paragraph spacing is a rule, not a class** four new paragraphs opted into
  (which had left one section reading lead → body flush → body gapped). Two
  pre-existing paragraph pairs gain that spacing; it is the only place existing
  rendering moves.
- **`#prefs` sits after `#type`** rather than last, so the UI material reads
  together and `#agent` + `#commit` close the page as they did before.

Evidence was re-captured after each pass; the paths above are the final render.

## After review (`ddf0dea`)

Both NICE-TO-HAVEs taken, since fidelity to master is the whole claim:

- **`#daily` is a day page again.** Dating the shared kitchen cast in this PR
  left that mock drawing undated rows — and the cabinets are `2026-08-07`, so
  the 12th was never their day. It shows `Book the plumber` with its pill (the
  row the agenda already puts on today) and the finished row now names WHICH
  date put it there — the occasion word inside the pill, value verbatim, as
  `DayNode`/`DateBadge` draw it. That also puts a real day-page fact on the site
  for the first time: a day collects the scheduled and the finished side by side.
- **The agenda trail lost its trailing `›`.** `Breadcrumbs.tsx` separates
  between crumbs, and a day page passes no file crumb, so a lone ancestor draws
  none.

Evidence re-captured at both widths (`desktop-daily.png`, `narrow-daily.png`
added); overflow, anchors and ids re-checked at 1280 / 390 / 320.
