### PR TITLE
The e2e keys stop racing the writes they make

### DIFF
--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -456,42 +456,32 @@ written" passes instantly and proves nothing. Where a count is the claim, it is
 both: wait for the number, then hold it, because the second of two writes lands
 a moment after the first.
 
-**A file the write has not minted yet.** `archive` writes `Archive.jsonl` the
-first time anything is put away, so a step polling for a node to ARRIVE in one
-is polling for the FILE too. Every waiting reader goes through
-`world.servedNodesSoFar`, which answers "nothing there yet" for a file that is
-not there — and ENOENT only: a line that is not JSON is still a fault. A step
-that WRITES the served directory calls `world.servedNodes`, which throws,
-because a missing file there is a scenario naming something its corpus does not
-hold.
+**A file the write has not minted yet** — `Archive.jsonl`, which the first
+archive creates. A waiting reader goes through `world.servedNodesSoFar`, which
+answers "nothing there yet" for a file that is not there; a step that WRITES the
+served directory goes through `world.servedNodes`, which throws. The reason
+either is right is on the method.
 
 **A key pressed before the page has answered the last one.** The one that costs
 the most to debug, because it fails four steps later on something that reads
-nothing like the cause. A write these scenarios make goes out through a DRAFT,
-and the draft is let go — closed, or moved to the line the key opened — only
-once the server has answered and the inverse it answered with is on the stack
-⌘Z spends. So the caret leaving the line it was on is this tab's own receipt,
-and it is the only one the harness has: the disk says a file was written, the
-DOM says the page was told, neither says this tab knows yet.
+nothing like the cause: `Escape` closes a draft that has not opened yet and the
+draft opens behind it, so every ⌘Z after that is dead; `Tab` walks the browser's
+focus ring out of the row, so the next key finds no editor; `⌘A` selects the
+page, so the title typed after it lands beside the old one instead of replacing
+it. The receipt this suite waits on — and why nothing else it can see will do —
+is `support/caret.ts`. What that buys each step:
 
-So the keys that end a line — `Enter`, `Backspace` at the head of one, `Escape`
-with a draft open — and `I click away from the editor` wait for the caret to
-leave; the keys that MOVE a row (`Tab`, `Shift+Tab`, and the two that walk it
-past a sibling) wait for it to be drawn where they put it; and every one of
-them will take "the page said why it did not" instead, which is the other way a
-key ends. `I press`, `I type` and `I select all and type` also wait for the
-line to hold the caret BEFORE they aim anything at it, because a redrawn row
-takes the focus with it and the client puts the caret back a round trip later.
+| step | waits for |
+|---|---|
+| `I press`, `I type`, `I select all and type` | the line to hold the caret, BEFORE aiming anything at it |
+| `I press "Enter"` / `"Backspace"` at the head of a line | the caret to leave that line, and arrive in the one the key opened |
+| `I press "Tab"` / `"Shift+Tab"` / `"Alt+Shift+Arrow…"` | the row to be drawn where the key put it |
+| `I press "Escape"` with a draft open | the draft to close |
+| `I click away from the editor` | the caret to leave the line |
 
-Skip any of that and: `Escape` closes a draft that has not opened yet and the
-draft opens behind it, so every ⌘Z after that is dead (a chord belongs to the
-input while a draft is open); `Tab` walks the browser's focus ring out of the
-row, so the next key finds no editor; `⌘A` selects the page, so the title typed
-after it lands beside the old one instead of replacing it. All three are silent
-until an assertion several steps later.
-
-`I press "…" without waiting` is the way to mean the race deliberately, and two
-scenarios do.
+Every one of them will take "the page said why it did not" instead, which is
+the other way a key ends. `I press "…" without waiting` is how the two scenarios
+that MEAN the race say so.
 
 None of the three mistakes is fixed by a longer timeout, and a step that needed
 one was asking the wrong question.

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -471,15 +471,27 @@ once the server has answered and the inverse it answered with is on the stack
 and it is the only one the harness has: the disk says a file was written, the
 DOM says the page was told, neither says this tab knows yet.
 
-`I press "Enter"`, `I press "Backspace"` at the head of a line, `I press
-"Escape"` with a draft open, and `I click away from the editor` therefore wait
-for the caret to leave — or for the page to say why it did not, which is the
-other way a key ends. Skip that and `Escape` closes a draft that has not opened
-yet, the draft opens behind it, and every ⌘Z after that is dead, because a
-chord belongs to the input while a draft is open.
+So the keys that end a line — `Enter`, `Backspace` at the head of one, `Escape`
+with a draft open — and `I click away from the editor` wait for the caret to
+leave; the keys that MOVE a row (`Tab`, `Shift+Tab`, and the two that walk it
+past a sibling) wait for it to be drawn where they put it; and every one of
+them will take "the page said why it did not" instead, which is the other way a
+key ends. `I press`, `I type` and `I select all and type` also wait for the
+line to hold the caret BEFORE they aim anything at it, because a redrawn row
+takes the focus with it and the client puts the caret back a round trip later.
 
-None of the three is fixed by a longer timeout, and a step that needed one was
-asking the wrong question.
+Skip any of that and: `Escape` closes a draft that has not opened yet and the
+draft opens behind it, so every ⌘Z after that is dead (a chord belongs to the
+input while a draft is open); `Tab` walks the browser's focus ring out of the
+row, so the next key finds no editor; `⌘A` selects the page, so the title typed
+after it lands beside the old one instead of replacing it. All three are silent
+until an assertion several steps later.
+
+`I press "…" without waiting` is the way to mean the race deliberately, and two
+scenarios do.
+
+None of the three mistakes is fixed by a longer timeout, and a step that needed
+one was asking the wrong question.
 
 ## The scripted agent
 

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -427,6 +427,59 @@ out locally: it is `index.html`'s mount point, which the client does not own.
    not that some title eventually reads a certain way. A tree that has lost one
    node and drawn another twice still has all the right titles in it, which is
    how a broken live view stayed green through a whole feature file.
+7. Read the section below before writing a step that reads the disk or presses
+   a key. All three mistakes it names pass on an idle laptop.
+
+## Waiting, which is the whole of being honest under load
+
+This suite runs parallel, on machines that are also doing something else, so
+every assertion in it is a race unless it was written not to be. A run on a
+saturated box is the only way to find out, and there are exactly three ways to
+get it wrong. All three are green on an idle laptop.
+
+**A value read on its way to its final one.** Most assertions here WAIT: they
+poll until the page or the file says the thing, and fail saying what they were
+waiting for. The ones that cannot are the NEGATIVES, and a negative is two
+different steps that read almost the same:
+
+| the claim | the shape | example |
+|---|---|---|
+| nothing was written, and stays unwritten | HOLD: assert repeatedly across the commit window | `"house.jsonl" holds no node titled "…"` |
+| the write took it away | WAIT: poll for it to go | `"house.jsonl" no longer holds a node titled "…"` |
+
+Asking the holding form of a write passes only when the round trip happens to
+land inside one animation frame. Asking the waiting form of "nothing was
+written" passes instantly and proves nothing. Where a count is the claim, it is
+both: wait for the number, then hold it, because the second of two writes lands
+a moment after the first.
+
+**A file the write has not minted yet.** `archive` writes `Archive.jsonl` the
+first time anything is put away, so a step polling for a node to ARRIVE in one
+is polling for the FILE too. Every waiting reader goes through
+`world.servedNodesSoFar`, which answers "nothing there yet" for a file that is
+not there — and ENOENT only: a line that is not JSON is still a fault. A step
+that WRITES the served directory calls `world.servedNodes`, which throws,
+because a missing file there is a scenario naming something its corpus does not
+hold.
+
+**A key pressed before the page has answered the last one.** The one that costs
+the most to debug, because it fails four steps later on something that reads
+nothing like the cause. A write these scenarios make goes out through a DRAFT,
+and the draft is let go — closed, or moved to the line the key opened — only
+once the server has answered and the inverse it answered with is on the stack
+⌘Z spends. So the caret leaving the line it was on is this tab's own receipt,
+and it is the only one the harness has: the disk says a file was written, the
+DOM says the page was told, neither says this tab knows yet.
+
+`I press "Enter"`, `I press "Backspace"` at the head of a line, `I press
+"Escape"` with a draft open, and `I click away from the editor` therefore wait
+for the caret to leave — or for the page to say why it did not, which is the
+other way a key ends. Skip that and `Escape` closes a draft that has not opened
+yet, the draft opens behind it, and every ⌘Z after that is dead, because a
+chord belongs to the input while a draft is open.
+
+None of the three is fixed by a longer timeout, and a step that needed one was
+asking the wrong question.
 
 ## The scripted agent
 

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -475,7 +475,7 @@ is `support/caret.ts`. What that buys each step:
 |---|---|
 | `I press`, `I type`, `I select all and type` | the line to hold the caret, BEFORE aiming anything at it |
 | `I press "Enter"` / `"Backspace"` at the head of a line | the caret to leave that line, and arrive in the one the key opened |
-| `I press "Tab"` / `"Shift+Tab"` / `"Alt+Shift+Arrow…"` | the row to be drawn where the key put it |
+| `I press "Tab"` / `"Shift+Tab"` / `"Alt+Shift+Arrow…"` | the row to be drawn where the key moved it |
 | `I press "Escape"` with a draft open | the draft to close |
 | `I click away from the editor` | the caret to leave the line |
 

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -13,6 +13,9 @@ packages/tests/
 ├── support/
 │   ├── world.ts             # OlaiWorld: page, locators, the UI contract
 │   ├── hooks.ts             # browser + a server per corpus (and per scratch copy)
+│   ├── caret.ts             # the client's own answer to a key, and how a step
+│                           #   waits for it (see "Waiting", below)
+│   ├── said.ts              # what the page said about a write, wherever it says it
 │   ├── mcp.ts               # an MCP client, for the agent olai did not start
 │   └── ndjson.ts            # line-delimited JSON off a pipe — one copy, shared
 │                           #   by that client and both fakes below

--- a/packages/tests/features/split_and_merge.feature
+++ b/packages/tests/features/split_and_merge.feature
@@ -138,8 +138,6 @@ Feature: Splitting and merging a row
     When I press "Escape"
     And I press "ControlOrMeta+z"
     Then the node "handles" has the title "choose the handles"
-    # Waited for, not held: the ⌘Z is a WRITE taking the tail away, and the
-    # holding form of the step is the promise that nothing was written at all.
     And "house.jsonl" no longer holds a node titled " the handles"
     When I press "ControlOrMeta+Shift+z"
     Then the node "handles" has the title "choose"

--- a/packages/tests/features/split_and_merge.feature
+++ b/packages/tests/features/split_and_merge.feature
@@ -138,7 +138,9 @@ Feature: Splitting and merging a row
     When I press "Escape"
     And I press "ControlOrMeta+z"
     Then the node "handles" has the title "choose the handles"
-    And "house.jsonl" holds no node titled " the handles"
+    # Waited for, not held: the ⌘Z is a WRITE taking the tail away, and the
+    # holding form of the step is the promise that nothing was written at all.
+    And "house.jsonl" no longer holds a node titled " the handles"
     When I press "ControlOrMeta+Shift+z"
     Then the node "handles" has the title "choose"
     # And the redo is the whole write, not half of it: the tail is a record on

--- a/packages/tests/features/undo.feature
+++ b/packages/tests/features/undo.feature
@@ -175,7 +175,11 @@ Feature: Undo
     And I press "Escape"
     Then "house.jsonl" holds a node titled "a line typed by mistake"
     When I press "ControlOrMeta+z"
-    Then "house.jsonl" holds no node titled "a line typed by mistake"
+    # WAITED for, not held: the two steps read alike and mean opposite things.
+    # "holds no node" is the promise that nothing was written and has to outlast
+    # the commit window; this is a WRITE going through, and asking the holding
+    # form of it passes only when the archive lands inside one animation frame.
+    Then "house.jsonl" no longer holds a node titled "a line typed by mistake"
     And "Archive.jsonl" holds a node titled "a line typed by mistake"
     # NOTHING is said now, and that is the news. This used to be the one entry
     # that explained why it could not be redone — a `move` is same-file by the
@@ -185,7 +189,11 @@ Feature: Undo
     And nothing is said about the undo
     When I press "ControlOrMeta+Shift+z"
     Then "house.jsonl" holds a node titled "a line typed by mistake"
-    And "Archive.jsonl" holds no node titled "a line typed by mistake"
+    # Waited for, and for the second reason the pair exists: an `unarchive` is
+    # two files, and the record leaves the archive a moment after it arrives
+    # here. Held, this reads the first of the two writes and calls the second
+    # one a failure.
+    And "Archive.jsonl" no longer holds a node titled "a line typed by mistake"
     # WHERE it landed, not just that it is back: the row was a sibling of
     # `handles`, so it belongs under `install`. With the chain above it still
     # standing, both roads lead there — the scenario below is the one that
@@ -210,7 +218,7 @@ Feature: Undo
     Then the node "install" has the title "fit the cabinets"
     When I press "ControlOrMeta+Shift+z"
     Then "house.jsonl" holds a node titled "a line typed by mistake" under "install"
-    And "Archive.jsonl" holds no node titled "a line typed by mistake"
+    And "Archive.jsonl" no longer holds a node titled "a line typed by mistake"
 
   Scenario: An undo does not clobber what somebody else did meanwhile
     # The whole reason this is an inverse and not a snapshot restore. Between

--- a/packages/tests/step_definitions/editing_steps.ts
+++ b/packages/tests/step_definitions/editing_steps.ts
@@ -179,6 +179,31 @@ const nothingIsBeingTyped = async (world: OlaiWorld): Promise<void> => {
   );
 };
 
+/** WHERE the caret is: the row the open editor belongs to, the line that does
+ *  not exist yet, or `null` for a page with nothing being typed. A NAME for
+ *  the place rather than the element drawing it, so a row redrawn where the
+ *  file now says it is stays the same place. */
+const caretPlace = async (world: OlaiWorld): Promise<string | null> =>
+  await world.page.evaluate(
+    ([caret, newRow, node]) => {
+      const editor = document.querySelector(caret);
+      if (editor === null) return null;
+      if (editor.closest(newRow) !== null) return "(a new line)";
+      const row = editor.closest("[data-node-id]");
+      if (row === null) return "(a line off the tree)";
+      // The chain of ids down to it AND where it sits, which together are what
+      // the client itself calls a `Row.key`: an indent changes the chain and a
+      // reorder changes only the seat, and both are the row being drawn
+      // somewhere else.
+      const chain: Array<string> = [];
+      for (let at: Element | null = row; at !== null; at = at.parentElement?.closest(node) ?? null) {
+        chain.unshift(at.getAttribute("data-node-id") ?? "?");
+      }
+      return `${chain.join("/")}@${[...document.querySelectorAll(node)].indexOf(row)}`;
+    },
+    [CARET_EDITOR, NEW_ROW, NODE] as [string, string, string],
+  );
+
 /** The line being typed HOLDS the caret. */
 const caretIsInTheLine = async (world: OlaiWorld): Promise<void> => {
   await world.waitUntil(
@@ -220,6 +245,15 @@ When(
 
 // ── the keys ───────────────────────────────────────────────────────────
 
+/** The keys that put the row somewhere else — indent, outdent, and the two
+ *  that walk it past a sibling. */
+const MOVES = new Set([
+  "Tab",
+  "Shift+Tab",
+  "Alt+Shift+ArrowUp",
+  "Alt+Shift+ArrowDown",
+]);
+
 /**
  * What waiting for this key MEANS — decided BEFORE it is pressed, because the
  * answer depends on where the caret was when it was. `null` for the keys that
@@ -229,11 +263,24 @@ const answering = async (
   world: OlaiWorld,
   key: string,
 ): Promise<(() => Promise<void>) | null> => {
-  if (key === "Alt+Shift+ArrowUp" || key === "Alt+Shift+ArrowDown") {
-    // A move redraws the row where the file now says it is. The caret has to
-    // come back before anything else is asked of that line; one frame is not
-    // that, under load.
-    return async () => await caretIsInTheLine(world);
+  if (MOVES.has(key)) {
+    // A MOVE, and its receipt is the row being drawn where the file now says
+    // it is — the same frame the client is waiting for to take the caret back
+    // (`editing.tsx`'s `settle`). Pressing the next thing before it arrives is
+    // what the scenarios above were doing, and the client is entitled to read
+    // a click in that window as its own: the blur is suppressed as the redraw
+    // it is still owed, and the caret is taken back over the top of it.
+    const was = await caretPlace(world);
+    if (was === null) return null;
+    return async () => {
+      await world.waitUntil(
+        async () =>
+          (await caretPlace(world)) !== was ||
+          (await world.page.locator(EDIT_REFUSAL).count()) > 0,
+        "the row the key moved to be drawn where it moved it, or the page to say why it did not",
+      );
+      await caretIsInTheLine(world);
+    };
   }
   if (key === "Escape") {
     // Escape abandons the draft, always — no write, so nothing to be refused.
@@ -346,15 +393,27 @@ Then(
 
 When("I click away from the editor", async function (this: OlaiWorld) {
   // Somewhere in the pane that is not a row: a blur, and nothing else.
-  const editor = await editorHeld(this, CARET_EDITOR);
+  const was = await caretPlace(this);
   await this.page.locator("main").click({ position: { x: 4, y: 4 } });
   await this.waitForFrame();
-  // And the editor that was open is LET GO, which is the same receipt the keys
-  // above wait for and for the same reason: a blur commits through the same
-  // queue, so the draft it was on outliving the click is this tab still
-  // waiting to hear.
-  if (editor !== null) {
-    await letGo(this, editor, "the editor the click was away from to be let go");
+  // And the caret LEAVES the line it was in, which is the same receipt the
+  // keys wait for and for the same reason: a blur commits through the same
+  // queue, so a draft still open on that line is this tab still waiting to
+  // hear.
+  //
+  // WHERE rather than WHICH ELEMENT, which is the one place these two waits
+  // differ: a structural key redraws the row the caret is in, and a row that
+  // came back as a new element would satisfy "the element I was holding is
+  // gone" without anybody having let go of anything — the draft is open, on
+  // the same line, and the ⌘Z after this step is dead in it. That is what
+  // `undo.feature:255` and `:324` were still failing on.
+  if (was !== null) {
+    await this.waitUntil(
+      async () =>
+        (await caretPlace(this)) !== was ||
+        (await this.page.locator(EDIT_REFUSAL).count()) > 0,
+      "the caret to leave the line the click was away from, or the page to say why it did not",
+    );
   }
 });
 

--- a/packages/tests/step_definitions/editing_steps.ts
+++ b/packages/tests/step_definitions/editing_steps.ts
@@ -36,8 +36,8 @@ import type { Locator } from "playwright";
 import {
   aimedAtTheLine,
   answering,
-  caretPlace,
-  leftThePlace,
+  leavingTheLine,
+  nothingIsBeingTyped,
 } from "../support/caret.ts";
 import { saysNothing, saysThat } from "../support/said.ts";
 import {
@@ -205,17 +205,18 @@ Then(
 );
 
 When("I click away from the editor", async function (this: OlaiWorld) {
-  // Somewhere in the pane that is not a row: a blur, and nothing else.
-  const was = await caretPlace(this);
-  await this.page.locator("main").click({ position: { x: 4, y: 4 } });
-  await this.waitForFrame();
-  // And the caret LEAVES the line it was in, which is the same receipt the
-  // keys wait for and for the same reason: a blur commits through the same
-  // queue, so a draft still open on that line is this tab still waiting to
-  // hear.
-  if (was !== null) {
-    await leftThePlace(this, was, "the caret to leave the line the click was away from");
-  }
+  // Somewhere in the pane that is not a row: a blur, and nothing else — and
+  // then the caret LEAVES, which is the same receipt the keys wait for and for
+  // the same reason: a blur commits through the same queue, so a draft still
+  // open on that line is this tab still waiting to hear.
+  await leavingTheLine(
+    this,
+    async () => {
+      await this.page.locator("main").click({ position: { x: 4, y: 4 } });
+      await this.waitForFrame();
+    },
+    "the caret to leave the line the click was away from",
+  );
 });
 
 // ── what is on screen ──────────────────────────────────────────────────
@@ -285,12 +286,10 @@ Then(
 );
 
 Then("no row is being edited", async function (this: OlaiWorld) {
-  await this.waitUntil(
-    async () =>
-      (await this.page.locator(TITLE_EDITOR).count()) === 0 &&
-      (await this.page.locator(DESC_EDITOR).count()) === 0,
-    "no editor to be open",
-  );
+  // The same question `Escape` is waited on with, asked as a promise — one
+  // spelling of "a page with no caret in a row", which is the state ⌘Z is
+  // answered from and the one these two would drift apart about.
+  await nothingIsBeingTyped(this);
 });
 
 Then("a new row is being typed", async function (this: OlaiWorld) {

--- a/packages/tests/step_definitions/editing_steps.ts
+++ b/packages/tests/step_definitions/editing_steps.ts
@@ -27,7 +27,7 @@ import { MARKS } from "@olai/format";
 
 import { IDLE_COMMIT } from "@olai/web/src/client/edit/draft.ts";
 
-import type { Locator } from "playwright";
+import type { ElementHandle, Locator } from "playwright";
 
 import { saysNothing, saysThat } from "../support/said.ts";
 import {
@@ -78,9 +78,130 @@ When("I start the first line", async function (this: OlaiWorld) {
     .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
 });
 
+/**
+ * THE DRAFT IS THIS TAB'S OWN RECEIPT, and the steps below wait for it.
+ *
+ * Every write these scenarios make with the keys goes out through a draft, and
+ * the draft is let go — closed, or moved to the line the key opened — only
+ * once `edit.apply` has answered AND the inverse it answered with is on the
+ * stack ⌘Z spends: `editing.tsx`'s `send` calls `undo.record` before it
+ * returns, and every caret move is downstream of that call. Nothing else this
+ * harness can see says as much. The DISK says a file was written; the DOM says
+ * the page was told; neither says THIS TAB has the way back yet, and "this tab
+ * has the way back" is the precondition of every ⌘Z in the suite.
+ *
+ * So: the caret leaving the line it was on is the signal, and the keys that
+ * end a line wait for it.
+ *
+ * WHAT SKIPPING IT COSTS is a failure that reads nothing like its cause.
+ * `Enter` commits the row and opens the next line's editor only when the write
+ * lands, so an `Escape` one frame behind it closes nothing — and then the
+ * draft opens behind the Escape, and every ⌘Z after that is dead, because a
+ * chord belongs to the input while a draft is open. The scenario fails four
+ * steps later on a file nobody wrote. Under load that was most of
+ * `undo.feature` and a third of `split_and_merge.feature`.
+ *
+ * THE OTHER WAY A KEY ENDS is refused: the row keeps the caret and the reason
+ * is drawn under it. That is a settled page too, so it ends the wait — and the
+ * reason on screen is this key's own rather than an older one, because the
+ * next keystroke drops it (`draft.ts`'s `typed`).
+ *
+ * THE SAME RECEIPT IS A PRECONDITION, which is the other half. A structural
+ * key redraws the row it was pressed in, and moving an element in the document
+ * is what takes the focus off it; the client puts the caret back through
+ * `editing.tsx`'s own `caret` counter, a frame or a round trip later. A key
+ * aimed at the row in that gap goes to the DOCUMENT instead — `Tab` walks the
+ * browser's focus ring out of the row, which closes the draft and leaves the
+ * next key with no editor at all, and ⌘A selects the page, so what is typed
+ * after it lands beside the title instead of replacing it. Both were seen on a
+ * loaded box, both are silent, and both are read as a wrong answer four steps
+ * later.
+ */
+
+/** The editor the caret is in — a row's title or its note, whichever is open.
+ *  A page with neither has no caret in a row, which is the state ⌘Z is
+ *  answered from. */
+const CARET_EDITOR = `${TITLE_EDITOR}, ${DESC_EDITOR}`;
+
+/** The editor that is open, as a handle — which goes on answering after the
+ *  page has taken it away, and that is the whole question {@link letGo} asks.
+ *  `null` when nothing is being typed, which is every `Enter` that picks a
+ *  menu item. `which` is the title alone for the keys the title claims. */
+const editorHeld = async (
+  world: OlaiWorld,
+  which: string,
+): Promise<ElementHandle<Node> | null> => {
+  const editor = world.page.locator(which).first();
+  return (await editor.count()) === 0 ? null : await editor.elementHandle();
+};
+
+/** Is `Backspace` the APP's key here, rather than the field's own?
+ *
+ *  Only at the head of a line that HAS something on it. Anywhere else in the
+ *  text it deletes a character; at the head of an empty draft it does nothing
+ *  at all, because an empty new row is not a node and there is nothing to join
+ *  it to (`editing.tsx`'s `merge` stops at that guard). Both leave the caret
+ *  where it was, so both have nothing to wait for. */
+const joinsWithBackspace = async (line: ElementHandle<Node>): Promise<boolean> =>
+  await line.evaluate((element) => {
+    const field = element as HTMLInputElement;
+    return field.selectionStart === 0 && field.selectionEnd === 0 && field.value !== "";
+  });
+
+/**
+ * That editor has been LET GO — the page has taken the element away — or it
+ * has said why it has not.
+ *
+ * The ELEMENT rather than "no editor is open", because the two differ in the
+ * case that matters: a new line that commits becomes the row it just made
+ * (`draft.ts`'s `landed`), so an editor is still open and it is a different
+ * one. That transition is downstream of the write, which is what makes it a
+ * receipt either way.
+ */
+const letGo = async (
+  world: OlaiWorld,
+  editor: ElementHandle<Node>,
+  what: string,
+): Promise<void> => {
+  await world.waitUntil(
+    async () =>
+      !(await editor.evaluate((element) => element.isConnected)) ||
+      (await world.page.locator(EDIT_REFUSAL).count()) > 0,
+    `${what}, or the page to say why it did not`,
+  );
+};
+
+/** No row is being typed in at all. */
+const nothingIsBeingTyped = async (world: OlaiWorld): Promise<void> => {
+  await world.waitUntil(
+    async () => (await world.page.locator(CARET_EDITOR).count()) === 0,
+    "the draft to close",
+  );
+};
+
+/** The line being typed HOLDS the caret. */
+const caretIsInTheLine = async (world: OlaiWorld): Promise<void> => {
+  await world.waitUntil(
+    async () =>
+      await world.page.evaluate(
+        (which) => document.activeElement?.matches(which) === true,
+        CARET_EDITOR,
+      ),
+    "the line being typed to hold the caret",
+  );
+};
+
+/** …before something is aimed at it. Nothing being typed is nothing to wait
+ *  for, which is every key a page answers with no draft open. */
+const aimedAtTheLine = async (world: OlaiWorld): Promise<void> => {
+  if ((await world.page.locator(CARET_EDITOR).count()) === 0) return;
+  await caretIsInTheLine(world);
+};
+
 // ── typing ─────────────────────────────────────────────────────────────
 
 When("I type {string}", async function (this: OlaiWorld, text: string) {
+  await aimedAtTheLine(this);
   await this.page.keyboard.type(text);
 });
 
@@ -90,23 +211,51 @@ When(
     // Select-all inside the field, which is what a person retyping a title
     // does. An empty `text` is the whole point of one scenario: the field is
     // cleared and the write is refused.
+    await aimedAtTheLine(this);
     await this.page.keyboard.press("ControlOrMeta+a");
     if (text === "") await this.page.keyboard.press("Backspace");
     else await this.page.keyboard.type(text);
   },
 );
 
+// ── the keys ───────────────────────────────────────────────────────────
+
+/**
+ * What waiting for this key MEANS — decided BEFORE it is pressed, because the
+ * answer depends on where the caret was when it was. `null` for the keys that
+ * are a keystroke and a frame, which is most of them.
+ */
+const answering = async (
+  world: OlaiWorld,
+  key: string,
+): Promise<(() => Promise<void>) | null> => {
+  if (key === "Alt+Shift+ArrowUp" || key === "Alt+Shift+ArrowDown") {
+    // A move redraws the row where the file now says it is. The caret has to
+    // come back before anything else is asked of that line; one frame is not
+    // that, under load.
+    return async () => await caretIsInTheLine(world);
+  }
+  if (key === "Escape") {
+    // Escape abandons the draft, always — no write, so nothing to be refused.
+    // With none open there is nothing to wait for, which is every Escape that
+    // shuts a menu, a picker or the palette instead.
+    if ((await world.page.locator(CARET_EDITOR).count()) === 0) return null;
+    return async () => await nothingIsBeingTyped(world);
+  }
+  if (key !== "Enter" && key !== "Backspace") return null;
+  const line = await editorHeld(world, TITLE_EDITOR);
+  if (line === null) return null;
+  if (key === "Backspace" && !(await joinsWithBackspace(line))) return null;
+  return async () =>
+    await letGo(world, line, "the caret to leave the line the key ended");
+};
+
 When("I press {string}", async function (this: OlaiWorld, key: string) {
+  await aimedAtTheLine(this);
+  const answered = await answering(this, key);
   await this.page.keyboard.press(key);
   await this.waitForFrame();
-  if (key === "Alt+Shift+ArrowUp" || key === "Alt+Shift+ArrowDown") {
-    // A move remounts the row. The next key (⌘Enter) is for the caret
-    // that has to come back; one frame is not that, under load.
-    await this.page
-      .locator(TITLE_EDITOR)
-      .first()
-      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-  }
+  if (answered !== null) await answered();
 });
 
 /** The same key, with nothing waited for afterwards — which is how a person
@@ -197,8 +346,16 @@ Then(
 
 When("I click away from the editor", async function (this: OlaiWorld) {
   // Somewhere in the pane that is not a row: a blur, and nothing else.
+  const editor = await editorHeld(this, CARET_EDITOR);
   await this.page.locator("main").click({ position: { x: 4, y: 4 } });
   await this.waitForFrame();
+  // And the editor that was open is LET GO, which is the same receipt the keys
+  // above wait for and for the same reason: a blur commits through the same
+  // queue, so the draft it was on outliving the click is this tab still
+  // waiting to hear.
+  if (editor !== null) {
+    await letGo(this, editor, "the editor the click was away from to be let go");
+  }
 });
 
 // ── what is on screen ──────────────────────────────────────────────────
@@ -367,7 +524,7 @@ Then(
  *  Deliberately the RECORDS rather than the page: what these scenarios claim
  *  is that a keystroke reached a file through the ops layer. */
 const titlesIn = (world: OlaiWorld, file: string): ReadonlyArray<string> =>
-  world.servedNodes(file).map((node) => String(node["title"] ?? ""));
+  world.servedNodesSoFar(file).map((node) => String(node["title"] ?? ""));
 
 Then(
   "{string} holds a node titled {string}",
@@ -388,7 +545,7 @@ Then(
   async function (this: OlaiWorld, file: string, title: string, parent: string) {
     await this.waitUntil(
       async () =>
-        this.servedNodes(file).some(
+        this.servedNodesSoFar(file).some(
           (node) => node["title"] === title && node["parent"] === parent,
         ),
       `${file} to hold ${JSON.stringify(title)} under ${JSON.stringify(parent)}`,
@@ -412,7 +569,7 @@ Then(
   async function (this: OlaiWorld, file: string, mark: string, title: string) {
     await this.waitUntil(
       async () =>
-        this.servedNodes(file).some(
+        this.servedNodesSoFar(file).some(
           (node) => node["title"] === title && node[mark] !== undefined,
         ),
       `${file} to hold a node titled ${JSON.stringify(title)} that is marked ${mark}`,
@@ -425,34 +582,13 @@ Then(
   async function (this: OlaiWorld, file: string, ending: string) {
     await this.waitUntil(
       async () =>
-        this.servedNodes(file).some((node) =>
+        this.servedNodesSoFar(file).some((node) =>
           String(node["desc"] ?? "").trimEnd().endsWith(ending)
         ),
       `${file} to hold a node whose note ends ${JSON.stringify(ending)}`,
     );
   },
 );
-
-/**
- * The records of a file that may not exist yet.
- *
- * `Archive.jsonl` is written by the write that archives the first thing, so a
- * scenario polling for a node to arrive in it is polling for the FILE too. A
- * missing file is "nothing there yet" for exactly that reason, and it is safe
- * to read it that way here: every step below waits, so a file that never
- * arrives fails as the assertion that was actually being made rather than as
- * an ENOENT from a helper.
- */
-const recordsIn = (
-  world: OlaiWorld,
-  file: string,
-): ReadonlyArray<Record<string, unknown>> => {
-  try {
-    return world.servedNodes(file);
-  } catch {
-    return [];
-  }
-};
 
 /** BY ID, which is the half a title cannot answer. Archiving keeps a node's
  *  id — that is what makes it a trash rather than a shredder, since a mirror
@@ -462,7 +598,7 @@ Then(
   "{string} holds the node {string}",
   async function (this: OlaiWorld, file: string, id: string) {
     await this.waitUntil(
-      async () => recordsIn(this, file).some((node) => node["id"] === id),
+      async () => this.servedNodesSoFar(file).some((node) => node["id"] === id),
       `${file} to hold the node ${JSON.stringify(id)}`,
     );
   },
@@ -472,7 +608,7 @@ Then(
   "{string} no longer holds the node {string}",
   async function (this: OlaiWorld, file: string, id: string) {
     await this.waitUntil(
-      async () => !recordsIn(this, file).some((node) => node["id"] === id),
+      async () => !this.servedNodesSoFar(file).some((node) => node["id"] === id),
       `${file} to have let go of the node ${JSON.stringify(id)}`,
     );
   },
@@ -492,7 +628,7 @@ Then(
   async function (this: OlaiWorld, file: string, id: string, date: string) {
     await this.waitUntil(
       async () =>
-        recordsIn(this, file).some(
+        this.servedNodesSoFar(file).some(
           (node) => node["id"] === id && node["date"] === date,
         ),
       `${file} to hold ${JSON.stringify(id)} with \`date\` exactly ${JSON.stringify(date)}`,
@@ -505,7 +641,7 @@ Then(
   async function (this: OlaiWorld, file: string, id: string) {
     await this.waitUntil(
       async () =>
-        recordsIn(this, file).some(
+        this.servedNodesSoFar(file).some(
           (node) => node["id"] === id && node["date"] === undefined,
         ),
       `${file} to hold ${JSON.stringify(id)} with no \`date\` field`,
@@ -527,7 +663,7 @@ Then(
   async function (this: OlaiWorld, file: string, id: string) {
     await this.waitUntil(
       async () =>
-        recordsIn(this, file).some(
+        this.servedNodesSoFar(file).some(
           (node) =>
             node["id"] === id && MARKS.every((mark) => node[mark] === undefined),
         ),
@@ -544,7 +680,7 @@ Then(
   async function (this: OlaiWorld, file: string, title: string) {
     await this.waitUntil(
       async () =>
-        this.servedNodes(file).some(
+        this.servedNodesSoFar(file).some(
           (node) => node["title"] === title && node["desc"] === undefined,
         ),
       `${file} to hold a node titled ${JSON.stringify(title)} carrying no note`,
@@ -566,7 +702,7 @@ Then(
   async function (this: OlaiWorld, file: string, title: string) {
     await this.waitUntil(
       async () =>
-        this.servedNodes(file).some(
+        this.servedNodesSoFar(file).some(
           (node) =>
             node["title"] === title &&
             Object.keys(node).every((field) =>
@@ -574,6 +710,30 @@ Then(
             ),
         ),
       `${file} to hold ${JSON.stringify(title)} carrying nothing but its placement`,
+    );
+  },
+);
+
+/**
+ * The row has GONE — WAITED for, which is the opposite of the step below it.
+ *
+ * The two read almost the same and mean opposite things, and confusing them is
+ * a flaky test rather than a wrong one: "nothing should have been written" has
+ * to HOLD across the commit window, and "the write took it away" has to WAIT
+ * for a round trip. `undo.feature` asked the holding form of ⌘Z — which passes
+ * only when the archive happens to land inside one animation frame, and fails
+ * whenever the machine is busy.
+ *
+ * BY TITLE, where the pair further up is by id: a row a keystroke created
+ * carries an id nobody chose, so its title is the only thing a scenario can
+ * name it by.
+ */
+Then(
+  "{string} no longer holds a node titled {string}",
+  async function (this: OlaiWorld, file: string, title: string) {
+    await this.waitUntil(
+      async () => !titlesIn(this, file).includes(title),
+      `${file} to have let go of the node titled ${JSON.stringify(title)}`,
     );
   },
 );

--- a/packages/tests/step_definitions/editing_steps.ts
+++ b/packages/tests/step_definitions/editing_steps.ts
@@ -35,9 +35,9 @@ import type { Locator } from "playwright";
 
 import {
   aimedAtTheLine,
-  answering,
   leavingTheLine,
   nothingIsBeingTyped,
+  pressed,
 } from "../support/caret.ts";
 import { saysNothing, saysThat } from "../support/said.ts";
 import {
@@ -112,10 +112,7 @@ When(
 
 When("I press {string}", async function (this: OlaiWorld, key: string) {
   await aimedAtTheLine(this);
-  const answered = await answering(this, key);
-  await this.page.keyboard.press(key);
-  await this.waitForFrame();
-  if (answered !== null) await answered();
+  await pressed(this, key);
 });
 
 /** The same key, with nothing waited for afterwards — which is how a person

--- a/packages/tests/step_definitions/editing_steps.ts
+++ b/packages/tests/step_definitions/editing_steps.ts
@@ -17,6 +17,10 @@
  * Keys are pressed by NAME (`"Alt+Shift+ArrowUp"`), which is Playwright's own
  * spelling and the same one the client's keyboard map is written against — so
  * a scenario says the chord a person presses rather than a synthetic event.
+ *
+ * And every gesture here waits for the CLIENT'S own answer to it before the
+ * next one is aimed at the page. What that answer looks like, and why nothing
+ * else in the harness can stand in for it, is `support/caret.ts`.
  */
 
 import * as assert from "node:assert";
@@ -27,8 +31,14 @@ import { MARKS } from "@olai/format";
 
 import { IDLE_COMMIT } from "@olai/web/src/client/edit/draft.ts";
 
-import type { ElementHandle, Locator } from "playwright";
+import type { Locator } from "playwright";
 
+import {
+  aimedAtTheLine,
+  answering,
+  caretPlace,
+  leftThePlace,
+} from "../support/caret.ts";
 import { saysNothing, saysThat } from "../support/said.ts";
 import {
   DESC_EDITOR,
@@ -78,151 +88,6 @@ When("I start the first line", async function (this: OlaiWorld) {
     .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
 });
 
-/**
- * THE DRAFT IS THIS TAB'S OWN RECEIPT, and the steps below wait for it.
- *
- * Every write these scenarios make with the keys goes out through a draft, and
- * the draft is let go — closed, or moved to the line the key opened — only
- * once `edit.apply` has answered AND the inverse it answered with is on the
- * stack ⌘Z spends: `editing.tsx`'s `send` calls `undo.record` before it
- * returns, and every caret move is downstream of that call. Nothing else this
- * harness can see says as much. The DISK says a file was written; the DOM says
- * the page was told; neither says THIS TAB has the way back yet, and "this tab
- * has the way back" is the precondition of every ⌘Z in the suite.
- *
- * So: the caret leaving the line it was on is the signal, and the keys that
- * end a line wait for it.
- *
- * WHAT SKIPPING IT COSTS is a failure that reads nothing like its cause.
- * `Enter` commits the row and opens the next line's editor only when the write
- * lands, so an `Escape` one frame behind it closes nothing — and then the
- * draft opens behind the Escape, and every ⌘Z after that is dead, because a
- * chord belongs to the input while a draft is open. The scenario fails four
- * steps later on a file nobody wrote. Under load that was most of
- * `undo.feature` and a third of `split_and_merge.feature`.
- *
- * THE OTHER WAY A KEY ENDS is refused: the row keeps the caret and the reason
- * is drawn under it. That is a settled page too, so it ends the wait — and the
- * reason on screen is this key's own rather than an older one, because the
- * next keystroke drops it (`draft.ts`'s `typed`).
- *
- * THE SAME RECEIPT IS A PRECONDITION, which is the other half. A structural
- * key redraws the row it was pressed in, and moving an element in the document
- * is what takes the focus off it; the client puts the caret back through
- * `editing.tsx`'s own `caret` counter, a frame or a round trip later. A key
- * aimed at the row in that gap goes to the DOCUMENT instead — `Tab` walks the
- * browser's focus ring out of the row, which closes the draft and leaves the
- * next key with no editor at all, and ⌘A selects the page, so what is typed
- * after it lands beside the title instead of replacing it. Both were seen on a
- * loaded box, both are silent, and both are read as a wrong answer four steps
- * later.
- */
-
-/** The editor the caret is in — a row's title or its note, whichever is open.
- *  A page with neither has no caret in a row, which is the state ⌘Z is
- *  answered from. */
-const CARET_EDITOR = `${TITLE_EDITOR}, ${DESC_EDITOR}`;
-
-/** The editor that is open, as a handle — which goes on answering after the
- *  page has taken it away, and that is the whole question {@link letGo} asks.
- *  `null` when nothing is being typed, which is every `Enter` that picks a
- *  menu item. `which` is the title alone for the keys the title claims. */
-const editorHeld = async (
-  world: OlaiWorld,
-  which: string,
-): Promise<ElementHandle<Node> | null> => {
-  const editor = world.page.locator(which).first();
-  return (await editor.count()) === 0 ? null : await editor.elementHandle();
-};
-
-/** Is `Backspace` the APP's key here, rather than the field's own?
- *
- *  Only at the head of a line that HAS something on it. Anywhere else in the
- *  text it deletes a character; at the head of an empty draft it does nothing
- *  at all, because an empty new row is not a node and there is nothing to join
- *  it to (`editing.tsx`'s `merge` stops at that guard). Both leave the caret
- *  where it was, so both have nothing to wait for. */
-const joinsWithBackspace = async (line: ElementHandle<Node>): Promise<boolean> =>
-  await line.evaluate((element) => {
-    const field = element as HTMLInputElement;
-    return field.selectionStart === 0 && field.selectionEnd === 0 && field.value !== "";
-  });
-
-/**
- * That editor has been LET GO — the page has taken the element away — or it
- * has said why it has not.
- *
- * The ELEMENT rather than "no editor is open", because the two differ in the
- * case that matters: a new line that commits becomes the row it just made
- * (`draft.ts`'s `landed`), so an editor is still open and it is a different
- * one. That transition is downstream of the write, which is what makes it a
- * receipt either way.
- */
-const letGo = async (
-  world: OlaiWorld,
-  editor: ElementHandle<Node>,
-  what: string,
-): Promise<void> => {
-  await world.waitUntil(
-    async () =>
-      !(await editor.evaluate((element) => element.isConnected)) ||
-      (await world.page.locator(EDIT_REFUSAL).count()) > 0,
-    `${what}, or the page to say why it did not`,
-  );
-};
-
-/** No row is being typed in at all. */
-const nothingIsBeingTyped = async (world: OlaiWorld): Promise<void> => {
-  await world.waitUntil(
-    async () => (await world.page.locator(CARET_EDITOR).count()) === 0,
-    "the draft to close",
-  );
-};
-
-/** WHERE the caret is: the row the open editor belongs to, the line that does
- *  not exist yet, or `null` for a page with nothing being typed. A NAME for
- *  the place rather than the element drawing it, so a row redrawn where the
- *  file now says it is stays the same place. */
-const caretPlace = async (world: OlaiWorld): Promise<string | null> =>
-  await world.page.evaluate(
-    ([caret, newRow, node]) => {
-      const editor = document.querySelector(caret);
-      if (editor === null) return null;
-      if (editor.closest(newRow) !== null) return "(a new line)";
-      const row = editor.closest("[data-node-id]");
-      if (row === null) return "(a line off the tree)";
-      // The chain of ids down to it AND where it sits, which together are what
-      // the client itself calls a `Row.key`: an indent changes the chain and a
-      // reorder changes only the seat, and both are the row being drawn
-      // somewhere else.
-      const chain: Array<string> = [];
-      for (let at: Element | null = row; at !== null; at = at.parentElement?.closest(node) ?? null) {
-        chain.unshift(at.getAttribute("data-node-id") ?? "?");
-      }
-      return `${chain.join("/")}@${[...document.querySelectorAll(node)].indexOf(row)}`;
-    },
-    [CARET_EDITOR, NEW_ROW, NODE] as [string, string, string],
-  );
-
-/** The line being typed HOLDS the caret. */
-const caretIsInTheLine = async (world: OlaiWorld): Promise<void> => {
-  await world.waitUntil(
-    async () =>
-      await world.page.evaluate(
-        (which) => document.activeElement?.matches(which) === true,
-        CARET_EDITOR,
-      ),
-    "the line being typed to hold the caret",
-  );
-};
-
-/** …before something is aimed at it. Nothing being typed is nothing to wait
- *  for, which is every key a page answers with no draft open. */
-const aimedAtTheLine = async (world: OlaiWorld): Promise<void> => {
-  if ((await world.page.locator(CARET_EDITOR).count()) === 0) return;
-  await caretIsInTheLine(world);
-};
-
 // ── typing ─────────────────────────────────────────────────────────────
 
 When("I type {string}", async function (this: OlaiWorld, text: string) {
@@ -244,58 +109,6 @@ When(
 );
 
 // ── the keys ───────────────────────────────────────────────────────────
-
-/** The keys that put the row somewhere else — indent, outdent, and the two
- *  that walk it past a sibling. */
-const MOVES = new Set([
-  "Tab",
-  "Shift+Tab",
-  "Alt+Shift+ArrowUp",
-  "Alt+Shift+ArrowDown",
-]);
-
-/**
- * What waiting for this key MEANS — decided BEFORE it is pressed, because the
- * answer depends on where the caret was when it was. `null` for the keys that
- * are a keystroke and a frame, which is most of them.
- */
-const answering = async (
-  world: OlaiWorld,
-  key: string,
-): Promise<(() => Promise<void>) | null> => {
-  if (MOVES.has(key)) {
-    // A MOVE, and its receipt is the row being drawn where the file now says
-    // it is — the same frame the client is waiting for to take the caret back
-    // (`editing.tsx`'s `settle`). Pressing the next thing before it arrives is
-    // what the scenarios above were doing, and the client is entitled to read
-    // a click in that window as its own: the blur is suppressed as the redraw
-    // it is still owed, and the caret is taken back over the top of it.
-    const was = await caretPlace(world);
-    if (was === null) return null;
-    return async () => {
-      await world.waitUntil(
-        async () =>
-          (await caretPlace(world)) !== was ||
-          (await world.page.locator(EDIT_REFUSAL).count()) > 0,
-        "the row the key moved to be drawn where it moved it, or the page to say why it did not",
-      );
-      await caretIsInTheLine(world);
-    };
-  }
-  if (key === "Escape") {
-    // Escape abandons the draft, always — no write, so nothing to be refused.
-    // With none open there is nothing to wait for, which is every Escape that
-    // shuts a menu, a picker or the palette instead.
-    if ((await world.page.locator(CARET_EDITOR).count()) === 0) return null;
-    return async () => await nothingIsBeingTyped(world);
-  }
-  if (key !== "Enter" && key !== "Backspace") return null;
-  const line = await editorHeld(world, TITLE_EDITOR);
-  if (line === null) return null;
-  if (key === "Backspace" && !(await joinsWithBackspace(line))) return null;
-  return async () =>
-    await letGo(world, line, "the caret to leave the line the key ended");
-};
 
 When("I press {string}", async function (this: OlaiWorld, key: string) {
   await aimedAtTheLine(this);
@@ -400,20 +213,8 @@ When("I click away from the editor", async function (this: OlaiWorld) {
   // keys wait for and for the same reason: a blur commits through the same
   // queue, so a draft still open on that line is this tab still waiting to
   // hear.
-  //
-  // WHERE rather than WHICH ELEMENT, which is the one place these two waits
-  // differ: a structural key redraws the row the caret is in, and a row that
-  // came back as a new element would satisfy "the element I was holding is
-  // gone" without anybody having let go of anything — the draft is open, on
-  // the same line, and the ⌘Z after this step is dead in it. That is what
-  // `undo.feature:255` and `:324` were still failing on.
   if (was !== null) {
-    await this.waitUntil(
-      async () =>
-        (await caretPlace(this)) !== was ||
-        (await this.page.locator(EDIT_REFUSAL).count()) > 0,
-      "the caret to leave the line the click was away from, or the page to say why it did not",
-    );
+    await leftThePlace(this, was, "the caret to leave the line the click was away from");
   }
 });
 

--- a/packages/tests/support/caret.ts
+++ b/packages/tests/support/caret.ts
@@ -10,12 +10,9 @@
  * told; neither says THIS TAB has the way back yet, and "this tab has the way
  * back" is the precondition of every ⌘Z in the suite.
  *
- * So the caret is the signal, and it answers in three shapes:
- *
- *   - it LEAVES the line a key ended ({@link letGo});
- *   - the row it is in is drawn where a key MOVED it ({@link leftThePlace});
- *   - it comes BACK to the line, which is what makes the next gesture safe
- *     ({@link caretIsInTheLine}).
+ * So the caret is the signal, and it answers in two shapes: it is somewhere
+ * ELSE than it was ({@link leftThePlace}), or it is BACK in the line, which is
+ * what makes the next gesture safe ({@link caretIsInTheLine}).
  *
  * WHAT SKIPPING IT COSTS is a failure that reads nothing like its cause.
  * `Enter` commits the row and opens the next line's editor only when the write
@@ -41,83 +38,63 @@
  * loaded box, both are silent, and both are read as a wrong answer four steps
  * later.
  *
+ * WHAT IT DOES NOT COVER, said here rather than left to be discovered:
+ *
+ *   - the keys that redraw a row WITHOUT moving the caret — `Control+Enter`
+ *     and the walk beside it — have no receipt of their own, because there is
+ *     nothing on the page that changes when the client takes the caret back
+ *     from where it already is. Every scenario that presses one asserts the
+ *     mark straight afterwards, and those steps wait; a scenario that pressed
+ *     two of them in a row would be racing again.
+ *   - `Escape` is answered by the draft closing, and the client closes it
+ *     without waiting for anything (`editing.tsx`'s `cancel` is the one action
+ *     that is not queued). An idle commit already in flight is still in flight
+ *     when this returns, so "nothing is being typed" is not the same promise
+ *     as "this tab has the way back".
+ *
  * Its own module for the reason `./said.ts` is one: this is a RITUAL rather
  * than a step, three step files could want it, and two of them waiting for the
  * client's answer two different ways is how one of them stops waiting properly.
  *
  * FOUR VERBS come out of it, and nothing else does — {@link aimedAtTheLine}
- * before a gesture, {@link answering} for a key, {@link leavingTheLine} for a
+ * before a gesture, {@link pressed} for a key, {@link leavingTheLine} for a
  * gesture meant to take the caret out, and {@link nothingIsBeingTyped} for the
  * promise a scenario makes about it. The shapes above are how they are built,
  * and a caller composing them by hand would be a caller that has to know what a
  * receipt is.
  */
 
-import type { ElementHandle } from "playwright";
-
-import { DESC_EDITOR, EDIT_REFUSAL, NEW_ROW, NODE, TITLE_EDITOR } from "./world.ts";
+import { CARET_EDITOR, EDIT_REFUSAL, NEW_ROW, NODE, TITLE_EDITOR } from "./world.ts";
 import type { OlaiWorld } from "./world.ts";
-
-/** The editor the caret is in — a row's title or its note, whichever is open.
- *  A page with neither has no caret in a row, which is the state ⌘Z is answered
- *  from. */
-const CARET_EDITOR = `${TITLE_EDITOR}, ${DESC_EDITOR}`;
 
 /** Is anything being typed at all? Every wait below is a claim about a draft,
  *  and a page with none has nothing to make it about. */
 const somethingIsBeingTyped = async (world: OlaiWorld): Promise<boolean> =>
   (await world.page.locator(CARET_EDITOR).count()) > 0;
 
-/** The title editor as a handle, which goes on answering after the page has
- *  taken it away — the whole question {@link letGo} asks. `null` when no row is
- *  being typed, which is every `Enter` that picks a menu item. */
-const lineHeld = async (
-  world: OlaiWorld,
-): Promise<ElementHandle<Node> | null> => {
-  const editor = world.page.locator(TITLE_EDITOR).first();
-  return (await editor.count()) === 0 ? null : await editor.elementHandle();
-};
-
-/** Is `Backspace` the APP's key here, rather than the field's own?
+/**
+ * Is `Backspace` the APP's key here, rather than the field's own?
  *
- *  Only at the head of a line that HAS something on it. Anywhere else in the
- *  text it deletes a character; at the head of an empty draft it does nothing
- *  at all, because an empty new row is not a node and there is nothing to join
- *  it to (`editing.tsx`'s `merge` stops at that guard). Both leave the caret
- *  where it was, so both have nothing to wait for. */
-const joinsWithBackspace = async (
-  line: ElementHandle<Node>,
-): Promise<boolean> =>
-  await line.evaluate((element) => {
+ * Only at the head of a TITLE that has something on it. In a note it is the
+ * field's own wherever it is pressed (`keys.ts` claims it for a title alone);
+ * anywhere else in the text it deletes a character; and at the head of an empty
+ * draft it does nothing at all, because an empty new row is not a node and
+ * there is nothing to join it to (`editing.tsx`'s `merge` stops at that guard).
+ * All three leave the caret where it was, so all three have nothing to wait
+ * for.
+ */
+const joinsWithBackspace = async (world: OlaiWorld): Promise<boolean> => {
+  const line = world.page.locator(TITLE_EDITOR).first();
+  if ((await line.count()) === 0) return false;
+  return await line.evaluate((element) => {
     const field = element as HTMLInputElement;
     return field.selectionStart === 0 && field.selectionEnd === 0 && field.value !== "";
   });
+};
 
 /** Anything the page could be saying about why a key did nothing. */
 const refused = async (world: OlaiWorld): Promise<boolean> =>
   (await world.page.locator(EDIT_REFUSAL).count()) > 0;
-
-/**
- * That editor has been LET GO — the page has taken the element away — or it has
- * said why it has not.
- *
- * The ELEMENT rather than "no editor is open", because the two differ in the
- * case that matters: a new line that commits becomes the row it just made
- * (`draft.ts`'s `landed`), so an editor is still open and it is a different
- * one. That transition is downstream of the write, which is what makes it a
- * receipt either way.
- */
-const letGo = async (
-  world: OlaiWorld,
-  line: ElementHandle<Node>,
-  what: string,
-): Promise<void> => {
-  await world.waitUntil(
-    async () =>
-      !(await line.evaluate((element) => element.isConnected)) || (await refused(world)),
-    `${what}, or the page to say why it did not`,
-  );
-};
 
 /** No row is being typed in at all — what `Escape` means, and it cannot be
  *  refused, because it writes nothing. */
@@ -129,42 +106,59 @@ export const nothingIsBeingTyped = async (world: OlaiWorld): Promise<void> => {
 };
 
 /**
- * WHERE the caret is: the row the open editor belongs to, the line that does
- * not exist yet, or `null` for a page with nothing being typed.
+ * WHERE the caret is, as a name: the row the open editor belongs to, the line
+ * that does not exist yet AND the row it is drawn after, or `null` for a page
+ * with nothing being typed.
  *
  * A NAME for the place rather than the element drawing it, which is the whole
  * reason it exists: a structural key redraws the row the caret is in, so the
  * row comes back as a NEW element and "the element I was holding is gone" would
  * be true with nobody having let go of anything.
+ *
+ * Two halves, because two different keys move two different things. The CHAIN
+ * of ids down to the row is what the client calls a `Row.key`, and an indent
+ * changes it; the SEAT is where the row sits AMONG ITS SIBLINGS, and a reorder
+ * changes only that. Among its siblings rather than in the document, which
+ * matters: a scenario with a second writer in it grows rows in other branches,
+ * and a document-wide index would call that "the caret moved" and end a wait
+ * that had not been answered.
+ *
+ * A NEW LINE is drawn inside the `<li>` of the row it will follow (`Tree.tsx`),
+ * so it is named by that row — which is how the second of two `Enter`s tells
+ * itself from the first: the line it opens follows the row the first one just
+ * made.
  */
 const caretPlace = async (world: OlaiWorld): Promise<string | null> =>
   await world.page.evaluate(
     ([caret, newRow, node]) => {
       const editor = document.querySelector(caret);
       if (editor === null) return null;
-      if (editor.closest(newRow) !== null) return "(a new line)";
-      const row = editor.closest("[data-node-id]");
-      if (row === null) return "(a line off the tree)";
-      // The chain of ids down to it AND where it sits, which together are what
-      // the client itself calls a `Row.key`: an indent changes the chain and a
-      // reorder changes only the seat, and both are the row being drawn
-      // somewhere else.
-      const chain: Array<string> = [];
-      for (
-        let at: Element | null = row;
-        at !== null;
-        at = at.parentElement?.closest(node) ?? null
-      ) {
-        chain.unshift(at.getAttribute("data-node-id") ?? "?");
+      const row = editor.closest(node);
+      let place = "(off the tree)";
+      if (row !== null) {
+        const chain: Array<string> = [];
+        for (
+          let at: Element | null = row;
+          at !== null;
+          at = at.parentElement?.closest(node) ?? null
+        ) {
+          chain.unshift(at.getAttribute("data-node-id") ?? "?");
+        }
+        let seat = 0;
+        for (let before = row.previousElementSibling; before !== null; ) {
+          if (before.matches(node)) seat += 1;
+          before = before.previousElementSibling;
+        }
+        place = `${chain.join("/")}@${seat}`;
       }
-      return `${chain.join("/")}@${[...document.querySelectorAll(node)].indexOf(row)}`;
+      return editor.closest(newRow) === null ? place : `a new line after ${place}`;
     },
     [CARET_EDITOR, NEW_ROW, NODE] as [string, string, string],
   );
 
 /** The caret is somewhere other than `was` — the receipt of every gesture that
- *  takes the caret out of a line or moves the line it is in — or the page has
- *  said why it is not. */
+ *  takes the caret out of a line, opens another, or moves the line it is in —
+ *  or the page has said why it is not. */
 const leftThePlace = async (
   world: OlaiWorld,
   was: string,
@@ -215,43 +209,52 @@ export const leavingTheLine = async (
   await leftThePlace(world, was, what);
 };
 
-/** The keys that put the row somewhere else — indent, outdent, and the two that
- *  walk it past a sibling. */
-const MOVES = new Set(["Tab", "Shift+Tab", "Alt+Shift+ArrowUp", "Alt+Shift+ArrowDown"]);
+/** The keys that leave the line the caret is on — the two that END it, and the
+ *  four that put the row somewhere else. What they have in common is the only
+ *  thing this module can see: afterwards the caret is not where it was. */
+const LEAVES = new Set([
+  "Enter",
+  "Backspace",
+  "Tab",
+  "Shift+Tab",
+  "Alt+Shift+ArrowUp",
+  "Alt+Shift+ArrowDown",
+]);
 
 /**
  * What waiting for this key MEANS — decided BEFORE it is pressed, because the
- * answer depends on where the caret was when it was. `null` for the keys that
- * are a keystroke and a frame, which is most of them.
+ * answer depends on where the caret was when it was. Nothing to wait for is a
+ * thunk that does nothing, which is most of the keys.
  */
-export const answering = async (
+const answering = async (
   world: OlaiWorld,
   key: string,
-): Promise<(() => Promise<void>) | null> => {
-  if (MOVES.has(key)) {
-    // A MOVE, and its receipt is the row being drawn where the file now says it
-    // is — the same frame the client is waiting for to take the caret back
-    // (`editing.tsx`'s `settle`). Pressing the next thing before it arrives is
-    // what the scenarios were doing, and the client is entitled to read a click
-    // in that window as its own: the blur is suppressed as the redraw it is
-    // still owed, and the caret is taken back over the top of it.
-    const was = await caretPlace(world);
-    if (was === null) return null;
-    return async () => {
-      await leftThePlace(world, was, "the row the key moved to be drawn where it moved it");
-      await caretIsInTheLine(world);
-    };
-  }
+): Promise<() => Promise<void>> => {
+  const nothing = async () => {};
   if (key === "Escape") {
     // Escape abandons the draft, always. With none open there is nothing to
     // wait for, which is every Escape that shuts a menu, a picker or the
     // palette instead.
-    if (!(await somethingIsBeingTyped(world))) return null;
+    if (!(await somethingIsBeingTyped(world))) return nothing;
     return async () => await nothingIsBeingTyped(world);
   }
-  if (key !== "Enter" && key !== "Backspace") return null;
-  const line = await lineHeld(world);
-  if (line === null) return null;
-  if (key === "Backspace" && !(await joinsWithBackspace(line))) return null;
-  return async () => await letGo(world, line, "the caret to leave the line the key ended");
+  if (!LEAVES.has(key)) return nothing;
+  if (key === "Backspace" && !(await joinsWithBackspace(world))) return nothing;
+  const was = await caretPlace(world);
+  if (was === null) return nothing;
+  return async () => {
+    await leftThePlace(world, was, "the caret to leave the line the key ended");
+    // And to arrive in the one the key opened. A move redraws the row where
+    // the file now says it is, which takes the focus off it, and the client
+    // takes it back a frame later (`editing.tsx`'s `settle`).
+    await caretIsInTheLine(world);
+  };
+};
+
+/** Press a key at the page, and wait for the client's answer to it. */
+export const pressed = async (world: OlaiWorld, key: string): Promise<void> => {
+  const answered = await answering(world, key);
+  await world.page.keyboard.press(key);
+  await world.waitForFrame();
+  await answered();
 };

--- a/packages/tests/support/caret.ts
+++ b/packages/tests/support/caret.ts
@@ -209,16 +209,23 @@ export const leavingTheLine = async (
   await leftThePlace(world, was, what);
 };
 
-/** The keys that leave the line the caret is on — the two that END it, and the
- *  four that put the row somewhere else. What they have in common is the only
- *  thing this module can see: afterwards the caret is not where it was. */
-const LEAVES = new Set([
-  "Enter",
-  "Backspace",
-  "Tab",
-  "Shift+Tab",
-  "Alt+Shift+ArrowUp",
-  "Alt+Shift+ArrowDown",
+/**
+ * The keys that leave the line the caret is on, and WHAT each is waited on as.
+ *
+ * Two kinds — the two that END a line, and the four that put the row somewhere
+ * else — and one predicate, because the only thing this module can see is the
+ * same for both: afterwards the caret is not where it was. The SENTENCE is per
+ * key all the same, because it is the one a red run reads, and a `Tab` that did
+ * nothing timing out as "the caret to leave the line the key ended" sends the
+ * reader looking for a line nobody was leaving.
+ */
+const LEAVES: ReadonlyMap<string, string> = new Map([
+  ["Enter", "the caret to leave the line the key ended"],
+  ["Backspace", "the caret to leave the line the key joined onto the row above"],
+  ["Tab", "the row to be drawn where the key moved it"],
+  ["Shift+Tab", "the row to be drawn where the key moved it"],
+  ["Alt+Shift+ArrowUp", "the row to be drawn where the key moved it"],
+  ["Alt+Shift+ArrowDown", "the row to be drawn where the key moved it"],
 ]);
 
 /**
@@ -238,12 +245,13 @@ const answering = async (
     if (!(await somethingIsBeingTyped(world))) return nothing;
     return async () => await nothingIsBeingTyped(world);
   }
-  if (!LEAVES.has(key)) return nothing;
+  const leaves = LEAVES.get(key);
+  if (leaves === undefined) return nothing;
   if (key === "Backspace" && !(await joinsWithBackspace(world))) return nothing;
   const was = await caretPlace(world);
   if (was === null) return nothing;
   return async () => {
-    await leftThePlace(world, was, "the caret to leave the line the key ended");
+    await leftThePlace(world, was, leaves);
     // And to arrive in the one the key opened. A move redraws the row where
     // the file now says it is, which takes the focus off it, and the client
     // takes it back a frame later (`editing.tsx`'s `settle`).

--- a/packages/tests/support/caret.ts
+++ b/packages/tests/support/caret.ts
@@ -1,0 +1,230 @@
+/**
+ * THE DRAFT IS THIS TAB'S OWN RECEIPT — and this is how a step waits for it.
+ *
+ * Every write these scenarios make with the keys goes out through a draft, and
+ * the draft is let go — closed, or moved to the line the key opened — only once
+ * `edit.apply` has answered AND the inverse it answered with is on the stack ⌘Z
+ * spends: `editing.tsx`'s `send` calls `undo.record` before it returns, and
+ * every caret move is downstream of that call. Nothing else this harness can
+ * see says as much. The DISK says a file was written; the DOM says the page was
+ * told; neither says THIS TAB has the way back yet, and "this tab has the way
+ * back" is the precondition of every ⌘Z in the suite.
+ *
+ * So the caret is the signal, and it answers in three shapes:
+ *
+ *   - it LEAVES the line a key ended ({@link letGo});
+ *   - the row it is in is drawn where a key MOVED it ({@link leftThePlace});
+ *   - it comes BACK to the line, which is what makes the next gesture safe
+ *     ({@link caretIsInTheLine}).
+ *
+ * WHAT SKIPPING IT COSTS is a failure that reads nothing like its cause.
+ * `Enter` commits the row and opens the next line's editor only when the write
+ * lands, so an `Escape` one frame behind it closes nothing — and then the draft
+ * opens behind the Escape, and every ⌘Z after that is dead, because a chord
+ * belongs to the input while a draft is open. The scenario fails four steps
+ * later on a file nobody wrote. Under load that was most of `undo.feature` and
+ * a third of `split_and_merge.feature`.
+ *
+ * THE OTHER WAY A KEY ENDS is refused: the row keeps the caret and the reason
+ * is drawn under it. That is a settled page too, so it ends every wait here —
+ * and the reason on screen is this key's own rather than an older one, because
+ * the next keystroke drops it (`draft.ts`'s `typed`).
+ *
+ * THE SAME RECEIPT IS A PRECONDITION, which is the other half. A structural key
+ * redraws the row it was pressed in, and moving an element in the document is
+ * what takes the focus off it; the client puts the caret back through
+ * `editing.tsx`'s own `caret` counter, a frame or a round trip later. A key
+ * aimed at the row in that gap goes to the DOCUMENT instead — `Tab` walks the
+ * browser's focus ring out of the row, which closes the draft and leaves the
+ * next key with no editor at all, and ⌘A selects the page, so what is typed
+ * after it lands beside the title instead of replacing it. Both were seen on a
+ * loaded box, both are silent, and both are read as a wrong answer four steps
+ * later.
+ *
+ * Its own module for the reason `./said.ts` is one: this is a RITUAL rather
+ * than a step, three step files could want it, and two of them waiting for the
+ * client's answer two different ways is how one of them stops waiting properly.
+ */
+
+import type { ElementHandle } from "playwright";
+
+import { DESC_EDITOR, EDIT_REFUSAL, NEW_ROW, NODE, TITLE_EDITOR } from "./world.ts";
+import type { OlaiWorld } from "./world.ts";
+
+/** The editor the caret is in — a row's title or its note, whichever is open.
+ *  A page with neither has no caret in a row, which is the state ⌘Z is answered
+ *  from. */
+export const CARET_EDITOR = `${TITLE_EDITOR}, ${DESC_EDITOR}`;
+
+/** Is anything being typed at all? Every wait below is a claim about a draft,
+ *  and a page with none has nothing to make it about. */
+export const somethingIsBeingTyped = async (world: OlaiWorld): Promise<boolean> =>
+  (await world.page.locator(CARET_EDITOR).count()) > 0;
+
+/** The title editor as a handle, which goes on answering after the page has
+ *  taken it away — the whole question {@link letGo} asks. `null` when no row is
+ *  being typed, which is every `Enter` that picks a menu item. */
+export const lineHeld = async (
+  world: OlaiWorld,
+): Promise<ElementHandle<Node> | null> => {
+  const editor = world.page.locator(TITLE_EDITOR).first();
+  return (await editor.count()) === 0 ? null : await editor.elementHandle();
+};
+
+/** Is `Backspace` the APP's key here, rather than the field's own?
+ *
+ *  Only at the head of a line that HAS something on it. Anywhere else in the
+ *  text it deletes a character; at the head of an empty draft it does nothing
+ *  at all, because an empty new row is not a node and there is nothing to join
+ *  it to (`editing.tsx`'s `merge` stops at that guard). Both leave the caret
+ *  where it was, so both have nothing to wait for. */
+export const joinsWithBackspace = async (
+  line: ElementHandle<Node>,
+): Promise<boolean> =>
+  await line.evaluate((element) => {
+    const field = element as HTMLInputElement;
+    return field.selectionStart === 0 && field.selectionEnd === 0 && field.value !== "";
+  });
+
+/** Anything the page could be saying about why a key did nothing. */
+const refused = async (world: OlaiWorld): Promise<boolean> =>
+  (await world.page.locator(EDIT_REFUSAL).count()) > 0;
+
+/**
+ * That editor has been LET GO — the page has taken the element away — or it has
+ * said why it has not.
+ *
+ * The ELEMENT rather than "no editor is open", because the two differ in the
+ * case that matters: a new line that commits becomes the row it just made
+ * (`draft.ts`'s `landed`), so an editor is still open and it is a different
+ * one. That transition is downstream of the write, which is what makes it a
+ * receipt either way.
+ */
+export const letGo = async (
+  world: OlaiWorld,
+  line: ElementHandle<Node>,
+  what: string,
+): Promise<void> => {
+  await world.waitUntil(
+    async () =>
+      !(await line.evaluate((element) => element.isConnected)) || (await refused(world)),
+    `${what}, or the page to say why it did not`,
+  );
+};
+
+/** No row is being typed in at all — what `Escape` means, and it cannot be
+ *  refused, because it writes nothing. */
+export const nothingIsBeingTyped = async (world: OlaiWorld): Promise<void> => {
+  await world.waitUntil(
+    async () => !(await somethingIsBeingTyped(world)),
+    "the draft to close",
+  );
+};
+
+/**
+ * WHERE the caret is: the row the open editor belongs to, the line that does
+ * not exist yet, or `null` for a page with nothing being typed.
+ *
+ * A NAME for the place rather than the element drawing it, which is the whole
+ * reason it exists: a structural key redraws the row the caret is in, so the
+ * row comes back as a NEW element and "the element I was holding is gone" would
+ * be true with nobody having let go of anything.
+ */
+export const caretPlace = async (world: OlaiWorld): Promise<string | null> =>
+  await world.page.evaluate(
+    ([caret, newRow, node]) => {
+      const editor = document.querySelector(caret);
+      if (editor === null) return null;
+      if (editor.closest(newRow) !== null) return "(a new line)";
+      const row = editor.closest("[data-node-id]");
+      if (row === null) return "(a line off the tree)";
+      // The chain of ids down to it AND where it sits, which together are what
+      // the client itself calls a `Row.key`: an indent changes the chain and a
+      // reorder changes only the seat, and both are the row being drawn
+      // somewhere else.
+      const chain: Array<string> = [];
+      for (
+        let at: Element | null = row;
+        at !== null;
+        at = at.parentElement?.closest(node) ?? null
+      ) {
+        chain.unshift(at.getAttribute("data-node-id") ?? "?");
+      }
+      return `${chain.join("/")}@${[...document.querySelectorAll(node)].indexOf(row)}`;
+    },
+    [CARET_EDITOR, NEW_ROW, NODE] as [string, string, string],
+  );
+
+/** The caret is somewhere other than `was` — the receipt of every gesture that
+ *  takes the caret out of a line or moves the line it is in — or the page has
+ *  said why it is not. */
+export const leftThePlace = async (
+  world: OlaiWorld,
+  was: string,
+  what: string,
+): Promise<void> => {
+  await world.waitUntil(
+    async () => (await caretPlace(world)) !== was || (await refused(world)),
+    `${what}, or the page to say why it did not`,
+  );
+};
+
+/** The line being typed HOLDS the caret. */
+export const caretIsInTheLine = async (world: OlaiWorld): Promise<void> => {
+  await world.waitUntil(
+    async () =>
+      await world.page.evaluate(
+        (which) => document.activeElement?.matches(which) === true,
+        CARET_EDITOR,
+      ),
+    "the line being typed to hold the caret",
+  );
+};
+
+/** …before something is aimed at it. Nothing being typed is nothing to wait
+ *  for, which is every key a page answers with no draft open. */
+export const aimedAtTheLine = async (world: OlaiWorld): Promise<void> => {
+  if (!(await somethingIsBeingTyped(world))) return;
+  await caretIsInTheLine(world);
+};
+
+/** The keys that put the row somewhere else — indent, outdent, and the two that
+ *  walk it past a sibling. */
+const MOVES = new Set(["Tab", "Shift+Tab", "Alt+Shift+ArrowUp", "Alt+Shift+ArrowDown"]);
+
+/**
+ * What waiting for this key MEANS — decided BEFORE it is pressed, because the
+ * answer depends on where the caret was when it was. `null` for the keys that
+ * are a keystroke and a frame, which is most of them.
+ */
+export const answering = async (
+  world: OlaiWorld,
+  key: string,
+): Promise<(() => Promise<void>) | null> => {
+  if (MOVES.has(key)) {
+    // A MOVE, and its receipt is the row being drawn where the file now says it
+    // is — the same frame the client is waiting for to take the caret back
+    // (`editing.tsx`'s `settle`). Pressing the next thing before it arrives is
+    // what the scenarios were doing, and the client is entitled to read a click
+    // in that window as its own: the blur is suppressed as the redraw it is
+    // still owed, and the caret is taken back over the top of it.
+    const was = await caretPlace(world);
+    if (was === null) return null;
+    return async () => {
+      await leftThePlace(world, was, "the row the key moved to be drawn where it moved it");
+      await caretIsInTheLine(world);
+    };
+  }
+  if (key === "Escape") {
+    // Escape abandons the draft, always. With none open there is nothing to
+    // wait for, which is every Escape that shuts a menu, a picker or the
+    // palette instead.
+    if (!(await somethingIsBeingTyped(world))) return null;
+    return async () => await nothingIsBeingTyped(world);
+  }
+  if (key !== "Enter" && key !== "Backspace") return null;
+  const line = await lineHeld(world);
+  if (line === null) return null;
+  if (key === "Backspace" && !(await joinsWithBackspace(line))) return null;
+  return async () => await letGo(world, line, "the caret to leave the line the key ended");
+};

--- a/packages/tests/support/caret.ts
+++ b/packages/tests/support/caret.ts
@@ -44,6 +44,13 @@
  * Its own module for the reason `./said.ts` is one: this is a RITUAL rather
  * than a step, three step files could want it, and two of them waiting for the
  * client's answer two different ways is how one of them stops waiting properly.
+ *
+ * FOUR VERBS come out of it, and nothing else does — {@link aimedAtTheLine}
+ * before a gesture, {@link answering} for a key, {@link leavingTheLine} for a
+ * gesture meant to take the caret out, and {@link nothingIsBeingTyped} for the
+ * promise a scenario makes about it. The shapes above are how they are built,
+ * and a caller composing them by hand would be a caller that has to know what a
+ * receipt is.
  */
 
 import type { ElementHandle } from "playwright";
@@ -54,17 +61,17 @@ import type { OlaiWorld } from "./world.ts";
 /** The editor the caret is in — a row's title or its note, whichever is open.
  *  A page with neither has no caret in a row, which is the state ⌘Z is answered
  *  from. */
-export const CARET_EDITOR = `${TITLE_EDITOR}, ${DESC_EDITOR}`;
+const CARET_EDITOR = `${TITLE_EDITOR}, ${DESC_EDITOR}`;
 
 /** Is anything being typed at all? Every wait below is a claim about a draft,
  *  and a page with none has nothing to make it about. */
-export const somethingIsBeingTyped = async (world: OlaiWorld): Promise<boolean> =>
+const somethingIsBeingTyped = async (world: OlaiWorld): Promise<boolean> =>
   (await world.page.locator(CARET_EDITOR).count()) > 0;
 
 /** The title editor as a handle, which goes on answering after the page has
  *  taken it away — the whole question {@link letGo} asks. `null` when no row is
  *  being typed, which is every `Enter` that picks a menu item. */
-export const lineHeld = async (
+const lineHeld = async (
   world: OlaiWorld,
 ): Promise<ElementHandle<Node> | null> => {
   const editor = world.page.locator(TITLE_EDITOR).first();
@@ -78,7 +85,7 @@ export const lineHeld = async (
  *  at all, because an empty new row is not a node and there is nothing to join
  *  it to (`editing.tsx`'s `merge` stops at that guard). Both leave the caret
  *  where it was, so both have nothing to wait for. */
-export const joinsWithBackspace = async (
+const joinsWithBackspace = async (
   line: ElementHandle<Node>,
 ): Promise<boolean> =>
   await line.evaluate((element) => {
@@ -100,7 +107,7 @@ const refused = async (world: OlaiWorld): Promise<boolean> =>
  * one. That transition is downstream of the write, which is what makes it a
  * receipt either way.
  */
-export const letGo = async (
+const letGo = async (
   world: OlaiWorld,
   line: ElementHandle<Node>,
   what: string,
@@ -130,7 +137,7 @@ export const nothingIsBeingTyped = async (world: OlaiWorld): Promise<void> => {
  * row comes back as a NEW element and "the element I was holding is gone" would
  * be true with nobody having let go of anything.
  */
-export const caretPlace = async (world: OlaiWorld): Promise<string | null> =>
+const caretPlace = async (world: OlaiWorld): Promise<string | null> =>
   await world.page.evaluate(
     ([caret, newRow, node]) => {
       const editor = document.querySelector(caret);
@@ -158,7 +165,7 @@ export const caretPlace = async (world: OlaiWorld): Promise<string | null> =>
 /** The caret is somewhere other than `was` — the receipt of every gesture that
  *  takes the caret out of a line or moves the line it is in — or the page has
  *  said why it is not. */
-export const leftThePlace = async (
+const leftThePlace = async (
   world: OlaiWorld,
   was: string,
   what: string,
@@ -170,7 +177,7 @@ export const leftThePlace = async (
 };
 
 /** The line being typed HOLDS the caret. */
-export const caretIsInTheLine = async (world: OlaiWorld): Promise<void> => {
+const caretIsInTheLine = async (world: OlaiWorld): Promise<void> => {
   await world.waitUntil(
     async () =>
       await world.page.evaluate(
@@ -186,6 +193,26 @@ export const caretIsInTheLine = async (world: OlaiWorld): Promise<void> => {
 export const aimedAtTheLine = async (world: OlaiWorld): Promise<void> => {
   if (!(await somethingIsBeingTyped(world))) return;
   await caretIsInTheLine(world);
+};
+
+/**
+ * A gesture MEANT to take the caret out of the line it is in — a click
+ * somewhere that is not a row — and the wait for it to have happened.
+ *
+ * The gesture comes in as an argument because the three lines around it are
+ * this module's knowledge and not the step's: WHERE the caret was has to be
+ * read before the gesture and compared after it, and a step file spelling that
+ * out is a step file that knows what a receipt is.
+ */
+export const leavingTheLine = async (
+  world: OlaiWorld,
+  gesture: () => Promise<void>,
+  what: string,
+): Promise<void> => {
+  const was = await caretPlace(world);
+  await gesture();
+  if (was === null) return;
+  await leftThePlace(world, was, what);
 };
 
 /** The keys that put the row somewhere else — indent, outdent, and the two that

--- a/packages/tests/support/world.ts
+++ b/packages/tests/support/world.ts
@@ -1251,6 +1251,35 @@ export class OlaiWorld extends World {
       .map((line) => JSON.parse(line) as Record<string, unknown>);
   }
 
+  /**
+   * The same records, off a file the served set MAY NOT HOLD YET — the reader
+   * every assertion that WAITS for something to arrive in one goes through.
+   *
+   * Some writes in this app mint the file they land in: `archive` writes
+   * `Archive.jsonl` the first time anything is put away. A scenario polling
+   * for a node to ARRIVE there is polling for the FILE too, and a reader that
+   * threw would fail on the first poll — at speed it usually does not, under
+   * load it does, and what the failure then names is an ENOENT out of a helper
+   * rather than the claim that was being made. Nothing written yet is "nothing
+   * there yet", which is safe here precisely BECAUSE every caller waits: a
+   * file that never arrives still fails, as the assertion it was making.
+   *
+   * ENOENT and nothing else. A line that is not JSON, or a directory where a
+   * file should be, is a fault this suite reports rather than polls through.
+   *
+   * A step that WRITES the served directory calls {@link servedNodes} instead:
+   * there, a missing file is a scenario naming something its corpus does not
+   * hold, and it should say so the moment it is asked.
+   */
+  servedNodesSoFar(file: string): ReadonlyArray<Record<string, unknown>> {
+    try {
+      return this.servedNodes(file);
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw cause;
+    }
+  }
+
   /** One more record at the end of a served outline, as another writer would
    *  leave it — a `git pull`, the agent, a second tab.
    *

--- a/packages/tests/support/world.ts
+++ b/packages/tests/support/world.ts
@@ -258,6 +258,10 @@ export const CHECKBOX = selector(TESTID.checkbox);
 export const TITLE_EDITOR = selector(TESTID.titleEditor);
 /** The note as text, under the row, while it is being written. */
 export const DESC_EDITOR = selector(TESTID.descEditor);
+/** Either of them: the editor the caret is in, whichever field it is. A page
+ *  matching neither has no caret in a row, which is the state ⌘Z is answered
+ *  from — and is what `support/caret.ts` is written around. */
+export const CARET_EDITOR = `${TITLE_EDITOR}, ${DESC_EDITOR}`;
 /** A row that does not exist yet — an editor standing where `Enter` will put
  *  one. Finding one is finding a DRAFT, never a write. */
 export const NEW_ROW = selector(TESTID.newRow);


### PR DESCRIPTION
The roadmap's `undo-feature-flaky`, taken at its word: *e2e assertions race the
writes they assert about*. It is not about undo, and it was not two or three
assertions — it is one mistake made in six places, and `undo.feature` is simply
where the keys and the round trips are densest.

## What was measured

A loop on this box (16 cores) with 24 busy loops pinning every one of them, the
suite at its own default 4 workers, against the nix-built binary — the same
shape as the roadmap's evidence. Same loop before and after.

| | `undo.feature` | the five suspect features |
|---|---|---|
| **before** | **5 of 5 runs failed** | **3 of 3 runs failed** — 10 distinct scenarios |
| **after** | — | **12 of 12 runs green** (93 scenarios each; 1116 in all) |

Unloaded, before and after, all of it is green — which is the whole character
of this debt: it bites developers and loaded runners, not CI.

## The one mistake

**A write these scenarios make goes out through a DRAFT, and the draft is the
only receipt this tab gives.** It is let go — closed, or moved to the line the
key opened — once `edit.apply` has answered *and* the inverse it answered with
is on the stack ⌘Z spends (`editing.tsx`'s `send` calls `undo.record` before it
returns). Nothing else the harness can see says that much: the disk says a file
was written, the DOM says the page was told, and neither says *this tab* knows
yet — which is the precondition of every ⌘Z in the suite.

`Enter` bit hardest. It commits the row and opens the next line's editor only
when the write lands, so the `Escape` a frame behind it closed nothing; the
draft then opened *behind* the Escape, and every ⌘Z after that was dead,
because a chord belongs to the input while a draft is open. The scenario failed
four steps later on a file nobody wrote.

The same receipt is a **precondition**, and that half cost two more scenarios. A
structural key redraws the row it was pressed in, which takes the focus off it,
and the client puts the caret back a round trip later. A key aimed into that gap
goes to the *document*:

- `Tab` walked the browser's own focus ring out of the row, closing the draft,
  so the next key found no editor at all — `keyboard_editing.feature:183`, the
  flake PR #157's verification recorded.
- `⌘A` selected the page, so the title typed after it landed **beside** the old
  one: the failure screenshot reads `choose the brass handleschoose the handles`
  (`keyboard_editing.feature:264`).

And a **move**'s receipt is the row, not the element. The first pass had `I
click away from the editor` wait for the element it was holding to leave the
document; a structural key brings the row back as a NEW element, so the wait
ended without anybody having let go of anything. It now waits for the caret to
leave the PLACE — the chain of ids down to the row and the seat it sits in,
which together are what the client calls a `Row.key` — and `Tab`, `Shift+Tab`
and the two keys that walk a row past a sibling wait for the row to be drawn
where they put it.

So `I press`, `I type`, `I select all and type` and `I click away from the
editor` wait for the caret to be in the line before aiming anything at it, and
for it to leave afterwards — or for the page to say **why** it did not, which is
the other way a key ends, and is this key's own reason because the next
keystroke drops the last one (`draft.ts`'s `typed`). `I press "…" without
waiting` is still how the two scenarios that MEAN the race say so.

## Two disk assertions that were the assertion's own fault

Both are the failure class PR #159 named, and both are still live on master:

- `titlesIn` read the disk directly, so a step polling for a node to arrive in
  `Archive.jsonl` — a file the first archive MINTS — failed on the first poll
  with an `ENOENT` rather than waiting. Every waiting reader now goes through
  `world.servedNodesSoFar`; a step that WRITES the served directory still calls
  `servedNodes`, which throws. **ENOENT and nothing else** — a line that is not
  JSON is still a fault, which is the one place this differs from #159's and
  #162's blanket `catch`.
- `holds no node titled` HOLDS a negative across the commit window, which is what
  "a draft is not a write" needs. **Four** scenarios asked it of a write going
  through (`undo.feature:182`, `:196`, `:221`; `split_and_merge.feature:141`).
  The waiting twin is now its own step, named for what it means; the holding
  form keeps the **five** that do mean it — `keyboard_editing.feature:33` (a
  draft is not a write), `:304` and `:316` (the write landed in the *other*
  file), `undo.feature:87` (an undo of a mirror retitle must not invent the
  title in `house.jsonl`), `split_and_merge.feature:194` (a refused split
  writes no tail).

  *(An earlier revision of this body — and commit `6dc17ef`'s message, left
  as written rather than rewriting reviewed history — says "four" for that
  second number. Five is the count; the five are the right shape.)*

## Mutation-proved

One scenario each against a deliberately broken product, to show the steps still
red where it matters:

| mutant | what reds |
|---|---|
| `archive` leaves the record in the source file | `"house.jsonl" no longer holds a node titled …` |
| `archive` writes nothing to `Archive.jsonl` | `"Archive.jsonl" holds a node titled …` — as the claim, not as an ENOENT |
| `Enter` commits and opens nothing | `I press "Enter"`, naming the caret that did not leave |
| `Tab` does nothing at all | `I press "Tab"` — *"timed out … waiting until the row to be drawn where the key moved it"* |

The last two red AT THE KEY rather than four steps later, which is the point of
a step that waits for what it just did. The `Tab` row is quoted verbatim because
it was not true when the reviewer read it: every key shared one sentence, so a
no-op `Tab` timed out as "the caret to leave the line the key ended" and sent
the reader looking for a line nobody was leaving. `LEAVES` is a map from key to
the sentence a red run reads now — one predicate, six names.

## FINDING — a product bug, reported not fixed

**Clicking away from a brand-new line commits it and leaves the caret in the row
it just made.** `Editor.blur` closes the draft only when the slot the blur came
from is still the open one; a new draft that lands becomes a *row* draft at a
different slot (`draft.ts`'s `landed`), so the guard reads "the reader went
somewhere else" when they went nowhere. Three scenarios walk through it
(`keyboard_editing.feature:306`, `:327`, `:338`) and none of them looks.

Not fixed here: it is a product change and wants its own scenario. The steps in
this PR wait for the caret to leave the LINE rather than for an empty page,
which is honest either way — and stays honest if the blur is fixed.

## Overlap with the two open PRs — how to resolve it

#159 and #162 each carry their own copy of the two disk fixes above, on their own
branches. Whichever lands second conflicts textually in `editing_steps.ts`.
Nothing here depends on either PR, and the resolution is not "keep either one":

1. **Keep ONE copy of `no longer holds a node titled`.** All three add the same
   step; two definitions of one step name is a Cucumber error, not a merge
   artifact. Either copy will do — they are the same wait.
2. **Keep THIS reader, and delete theirs.** `world.servedNodesSoFar` returns
   `[]` for `code === "ENOENT"` **and nothing else**, so a line that is not JSON
   still throws out of the poll and is reported as the fault it is. #159's and
   #162's local `recordsIn` is a blanket `catch { return [] }`, which swallows a
   malformed record and turns it into a 15-second timeout that names the wrong
   thing. Delete the local `recordsIn` on the branch that lands second and point
   its call sites at `world.servedNodesSoFar`.

The second one is the one worth being careful about: taking their copy is a
silent regression that nothing in either suite would catch.

## What it does not do

No timeout was raised, no retry was added, and no claim was deleted or loosened.
The steps that got a wait fail *sooner and saying what they were waiting for* —
the run that used to fail on a file four steps later now fails on the key that
did not land.

## A second FINDING, from the reviewers rather than the loop

**A structural key takes the caret back with nothing on the page saying when.**
`structural` re-focuses the row and collapses its selection after the write
answers (`RowEditor.tsx`'s `takeCaret`), and a refused key redraws nothing, so
a second refusal is indistinguishable from the first. The harness therefore
cannot know a refused key has been answered, and under load that landed inside
the next gesture: the ⌘A of the retype that followed was collapsed, and the
title was prepended instead of replacing (`keyboard_editing.feature:264`, twice
in ~30 loaded runs before the move-key receipt went in, not since).

The receipts here cover it for every key that MOVES the caret, which is what
made the loop green. The keys that redraw a row without moving it —
`Control+Enter` and the walk beside it — still have no receipt of their own,
and the module says so rather than leaving it to be found. Publishing the
client's own quiescence (a counter bumped when a key is enqueued and cleared
when the queue drains) would cover all of them at once and is the honest fix,
but it is a product change made for tests and belongs to the human.

## Evidence, in full

| | `undo.feature` | the five suspect features |
|---|---|---|
| before | 5 of 5 runs failed | 3 of 3 runs failed — 10 distinct scenarios |
| after the fix | — | 12 of 12 runs green |
| after `/simplify` | — | 12 of 12 runs green (re-run from scratch) |

Plus the full suite green under load, and CI green 10/10 on x86_64-linux at
both `93d236e` and `87e9695`.
