### PR TITLE
One quiet pill: the button spelling converges where pixels allow

### DIFF
--- a/packages/web/src/client/chat/AskForm.tsx
+++ b/packages/web/src/client/chat/AskForm.tsx
@@ -198,6 +198,9 @@ export function AskForm(props: {
               >
                 answer
               </button>
+              {/* Not `../pill.ts`'s quiet pill: this row's height is set by
+                  the accent "answer" beside it, so dismiss keeps h-8/px-3 —
+                  the shared px-2/py-1 would shrink it out of the pair. */}
               <button
                 type="button"
                 class="flex h-8 items-center rounded border border-rule px-3 text-xs text-muted hover:text-ink disabled:opacity-60"

--- a/packages/web/src/client/chat/Header.tsx
+++ b/packages/web/src/client/chat/Header.tsx
@@ -26,6 +26,7 @@
 
 import { Show } from "solid-js"
 
+import { QUIET_PILL } from "../pill.ts"
 import { TESTID } from "../testids.ts"
 import { Sessions } from "./Sessions.tsx"
 import type { Chat } from "./state.ts"
@@ -78,7 +79,7 @@ export function Header(props: {
         <Sessions chat={props.chat} />
         <button
           type="button"
-          class="rounded border border-rule px-2 py-1 text-xs text-muted hover:text-ink"
+          class={QUIET_PILL}
           data-testid={TESTID.chatNew}
           onClick={() => props.chat.newSession()}
         >

--- a/packages/web/src/client/chat/Sessions.tsx
+++ b/packages/web/src/client/chat/Sessions.tsx
@@ -14,6 +14,7 @@
 import { createSignal, For, Match, Show, Switch } from "solid-js"
 
 import { Refusal } from "./Refusal.tsx"
+import { QUIET_PILL } from "../pill.ts"
 import { TESTID } from "../testids.ts"
 import type { Chat, Sessions as Answer } from "./state.ts"
 import type { OpFailure, SessionInfo } from "@olai/surface"
@@ -56,7 +57,7 @@ export function Sessions(props: { readonly chat: Chat }) {
     <div class="relative">
       <button
         type="button"
-        class="rounded border border-rule px-2 py-1 text-xs text-muted hover:text-ink"
+        class={QUIET_PILL}
         data-testid={TESTID.chatSessions}
         aria-expanded={picker()._tag !== "shut"}
         onClick={toggle}

--- a/packages/web/src/client/claims.test.ts
+++ b/packages/web/src/client/claims.test.ts
@@ -79,3 +79,14 @@ test("nothing outside connection/status.ts reads the readout's raw states", () =
     path.join("connection", "status.ts"),
   ])
 })
+
+// pill.ts's claim — one spelling of the quiet pill button, worn by import.
+// The string was spelled near-identically at five sites across five modules
+// (PR #134's flag); the three that render identically wear the constant now,
+// and the two that keep a geometry of their own (the ask form's h-8 dismiss,
+// the unpushed line's py-0.5 Push) do not match this pattern — which is the
+// point: what cannot reappear is the SHARED spelling, retyped.
+test("only pill.ts spells the quiet pill button", () => {
+  const spelling = /rounded border border-rule px-2 py-1 text-xs text-muted hover:text-ink/
+  expect(filesSpelling(spelling)).toEqual(["pill.ts"])
+})

--- a/packages/web/src/client/claims.test.ts
+++ b/packages/web/src/client/claims.test.ts
@@ -81,10 +81,10 @@ test("nothing outside connection/status.ts reads the readout's raw states", () =
 })
 
 // pill.ts's claim — one spelling of the quiet pill button, worn by import.
-// The string was spelled near-identically at five sites across five modules
-// (PR #134's flag); the three that render identically wear the constant now,
-// and the two that keep a geometry of their own (the ask form's h-8 dismiss,
-// the unpushed line's py-0.5 Push) do not match this pattern — which is the
+// Same construction as the connectSurface sweep: asserting equality keeps it
+// honest, because pill.ts itself must keep matching — a respelled QUIET_PILL
+// fails here rather than rotting the pattern to an empty pass. The lookalikes
+// that deliberately diverge (`pill.ts` says where) do not match, which is the
 // point: what cannot reappear is the SHARED spelling, retyped.
 test("only pill.ts spells the quiet pill button", () => {
   const spelling = /rounded border border-rule px-2 py-1 text-xs text-muted hover:text-ink/

--- a/packages/web/src/client/commit/Unpushed.tsx
+++ b/packages/web/src/client/commit/Unpushed.tsx
@@ -39,6 +39,9 @@ export function Unpushed(props: { readonly commit: Commit }) {
             data-commits={props.commit.pending().unpushed?.commits ?? 0}
           >
             <span class="min-w-0 truncate">{words()}</span>
+            {/* Not `../pill.ts`'s quiet pill: this verb sits INSIDE a text-xs
+                line, so it keeps py-0.5 — the shared py-1 would thicken the
+                unpushed line it lives on. */}
             <button
               type="button"
               class="ml-auto shrink-0 rounded border border-rule px-2 py-0.5 hover:text-ink disabled:opacity-50"

--- a/packages/web/src/client/menu/NodeMenu.tsx
+++ b/packages/web/src/client/menu/NodeMenu.tsx
@@ -22,6 +22,7 @@
 
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js"
 
+import { QUIET_PILL } from "../pill.ts"
 import { TESTID } from "../testids.ts"
 import { HOVER_CELL, MENU_REVEAL } from "../touch.ts"
 import type { Said } from "../edit/undoing.ts"
@@ -302,7 +303,7 @@ function Confirm(props: {
         </button>
         <button
           type="button"
-          class="cursor-pointer rounded border border-rule bg-transparent px-2 py-1 text-xs text-muted hover:text-ink"
+          class={`${QUIET_PILL} cursor-pointer`}
           data-testid={TESTID.nodeMenuItem}
           data-action="cancel"
           onClick={() => props.onCancel(props.action)}

--- a/packages/web/src/client/pill.ts
+++ b/packages/web/src/client/pill.ts
@@ -1,0 +1,26 @@
+/**
+ * The quiet pill button: a bordered verb beside something louder.
+ *
+ * Three sites wear it — the chat header's "chats" and "+ new", and the menu
+ * confirm's Cancel — and they are the same button: a small action a reader
+ * should not notice until they go looking for one, drawn as a border, no
+ * fill, and muted text that inks on hover. One spelling, because the day this
+ * button changes it must change everywhere at once; `claims.test.ts` sweeps
+ * for the spelling so a fourth site copies the constant rather than the
+ * string.
+ *
+ * No background here on purpose: Tailwind's preflight already paints a button
+ * transparent, so a `bg-transparent` in this string would be that fact
+ * spelled in a second place. And no cursor either — whether a pointer is
+ * offered belongs to the surface the button sits on (the menu panel says
+ * `cursor-pointer` beside this; chrome does not).
+ *
+ * Two buttons LOOK like this one and are deliberately not it, each holding a
+ * geometry of its own: the ask form's "dismiss" is h-8/px-3 because it stands
+ * beside an accent "answer" of the same height, and the Push on the unpushed
+ * line is py-0.5 because it sits inside a line of text rather than under one.
+ * Converging either would move pixels, which is a different change from
+ * unifying a spelling — each says so where it diverges.
+ */
+export const QUIET_PILL =
+  "rounded border border-rule px-2 py-1 text-xs text-muted hover:text-ink"

--- a/packages/web/src/client/pill.ts
+++ b/packages/web/src/client/pill.ts
@@ -9,18 +9,19 @@
  * for the spelling so a fourth site copies the constant rather than the
  * string.
  *
- * No background here on purpose: Tailwind's preflight already paints a button
- * transparent, so a `bg-transparent` in this string would be that fact
- * spelled in a second place. And no cursor either — whether a pointer is
- * offered belongs to the surface the button sits on (the menu panel says
- * `cursor-pointer` beside this; chrome does not).
+ * Not `readout.ts`'s PILL — that is the app bar's rounded-full readout chip;
+ * this is the bordered BUTTON. Two constants, because they are two shapes
+ * that change for two different reasons.
  *
- * Two buttons LOOK like this one and are deliberately not it, each holding a
- * geometry of its own: the ask form's "dismiss" is h-8/px-3 because it stands
- * beside an accent "answer" of the same height, and the Push on the unpushed
- * line is py-0.5 because it sits inside a line of text rather than under one.
- * Converging either would move pixels, which is a different change from
- * unifying a spelling — each says so where it diverges.
+ * No background in this string: Tailwind's preflight already paints a button
+ * transparent, so a `bg-transparent` here would say nothing. And no cursor —
+ * whether a pointer is offered belongs to the surface the button sits on
+ * (the menu panel says `cursor-pointer` beside this; chrome does not).
+ *
+ * Buttons that LOOK like this one but keep a geometry of their own — the ask
+ * form's dismiss, the unpushed line's Push — say why in place: converging
+ * them would move pixels, which is a different change from unifying a
+ * spelling.
  */
 export const QUIET_PILL =
   "rounded border border-rule px-2 py-1 text-xs text-muted hover:text-ink"


### PR DESCRIPTION
One spelling of the "quiet pill button", zero pixels moved. Roadmap item
`quiet-pill-unify` — flagged by PR #134, reclassified by the 2026-08-13 debate
as plain cleanup (a class string is not an axis; no receptacle credit).

## The ruling this PR is built under

**Pixel parity.** Only sites that render identically after the change converge
on the shared spelling. A site where unification would shift geometry even
slightly stays on its own spelling, with a comment saying why — converging it
would be a different, un-ratified change.

## The five sites

| # | Site | Button | Verdict |
|---|------|--------|---------|
| 1 | `chat/Header.tsx` | `+ new` | **Unified** — its spelling was already the shared one, verbatim. |
| 2 | `chat/Sessions.tsx` | `chats` | **Unified** — same verbatim spelling. |
| 3 | `menu/NodeMenu.tsx` | the confirm's `Cancel` | **Unified** — wears `QUIET_PILL` plus its own `cursor-pointer` (the menu panel's convention, kept). Its `bg-transparent` is dropped: Tailwind's preflight already paints every button `background-color: transparent` (verified in the built CSS), so it drew nothing. |
| 4 | `chat/AskForm.tsx` | `dismiss` | **Left divergent** — `h-8`/`px-3`: its height is set by the accent `answer` button beside it; the shared `px-2 py-1` would shrink it out of the pair. Comment in place. |
| 5 | `commit/Unpushed.tsx` | `Push` | **Left divergent** — `py-0.5`: the verb sits *inside* a `text-xs` text line; the shared `py-1` would thicken the unpushed line. Comment in place. |

A sixth near-spelling exists — `commit/Panel.tsx`'s Commit button — and is
deliberately not touched: it renders in ink, not muted (it is the panel's
primary verb), so it is not a quiet pill at all; only its ancestry is.

## Where the one spelling lives

`packages/web/src/client/pill.ts` — `QUIET_PILL`, with the divergences and the
no-`bg-transparent` / no-cursor decisions documented on the definition.

## Evidence: zero drift

Captured against the dev server on `packages/tests/fixtures/good` with the
scripted ACP agent, before and after the change, same states, both palettes
(`chalk`, `pitch`), real widths (1440×900 desktop, 390×844 phone; the node-menu
confirm is pointer-only so desktop-only):

- 10 tight crops (per unified site × palette × width) and 2 full-page
  1440×900 confirm shots: **every before/after pair is byte-identical**
  (`cmp` clean on all 12) — stronger than a pixel diff; there is no pixel to
  diff. Shots and the capture script are in `.worktrees/quiet-pill-out/`.

## Tests

`claims.test.ts` gains a sweep in its existing style: the quiet-pill spelling
appears in exactly `["pill.ts"]`. **Sabotage-verified**: re-inlining the string
at a site fails the sweep naming both files; reverted.

Full unit suite green: 1231 pass. Typecheck green across the workspace.

`docs/roadmap.jsonl` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
