### PR TITLE
The kolu probe moves upstream — kolu supplies the evidence, olai keeps the judgement

### DIFF
--- a/nix/kolu.nix
+++ b/nix/kolu.nix
@@ -24,7 +24,7 @@ let
   # zero-dependency leaf `@kolu/surface-app/serve` reads its host/port
   # bracketing from, so the URL a listener reports is a URL when the host is an
   # IPv6 literal.
-  names = [ "surface" "surface-app" "surface-mcp" "log" "url-shape" ];
+  names = [ "surface" "surface-app" "surface-mcp" "detect" "log" "url-shape" ];
 
   pairs = pkgs: builtins.concatMap
     (name: [ "${pkgs."kolu-${name}"}" "@kolu/${name}" ])

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "dad81604eaaf66ec5ff59942973865f62bcddefd",
-      "url": "https://github.com/juspay/kolu/archive/dad81604eaaf66ec5ff59942973865f62bcddefd.tar.gz",
-      "hash": "sha256-gIM4+eC6CTze9hHVAR7oEI2zyJXvd+h8+bUVQgtpweQ="
+      "revision": "39b97df6815988d1f44678ff3c6652ecc6da195b",
+      "url": "https://github.com/juspay/kolu/archive/39b97df6815988d1f44678ff3c6652ecc6da195b.tar.gz",
+      "hash": "sha256-csZp+0WaN33EFFqdDUweNGdm269zyl3nkm+my/xw79Y="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -222,13 +222,15 @@ fault would be a complaint on every machine that has never heard of kolu.
 
 The `it could not be started` arm is a second door and has to be: under Bun an
 exec failure arrives as an `error` EVENT on a child `spawn` has already
-returned, so the `try` around the spawn never sees one. That axis is
-`pipes.ts`'s (`unstartable`), beside the framing, because it is the same
-question — what a Node child does to the process that spawned it — and because
-**both** subprocesses this package starts had the same two problems: an
-unhandled `error` event is an uncaught exception, and what follows an exec
-failure is our own write to a stdin that died with it, so the reason a person
-got was `Cannot call write after a stream was destroyed`.
+returned, so the `try` around the spawn never sees one. Two things hang on
+racing it rather than merely catching it — an unhandled `error` event is an
+uncaught exception, and what *follows* an exec failure is our own write to a
+stdin that died with it, so the reason a person got was `Cannot call write
+after a stream was destroyed`. Both subprocesses this package deals with had
+that problem; each now solves it where its spawn lives. The ACP agent's is
+`pipes.ts`'s (`unstartable`), beside the framing, because that is the same
+question — what a Node child does to the process that spawned it. The kolu
+probe's is `@kolu/detect`'s, because kolu starts that child now.
 
 That mattered most on the one this file is not about. `OLAI_ACP_AGENT` is a path
 a PERSON sets — a typo, a moved binary, a store path that was collected — which
@@ -238,13 +240,19 @@ failed on a destroyed stream. `agent.ts` races the same promise against its
 handshake now and refuses with `could not start the agent \`<command>\`: …`,
 which names the thing to go and fix.
 
-The probe is a JSON-RPC conversation on a subprocess's pipes, which is what the
-ACP session is too — so the framing lives in `pipes.ts` and neither of them owns
-it. What that file encapsulates is one axis, read at both ends: what a Node
-child does to the process that spawned it under Bun's node compatibility — how
-its pipes become Web streams, and how it says it never ran. `kolu.ts` writes
-three messages and reads until one of them is answered; it does not know what a
-newline is, and it does not know how an exec failure is delivered.
+**The probe itself is kolu's** (`@kolu/detect`, juspay/kolu#2168). Resolving
+`kolu` on PATH, starting it, handshaking, and reading a cell only a live daemon
+can answer is knowledge *about kolu* — including the two incidents it encodes,
+which are facts about kolu's own builds and discoverable there rather than
+here. So `kolu.ts` no longer writes a message or reads a pipe: it asks, and
+gets back which of the five ways it failed, with the failing party's own words
+where there were any. What stays is the judgement — this file still owns every
+sentence on the strip, still decides that an absence is only a fault when
+`PADI_SOCKET` says a padi was expected, and still reads `PADI_SOCKET` and
+`PATH` itself rather than letting the probe reach for them, because that
+environment is olai's fact and not kolu's to interpret. `pipes.ts` remains what
+it always was for the ACP session, which is still this package's own
+subprocess.
 
 **What is detected is the DAEMON, not kolu's web server**, which may be running
 on another machine reaching this host as a remote. `PADI_SOCKET` is forwarded

--- a/packages/chat/src/kolu.ts
+++ b/packages/chat/src/kolu.ts
@@ -7,7 +7,17 @@
  * anything — so this module answers one question, `Kolu.detect`, and
  * {@link ./agent.ts} adds what it answers to the servers a session is given.
  *
- * Three decisions are what this file is:
+ * **The probe itself is now kolu's** (`@kolu/detect`, juspay/kolu#2168). What
+ * used to live here — resolve `kolu` on PATH, start it, handshake, read a cell
+ * only a live daemon can answer, keep the absolute path that answered — was
+ * knowledge about kolu that this repo was holding on kolu's behalf, and it is
+ * the kind that goes stale silently: the two incidents it encodes
+ * (juspay/kolu#2146, a bundled build ahead on PATH answering with the same
+ * version string; juspay/kolu#2148, a `kolu mcp` that completes the handshake
+ * and lists everything with no daemon behind it) are facts about kolu's own
+ * builds, discoverable there and not here. So kolu supplies the EVIDENCE and
+ * this file keeps the JUDGEMENT, which is the division `mcp-fail-visible`
+ * needs and the reason the sentences below did not move with the probe:
  *
  *   - **What is detected is PADI, not kolu's web server.** The browser face
  *     may be running on another machine reaching this host as a remote (the
@@ -19,39 +29,43 @@
  *     already finds its own default and already says so when a host is running
  *     more than one, and a host that ambiguous is one to leave alone rather
  *     than to guess about.
- *   - **The probe is the detection.** A `kolu` on PATH is not necessarily the
- *     host's kolu — a padi-spawned terminal prepends its own bundled copy, and
- *     one of those was an older build reporting the same version string while
- *     missing most of the verbs (juspay/kolu#2146, fixed by #2147; the lesson
- *     survives the fix, because the wrong build still SPAWNS). So nothing here
- *     trusts a path, a version string or an exit code: the executable is
- *     started, handshaken with, and asked to read a resource that only the
- *     daemon can answer. An answer is the evidence, and it is evidence of both
- *     halves at once — this binary speaks the protocol, AND a padi is behind
- *     it. Anything else is a no — because a host without kolu is the ordinary
- *     case rather than a fault — but a no that SAYS WHY ({@link Detected}). It
- *     used to be one silent `false` for all four ways of failing, with the
- *     reason destroyed by a `catch` before anything could report it.
+ *   - **The probe is the detection.** Nothing here trusts a path, a version
+ *     string or an exit code — kolu starts the executable, handshakes with it,
+ *     and asks it to read a resource only the daemon can answer. An answer is
+ *     the evidence, and it is evidence of both halves at once: this binary
+ *     speaks the protocol, AND a padi is behind it. Anything else is a no —
+ *     because a host without kolu is the ordinary case rather than a fault —
+ *     but a no that SAYS WHY ({@link Detected}). It used to be one silent
+ *     `false` for all four ways of failing, with the reason destroyed by a
+ *     `catch` before anything could report it.
  *   - **The path we probe is the path we hand over.** `kolu` is resolved on
- *     PATH here, once, and the session is given that absolute path — which is
- *     also what ACP's stdio shape asks for. Handing the bare word would leave
- *     the agent free to resolve it against a different PATH and spawn a
- *     different build than the one that answered.
+ *     PATH once, and the session is given that absolute path — which is also
+ *     what ACP's stdio shape asks for. Handing the bare word would leave the
+ *     agent free to resolve it against a different PATH and spawn a different
+ *     build than the one that answered.
+ *
+ * What kolu will NOT decide for us is the last arm: whether an absence is
+ * worth reporting. `@kolu/detect` answers `notOnPath` with no reason attached,
+ * because the question "was a kolu expected here?" is answered by
+ * `PADI_SOCKET` — olai's environment, under olai's service manager — and kolu
+ * has no business asserting a fact about our PATH. That judgement, and the
+ * sentence it produces ({@link EXPECTED}), stay here.
  */
 
-import { type ChildProcess, spawn } from "node:child_process"
+import type { ChildProcess } from "node:child_process"
 
-import type { AnyMessage } from "@agentclientprotocol/sdk"
-import { reasonOf } from "@olai/log"
+import {
+  detect as detectKolu,
+  probe as probeKolu,
+  type ProbeFailure,
+} from "@kolu/detect"
 import type { MissingServer } from "@olai/surface"
 import { Effect } from "effect"
 
-import { streamOver, unstartable } from "./pipes.ts"
-
 /** The executable, its verb, and the variable that says which padi. All three
- *  are kolu's own `.mcp.json` entry, unchanged. */
+ *  are kolu's own `.mcp.json` entry, unchanged — and now kolu's own constants,
+ *  so a rename there cannot leave this file quietly spelling the old one. */
 const COMMAND = "kolu"
-const ARGS = ["mcp"] as const
 const SOCKET = "PADI_SOCKET"
 
 /**
@@ -74,20 +88,6 @@ const SOCKET = "PADI_SOCKET"
  */
 const EXPECTED = `${SOCKET} names a padi on this host, but no \`kolu\` is on the PATH `
   + `this server was started with — so there is nothing here to reach it through`
-
-/** What the probe reads. A padi's identity — the commit it is running, when it
- *  started — is the daemon's own, so an answer cannot be produced by a kolu
- *  that reached no daemon: that one fails the read with `padi transport down`.
- *  Read-only, and one round trip. */
-const IDENTITY = "surface://cells/identity"
-
-/** How long the probe gets. Generous for a process start and one round trip
- *  over a unix socket — and it is spent BEFORE the session opens, so a host
- *  whose kolu wedges pays this much per conversation and gets no kolu in it.
- *  What makes five seconds affordable is where they are spent: booting the
- *  agent is a background job with the panel already drawn (`chat.ts`'s
- *  `start`), and a `session/load` next to it is allowed two minutes. */
-const PROBE_MS = 5_000
 
 /** An MCP server to spawn, in olai's terms — {@link ./agent.ts} renders it
  *  into what ACP wants, the same way it does olai's own. */
@@ -174,14 +174,30 @@ export const detect: Effect.Effect<Detected> = Effect.gen(function*() {
   // not a failure: kolu resolves this host's padi by itself, and says so when
   // there is more than one to choose from (which the probe then reports as
   // "no", correctly — that host is ambiguous, not ours to guess about).
+  //
+  // Read HERE and passed in, rather than left for `@kolu/detect` to find: this
+  // process's environment is olai's fact, and a probe that reached for it
+  // itself would be answering a different question than the one the session
+  // will ask when it spawns the real server.
   const socket = process.env[SOCKET]
   const expected = socket !== undefined && socket !== ""
-  const env: Readonly<Record<string, string>> = expected ? { [SOCKET]: socket } : {}
 
-  const command = onPath(COMMAND)
-  if (command === null) {
+  // The LIVE PATH, for the same reason it always was: it is what a spawn would
+  // resolve against, and the point of the whole exercise is to probe the file
+  // that would actually run.
+  const found = yield* Effect.promise(() =>
+    detectKolu({
+      ...(process.env["PATH"] !== undefined ? { path: process.env["PATH"] } : {}),
+      ...(socket !== undefined ? { socket } : {}),
+    })
+  )
+
+  if (found._tag === "notOnPath") {
     // Nothing to probe — but "nothing to probe" and "nothing was expected" are
-    // two facts, and only the second is quiet. See {@link EXPECTED}.
+    // two facts, and only the second is quiet. See {@link EXPECTED}. This is the
+    // arm kolu deliberately hands back bare: it reports that nothing was found,
+    // and whether that is a fault is decided here, against olai's own
+    // environment.
     if (!expected) return { _tag: "none" }
     yield* Effect.logDebug("a padi is named here but kolu is not on this PATH").pipe(
       Effect.annotateLogs({ [SOCKET]: socket }),
@@ -189,169 +205,92 @@ export const detect: Effect.Effect<Detected> = Effect.gen(function*() {
     return { _tag: "silent", kolu: null, why: EXPECTED }
   }
 
-  const why = yield* Effect.promise(() => whyNotAnswered(command, env))
-  if (why !== null) {
+  if (found._tag === "unreachable") {
+    const why = whyOf(found.why)
     // The reason is on the line now as well as on the value. It used to say
     // only that "no padi answered", which is the one thing every way of
     // failing had in common and the one thing that never helped.
     yield* Effect.logDebug("kolu is on PATH but did not answer").pipe(
-      Effect.annotateLogs({ kolu: command, why }),
+      Effect.annotateLogs({ kolu: found.command, why }),
     )
-    return { _tag: "silent", kolu: command, why }
+    return { _tag: "silent", kolu: found.command, why }
   }
+
   yield* Effect.logInfo("kolu's terminals are on this session").pipe(
-    Effect.annotateLogs({ kolu: command }),
+    Effect.annotateLogs({ kolu: found.server.command }),
   )
-  return { _tag: "kolu", server: { name: COMMAND, command, args: ARGS, env } }
+  return {
+    _tag: "kolu",
+    server: {
+      name: COMMAND,
+      command: found.server.command,
+      args: found.server.args,
+      env: found.server.env,
+    },
+  }
 })
 
-/** The executable by that name on PATH, or `null`. The PATH is passed rather
- *  than left to the runtime's own copy, which is the one this process STARTED
- *  with — the live one is what a spawn would resolve against, and the point of
- *  this whole file is to probe the file that would actually run. */
-const onPath = (name: string): string | null => Bun.which(name, { PATH: process.env["PATH"] ?? "" })
-
-/** The id the read is sent under, so the answer to it is the only message that
- *  decides anything. Exported for `kolu.test.ts`, whose fixtures answer under
- *  it — an answer carrying a different id is not an answer, and a test that
- *  spelled the number itself could go on passing while this one moved. */
-export const PROBE_ID = 2
-
-/** The whole conversation, sent at once. A server that reads its input in order
- *  answers in order, and one that cannot is one whose answer we would not
- *  want. */
-const CONVERSATION: ReadonlyArray<AnyMessage> = [
-  {
-    jsonrpc: "2.0",
-    id: 1,
-    method: "initialize",
-    params: {
-      protocolVersion: "2024-11-05",
-      capabilities: {},
-      clientInfo: { name: "olai", version: "0" },
-    },
-  },
-  { jsonrpc: "2.0", method: "notifications/initialized" },
-  { jsonrpc: "2.0", id: PROBE_ID, method: "resources/read", params: { uri: IDENTITY } },
-]
-
 /**
- * Start it, say all that, and wait for the one answer that decides it — then
- * kill it either way. This process is a PROBE and never a client: the session
- * gets its own, spawned by the agent.
+ * The sentence for each way a `kolu` that WAS found failed to be this host's.
  *
- * `null` means it answered; anything else is the sentence saying which way it
- * did not, which is the difference between "kolu is not running here" (fine,
- * and common) and "the kolu on your PATH is a build that cannot do this" (worth
- * knowing, and — until `mcp-fail-visible` drew it — invisible).
+ * These words are the whole of what a person sees on the strip
+ * (`mcp-fail-visible`), so they stay here rather than crossing the package
+ * boundary in either direction: kolu reports which way it failed as a TAG and
+ * hands back the failing party's own words where there were any, and olai
+ * decides how to say it. A kolu that pre-worded these would make four English
+ * strings a contract between two repos — the exact coupling the division of
+ * labour exists to avoid — and one that only said "it did not work" would put
+ * the debug log line on screen, which is what the incident behind this feature
+ * was debugged around.
  *
- * Almost every way of failing arrives by one door: the pipes closing ends the
- * read, and the deadline is a KILL rather than a race, so a wedged server and a
- * server that hung up are the same `done` with a flag to tell them apart. The
- * ONE that cannot come that way is a file that would not exec, which is a
- * second door and says below why it has to be.
+ * The one that carries the most is `refused`: it is what a kolu that reached no
+ * daemon sends, so its `said` is a verdict rather than noise — a kolu answering
+ * that way is installed, running, and running against nothing.
  */
-const whyNotAnswered = async (
-  command: string,
-  env: Readonly<Record<string, string>>,
-): Promise<string | null> => {
-  let child: ChildProcess
-  try {
-    child = spawn(command, [...ARGS], {
-      stdio: ["pipe", "pipe", "ignore"],
-      env: { ...process.env, ...env },
-    })
-  } catch (cause) {
-    return couldNotStart(reasonOf(cause))
+const whyOf = (failure: ProbeFailure): string => {
+  switch (failure._tag) {
+    case "couldNotStart":
+      // Wherever the refusal reached us — Bun raises it on an event and Node
+      // may throw it for a malformed call, and a reader has no business being
+      // told which.
+      return `it could not be started: ${failure.cause}`
+    case "timedOut":
+      return `it did not answer within ${failure.deadlineMs / 1000}s`
+    case "closed":
+      return "it closed the connection without answering"
+    case "failed":
+      return `talking to it failed: ${failure.cause}`
+    case "refused":
+      return failure.said !== null
+        ? `it refused to read the daemon's identity: ${failure.said}`
+        : "it refused to read the daemon's identity, so no padi is behind it"
   }
-
-  // A `kolu` on PATH with the executable bit is not necessarily a program, and
-  // an exec that fails does so AFTER `spawn` has returned — so the `catch`
-  // above never sees one. It is raced rather than merely handled, because what
-  // FOLLOWS an exec failure is our own write to a stdin that died with it, and
-  // that is the sentence `askOver` would otherwise come back with.
-  // {@link ../pipes.ts} owns the rest of the argument, and the ACP agent races
-  // the same promise for the same reason.
-  return await Promise.race([
-    unstartable(child).then(couldNotStart),
-    askOver(child, PROBE_MS),
-  ])
 }
 
 /**
- * Say all of it, and wait for the one answer that decides it — then kill the
- * process either way ({@link whyNotAnswered} is what starts it, and says why
- * the start is a question of its own).
+ * Say it all to an already-started `kolu mcp` and answer why it is not this
+ * host's — `null` if it answered.
  *
- * The deadline is a PARAMETER and this is exported for one reason, which is the
- * same reason {@link PROBE_ID} is: a test needs it. Two of the four sentences
- * here are told apart only by the `expired` flag — a wedged server and one that
- * hung up are the same closed pipe — so the flag is exactly the sort of thing
- * that rots into the wrong sentence, and the only way to exercise it through
- * `detect` is to spend five real seconds on every run forever. A fixture that
- * reads and never answers, given a tenth of a second, says the same thing.
+ * The conversation is kolu's now ({@link probeKolu}); the WORDS are still ours,
+ * so this is {@link whyOf} over kolu's verdict and nothing else. It stays
+ * exported, and the deadline stays a parameter, for the reason it always was: a
+ * wedged server and one that hung up reach the same closed pipe, and the only
+ * thing telling them apart is which of these two sentences comes back — exactly
+ * the sort of thing that rots into the wrong one with every other test still
+ * green. Exercising it through `detect` would mean spending a real five seconds
+ * on every run forever; a fixture that reads and never answers, given a tenth
+ * of one, says the same thing.
  */
 export const askOver = async (
   child: ChildProcess,
   deadlineMs: number,
 ): Promise<string | null> => {
-  /** Whether the deadline is what ended this, so the closed pipe below is read
-   *  as the timeout it is rather than as an agent that hung up. */
-  let expired = false
-  const deadline = setTimeout(() => {
-    expired = true
-    child.kill("SIGKILL")
-  }, deadlineMs)
-  try {
-    const stream = streamOver(child)
-    const writer = stream.writable.getWriter()
-    for (const message of CONVERSATION) await writer.write(message)
-    // stdin stays OPEN: a server told its client has gone is entitled to leave
-    // before it has finished answering, and the kill below is what ends this
-    // one.
-    const reader = stream.readable.getReader()
-    while (true) {
-      const next = await reader.read()
-      if (next.done) {
-        return expired
-          ? `it did not answer within ${deadlineMs / 1000}s`
-          : "it closed the connection without answering"
-      }
-      if (!answersTheProbe(next.value)) continue
-      return refusalIn(next.value)
-    }
-  } catch (cause) {
-    return `talking to it failed: ${reasonOf(cause)}`
-  } finally {
-    clearTimeout(deadline)
-    child.kill("SIGKILL")
-  }
+  const verdict = await probeKolu(child, deadlineMs)
+  return verdict._tag === "answered" ? null : whyOf(verdict)
 }
 
-/** The one sentence for a file that would not run, wherever the refusal reached
- *  us — Bun raises it on an event and Node may throw it for a malformed call,
- *  and a reader has no business being told which. */
-const couldNotStart = (why: string): string => `it could not be started: ${why}`
-
-/** Two questions, and they were one three-valued answer: this one is "is this
- *  message ours at all", which is about the ENVELOPE and true of a refusal
- *  exactly as much as of a success. */
-const answersTheProbe = (message: AnyMessage): boolean =>
-  (message as { readonly id?: unknown }).id === PROBE_ID
-
-/** ... and this one is what our answer SAYS: `null` it answered, a sentence it
- *  refused. A refusal is what a kolu that reached no daemon sends, so it is a
- *  verdict rather than noise — and it is the one whose reason a reader most
- *  wants, since a kolu answering this way is installed, running, and running
- *  against nothing. */
-const refusalIn = (message: AnyMessage): string | null => {
-  const shape = message as {
-    readonly result?: unknown
-    readonly error?: { readonly message?: unknown }
-  }
-  if (shape.result !== undefined && shape.result !== null) return null
-  const said = shape.error?.message
-  return typeof said === "string" && said !== ""
-    ? `it refused to read the daemon's identity: ${said}`
-    : "it refused to read the daemon's identity, so no padi is behind it"
-}
+/** The id kolu sends the identity read under, re-exported because this
+ *  package's fixtures answer under it — an answer carrying a different id is
+ *  not an answer, and a fixture that spelled the number itself could go on
+ *  passing while kolu's moved. */
+export { PROBE_ID } from "@kolu/detect"

--- a/packages/chat/src/pipes.test.ts
+++ b/packages/chat/src/pipes.test.ts
@@ -1,7 +1,7 @@
 /**
  * The half of a subprocess's lifecycle that is not a pipe: whether it ever ran.
  *
- * Both subprocesses this package starts go through {@link unstartable}, and it
+ * The ACP agent this package starts goes through {@link unstartable}, and it
  * is the kind of thing that is only ever exercised by a machine somebody else
  * has misconfigured — so it is asserted here, against real children, rather
  * than left to be discovered in the field a second time.


### PR DESCRIPTION
Pairs with **[juspay/kolu#2168](https://github.com/juspay/kolu/pull/2168)**, which gives kolu its own host-side `detect()`. This is olai's side: `packages/chat/src/kolu.ts` stops hand-rolling the probe and asks kolu instead.

Draft until kolu#2168 merges — the npins pin currently tracks that PR's head branch (`kolu-detect`, `9010529`) and gets repointed at a master SHA before this goes ready.

## What moved, and what deliberately did not

**Moved (to `@kolu/detect`):** resolving `kolu` on PATH, spawning it, racing the exec-failure event against the conversation, writing the MCP handshake, framing ndjson, reading until the identity read is answered, and killing the probe either way. All of that is knowledge *about kolu* — including the two incidents it encodes ([kolu#2146](https://github.com/juspay/kolu/issues/2146), a padi-spawned terminal's bundled build ahead on PATH answering with the same version string; [kolu#2148](https://github.com/juspay/kolu/issues/2148), a `kolu mcp` that completes the handshake and lists everything with no daemon behind it). Those are facts about kolu's own builds, discoverable there and not here, and this repo was holding them on kolu's behalf.

**Did not move: every sentence a person reads.** kolu reports *which way* it failed as a tag and hands back the failing party's own words where there were any; `whyOf` turns that into the five strings the strip draws, unchanged to the character. A kolu that pre-worded them would make four English strings a contract between two repos, which is exactly the coupling `mcp-fail-visible` must not acquire.

**Did not move: the judgement about absence.** `@kolu/detect` answers `notOnPath` with *no reason attached*, on purpose. Whether a missing kolu is a fault depends on `PADI_SOCKET` — olai's environment, under olai's service manager — so the `EXPECTED` sentence and the decision to be quiet without it stay here. `PADI_SOCKET` and `PATH` are read here and passed in for the same reason: a probe that reached for them itself would answer a different question than the one the session asks when it spawns the real server.

That split is what let the kolu API be shaped around this repo's constraints rather than the reverse — `refused` carries `said` so `it refused to read the daemon's identity: …` still composes, `timedOut` carries `deadlineMs` so `0.15s` still renders from `150`.

## The pins pass unmodified

`packages/chat/src/kolu.test.ts` is **byte-for-byte unchanged** (`git diff` on it is empty) and green: **15/15**, 22 assertions.

That includes every pin the constraint names: the full `EXPECTED` sentence verbatim, `{_tag: "silent", kolu: null}` with `missingFrom` → `{name: "kolu", where: null}`, the refusal carrying `padi transport down`, `it closed the connection without answering`, `it could not be started: …` *without* `stream was destroyed`, `{_tag: "none"}` when nothing is expected, `env: {}` with no socket, the success shape's absolute path, and `mcpServersOf` rendering kolu beside olai's http entry. The whole `@olai/chat` suite is green too (**87/87** across 9 files), under Bun.

Two exports were kept precisely so the file would not have to change:

- **`askOver(child, deadlineMs)`** survives as the wording layer over kolu's `probe`, so `expect(await askOver(child, 150)).toBe("it did not answer within 0.15s")` still holds — and the deadline stays a parameter for the reason it always was: a wedged server and one that hung up reach the same closed pipe, and only which sentence comes back tells them apart. Exercising that through `detect` would mean spending five real seconds on every run forever.
- **`PROBE_ID`** is re-exported from `@kolu/detect`, so the fixtures still answer under the id the prober actually sends — and now they cannot drift from it.

`pipes.ts` stays exactly as it was: the ACP agent is still this package's own subprocess, and `unstartable` is still its exec-failure race. Only its test's header comment changed, which had claimed *both* subprocesses go through it.

## Also in this branch

- `nix/kolu.nix` hydrates `detect` alongside the other five `@kolu/*` sources (one word). `@kolu/detect` is zero-dependency, so olai's root `dependencies` needed nothing — `just kolu-deps` confirms.
- `packages/chat/README.md`: two paragraphs described a mechanism that has moved and would otherwise have become quietly false ("the framing lives in `pipes.ts` and neither of them owns it"; "`kolu.ts` writes three messages and reads until one is answered"). Rewritten to say where the probe lives now and what this file still owns. The prose about the five sentences, the `PADI_SOCKET` rule and the path-naming is untouched because it is still true.
- `docs/roadmap.jsonl` untouched, per the dispatch.
