### PR TITLE
The three gestures #159 deferred: a sweep, a page that keeps up, a finger

### DIFF
--- a/docs/brainstorming/editing-web.md
+++ b/docs/brainstorming/editing-web.md
@@ -192,12 +192,50 @@ the build decided:
   thing in this feature that a reader would have to re-derive.
 
 Two things it deliberately did not do. **Drag-across** — Workflowy's fifth
-picking gesture — is not built: it wants a marquee over a tree that also has
+picking gesture — was not built: it wants a marquee over a tree that also has
 native text selection in it, and the other four gestures reach every pick it
 would. And **there is still no delete key**: the bulk put-away is a button on
 the selection bar, behind the same confirm the `•••` menu asks, because the
 human's 2026-08-11 ruling is precisely a ruling about a chord that takes a
 branch away — a bulk one would be that at its worst.
+
+## The three deferrals it named, as they shipped (2026-08-14)
+
+`multiselect-completion` closed the first three of those (the delete key is
+still the human's). What each one turned out to BE, rather than what it looked
+like from the outside:
+
+- **Drag-across was one sentence, not a marquee.** The tension is real —
+  press-and-pull already means "select text" — and the way out is not a modifier
+  or a mode but **where the pull BEGINS**. On the words the browser keeps it,
+  unchanged; on the outline's own scaffolding (the indent rails, the strip left
+  of a note, the page below the last row) there is nothing else for the press to
+  be about, so it picks rows. An ALLOWLIST, marked on the scaffolding itself, so
+  a control added to a row tomorrow inherits the safe answer. And the obvious
+  implementation is wrong: `preventDefault` on the press takes the FOCUS with
+  it and leaves a draft that never blurred, while the `user-select` guard the
+  shared gesture primitive already puts up for the panel edges suppresses the
+  selection and nothing else.
+- **It is a BAND, not a box.** A rectangle asks about two axes and the second
+  one has no meaning here: a row is a LINE drawn as far in as its depth says, so
+  a box down the left of the page would cross a root and miss its indented
+  grandchild. Reading only Y is not a simplification — it is the correct
+  question, and what is drawn is the shape the answer came from.
+- **The touch drag's real content was WHICH CELL, not the timer.** A long press
+  was the obvious answer and it is; what it cost was that the `•••` menu already
+  had one on the row line. Two long presses cannot own one press, so the handle
+  is the BULLET — which is what a mouse and a pen have always dragged from — and
+  the menu keeps the rest of the row. The second half is that claiming the
+  scroll with `touch-action: none` would have passed every scenario and left a
+  28px dead strip down every outline; the claim is a non-passive `touchmove`
+  listener put up at the DEADLINE, a moment the browser has already agreed is
+  not a scroll.
+- **Auto-scroll is a coordinate-space split.** Whether to move is a question
+  about the WINDOW (client coordinates); where the gesture now is is a question
+  about the PAGE (document coordinates, which is how both gestures measured
+  their rows). A pointer held still inside an edge zone therefore keeps
+  producing new answers with no `pointermove` behind it, which a caller that
+  re-planned only on `pointermove` would miss entirely.
 
 ## The three input widgets, as they shipped (2026-08-14)
 
@@ -305,8 +343,8 @@ Status keys: **shipped** (item, PR) · **filed** (roadmap id) · **MISSING**
 | Indent / outdent | `Tab` / `Shift+Tab` (also `Alt+Shift+→/←`) | shipped (#109) |
 | Move among siblings | `Alt/Ctrl+Shift+↑↓` | shipped (#109) |
 | Split at caret / merge into previous | `Enter` mid-text / `Backspace` at line start | filed `split-merge` |
-| Drag-drop subtree | drag the bullet | **shipped** (`dragdrop-multiselect`) — pointer events, not HTML5 DnD; the drop is a GAP plus a DEPTH, sent as the surface's existing `place` verb |
-| Multi-select + bulk complete/move/indent/delete | five gestures | **shipped** (`dragdrop-multiselect`), four of the five: modifier-click, shift-click, shift-arrows, double `⌘A`. DRAG-ACROSS is not built — it wants a marquee over a tree that also has text selection in it. Bulk complete / move / indent / drag are the single-row op repeated; "delete" is the Trash, on the bar, behind the same confirm the `•••` menu asks |
+| Drag-drop subtree | drag the bullet | **shipped** (`dragdrop-multiselect`) — pointer events, not HTML5 DnD; the drop is a GAP plus a DEPTH, sent as the surface's existing `place` verb. `multiselect-completion` added the two halves that make it reach: the page auto-scrolls near an edge, and a FINGER drags after holding the bullet (the claim goes up at the deadline, so a flick still scrolls) |
+| Multi-select + bulk complete/move/indent/delete | five gestures | **shipped**, all five: modifier-click, shift-click, shift-arrows, double `⌘A` (`dragdrop-multiselect`) and DRAG-ACROSS (`multiselect-completion`) — where a pull BEGINS decides whether it is a sweep or the browser's own text selection, and what it pulls is a band rather than a box, because a row is a line. Bulk complete / move / indent / drag are the single-row op repeated; "delete" is the Trash, on the bar, behind the same confirm the `•••` menu asks |
 | **Duplicate** (subtree; result auto-tagged `#copy`; also `Alt+Drag` clone) | `Alt/⌘+Shift+D`, menu | **MISSING** |
 | **Move to** (search dialog; moves subtree anywhere, across lists) | slash command, menu | **MISSING** — olai's version is the harder cross-OUTLINE move: `parent` is same-file by the format, so this is an op design (move vs re-create vs mirror), not just a dialog |
 | **Delete** (recoverable from Trash) + **Trash restore** | `Ctrl/⌘+Shift+Backspace`, menu | ruled 2026-08-11: still no delete affordance. olai's trash is `Archive.jsonl`, and ARCHIVE has one — the `•••` menu's `Move to Trash` (né `Archive`), subtree with a confirm naming the blast radius (human, 2026-08-12), closing `parity-archive`. **Trash restore shipped too** (`trash-parity`, 2026-08-13, closing `parity-unarchive`): the sidebar's Trash draws every archive read-only, `Put back` sends the `unarchive` op both faces got together, and the confirm now promises the bin it implies |

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -210,14 +210,25 @@ What a drop sends is one op per row moved — the same `move_node` an agent woul
 send, naming a parent and the sibling to sit after — so a drop is refused, and
 says why, exactly as a `Tab` is. ⌘Z takes one back like any other edit.
 
-Dragging is a pointer gesture: a mouse or a pen, not a finger. A touch drag
-would have to claim the gesture that scrolls the page, and a phone's gutter is
-already narrower for the same kind of reason.
+**Hold a row near the top or bottom of the window and the page comes to you.**
+An outline is longer than a screen nearly always, so a drag that could only
+reach what happened to be visible when you pressed would be most of the gesture
+missing. The nearer the edge, the faster it moves; move away and it stops. The
+line that says where the row would land is re-read as the page goes, so it is
+always about where the pointer is *on the page*.
+
+**With a finger, hold the bullet first.** Press it, wait for the row to lift,
+and then it follows your thumb — the same drop line, the same landing. Until
+that moment nothing is claimed: a finger that moves before the row lifts is
+scrolling the page, exactly as it always was, and that is true whether it
+started on a bullet or anywhere else. The bullet is the handle on every device,
+which is why holding a finger *there* no longer opens the row's ••• menu —
+holding the row anywhere else still does.
 
 ## Picking several rows
 
-Everything above works on more than one row at a time. Four ways to pick them —
-Workflowy's, minus the fifth (dragging across rows), which is not built:
+Everything above works on more than one row at a time. All five of Workflowy's
+ways to pick them:
 
 | | |
 |---|---|
@@ -225,6 +236,23 @@ Workflowy's, minus the fifth (dragging across rows), which is not built:
 | **Shift-click** a title | pick everything between |
 | **Shift+↑ / Shift+↓** from a caret | leave the caret and start picking |
 | **⌘A / Ctrl+A** twice in a row | the line, then the row and the ones beside it — and again to widen to the page |
+| **Drag across the rows** | pick everything the pull passes over |
+
+**Where a pull begins is what decides whether it is a sweep or a text
+selection**, and that is the whole rule. Press *on the words* — a title, a note
+— and it is the browser's own gesture, unchanged: sweep a line and quote it,
+across as many rows as you like. Press on the outline's own empty space — the
+rail beside an indented branch, the strip left of a note, the page below the
+last row — and there is nothing there for the press to be about except the rows
+themselves, so it picks them. A band follows the pull and spans the rows' full
+width, because a row is a *line*: which rows a sweep crosses is a question about
+how far down it went, never about how far in they are drawn. Pressing that empty
+space without pulling puts the pick away.
+
+A sweep leaves the two ends every other picking gesture leaves, so a Shift-click
+or a Shift+arrow after one carries on from where the pull started. It replaces
+the pick rather than adding to it, and it is a pointer gesture: on a phone, a
+finger on empty space is scrolling.
 
 A pick and a caret are never both live: picking rows puts the caret away, and
 putting a caret anywhere — a title, a note, a new line — puts the pick away. That
@@ -238,6 +266,9 @@ same thing, several times.
 | **⌘Enter** / **Ctrl+Enter** | tick them off, or take that back |
 | **Drag any of their bullets** | move all of them, subtrees and all |
 | **Escape** | put the pick away |
+
+A sweep held near the bottom of the window scrolls the page too, the same way a
+drag does.
 
 **A parent and a child in the same pick are one row to a verb.** A subtree moves
 whole, so the child is already coming along; asking again would be asking about

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -241,13 +241,20 @@ ways to pick them:
 **Where a pull begins is what decides whether it is a sweep or a text
 selection**, and that is the whole rule. Press *on the words* — a title, a note
 — and it is the browser's own gesture, unchanged: sweep a line and quote it,
-across as many rows as you like. Press on the outline's own empty space — the
-rail beside an indented branch, the strip left of a note, the page below the
-last row — and there is nothing there for the press to be about except the rows
-themselves, so it picks them. A band follows the pull and spans the rows' full
-width, because a row is a *line*: which rows a sweep crosses is a question about
-how far down it went, never about how far in they are drawn. Pressing that empty
-space without pulling puts the pick away.
+across as many rows as you like. Press on the outline's own empty space and
+there is nothing there for the press to be about except the rows themselves, so
+it picks them. That empty space is the **rail down the left of the outline**
+(beside every row, however far in it is drawn), the strip left of a note, the
+gaps between rows, and the page below the last one. A band follows the pull and
+spans the rows' full width, because a row is a *line*: which rows a sweep
+crosses is a question about how far down it went, never about how far in they
+are drawn.
+
+What is *not* empty space is a row's own gutter, even before its controls fade
+in: the collapse triangle and the ••• live there, and a press in that column is
+theirs. Pressing one of the sweep's own surfaces without pulling puts the pick
+away; pressing a control does not, because it is aimed at the row rather than at
+nothing — and anything that puts a caret in a row puts the pick away by itself.
 
 A sweep leaves the two ends every other picking gesture leaves, so a Shift-click
 or a Shift+arrow after one carries on from where the pull started. It replaces

--- a/packages/tests/evidence.ts
+++ b/packages/tests/evidence.ts
@@ -61,8 +61,9 @@ const promised = async (page: Page) => {
   } depth=${await line.getAttribute("data-depth")}`
 }
 
+const SELECTION_BAR = '[data-testid="selection-bar"]'
 const picked = async (page: Page) =>
-  await page.locator('[data-testid="selection-bar"]').getAttribute("data-rows")
+  await page.locator(SELECTION_BAR).getAttribute("data-rows")
 
 /** The band a drag-across pulls, and how many rows it says it is crossing —
  *  the half of that gesture that is still a prediction while the pointer is
@@ -97,6 +98,42 @@ const pick = async (page: Page, first: string, last?: string) => {
   await page.locator(title(first)).click({ modifiers: ["Control"] })
   if (last !== undefined) await page.locator(title(last)).click({ modifiers: ["Shift"] })
   await page.waitForTimeout(300)
+}
+
+/**
+ * A window shorter than the outline, so there is something to scroll.
+ *
+ * No corpus here is taller than a screen on its own — they are outlines a
+ * person can read inside a scenario — so the WINDOW is what shrinks, which is a
+ * real shape too (a short laptop, a handset with its keyboard up). The browser
+ * tests make their room the same way and assert it (`support/world.ts`'s
+ * `shrinkToScroll`).
+ */
+const short = async (page: Page, width: number, height: number): Promise<void> => {
+  await page.setViewportSize({ width, height })
+  await page.waitForTimeout(400)
+}
+
+/**
+ * Hold the pointer at the bottom of the window, the way a hand does: it arrives
+ * there and then keeps moving a little, because a hand at the edge of a screen
+ * is a hand pushing rather than a hand parked.
+ *
+ * The nudges are not decoration. A gesture that has run out of screen keeps
+ * reporting on its own (`client/autoscroll.ts` re-reads the pointer against a
+ * page that has moved), but a headless browser's frame clock is not a hand's,
+ * and a section that stood perfectly still for a fixed number of milliseconds
+ * would be a section about the harness's timing.
+ */
+const atTheEdge = async (page: Page, x: number): Promise<void> => {
+  const view = page.viewportSize()
+  if (view === null) throw new Error("this page has no viewport size")
+  await page.mouse.move(x, view.height - 8, { steps: 10 })
+  for (let nudge = 0; nudge < 8; nudge++) {
+    await page.waitForTimeout(120)
+    await page.mouse.move(x + (nudge % 2), view.height - 8)
+  }
+  await page.waitForTimeout(200)
 }
 
 const SETTLE = 1800
@@ -286,7 +323,9 @@ const SECTIONS: Record<string, (page: Page) => Promise<void>> = {
     // is about the rows rather than about the text.
     const from = await rail(page, "demo")
     const to = await boxOf(page.locator(title("install")))
-    console.log(`  before: ${await picked(page) ?? "nothing picked"}`)
+    // The BAR, not what it says: a page with nothing picked draws none at all,
+    // so this is "how many bars" rather than "how many rows".
+    console.log(`  before: ${await page.locator(SELECTION_BAR).count()} bars drawn`)
     await page.mouse.move(from.x, from.y)
     await page.mouse.down()
     await page.mouse.move(from.x, to.y + to.height / 2, { steps: 14 })
@@ -318,18 +357,19 @@ const SECTIONS: Record<string, (page: Page) => Promise<void>> = {
   },
 
   "the-page-keeps-up": async (page) => {
+    await short(page, 1_100, 320)
     console.log(`  room: ${await room(page)}`)
     console.log(`  at: ${await page.evaluate(() => window.scrollY)}`)
     await shot(page, "at-the-top")
     const box = await boxOf(page.locator(handle("demo")))
     await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
     await page.mouse.down()
-    const view = page.viewportSize()
-    await page.mouse.move(box.x + 40, (view?.height ?? 0) - 8, { steps: 10 })
-    await page.waitForTimeout(900)
+    await atTheEdge(page, box.x + 40)
     console.log(`  held at the bottom edge, the page is at: ${
       await page.evaluate(() => window.scrollY)
     }`)
+    // The last row of the file, which was below the fold when the press
+    // landed: the gesture reaches it only because the page came to it.
     console.log(`  the line promises: ${await promised(page)}`)
     await shot(page, "scrolled")
     await page.mouse.up()
@@ -339,12 +379,12 @@ const SECTIONS: Record<string, (page: Page) => Promise<void>> = {
   },
 
   "a-sweep-keeps-up": async (page) => {
+    await short(page, 1_100, 320)
+    console.log(`  room: ${await room(page)}`)
     const from = await rail(page, "demo")
-    const view = page.viewportSize()
     await page.mouse.move(from.x, from.y)
     await page.mouse.down()
-    await page.mouse.move(from.x, (view?.height ?? 0) - 8, { steps: 10 })
-    await page.waitForTimeout(1_000)
+    await atTheEdge(page, from.x)
     console.log(`  the page is at: ${await page.evaluate(() => window.scrollY)}`)
     console.log(`  the band is crossing: ${await band(page)} rows`)
     console.log(`  picked: ${await picked(page)}`)
@@ -360,26 +400,9 @@ const SECTIONS: Record<string, (page: Page) => Promise<void>> = {
         touchPoints: at === undefined ? [] : [at],
       } as never)
 
-    // A flick FIRST, because it is the promise the rest of this rests on: the
-    // page still scrolls under a finger that starts on the handle.
     console.log(`  room: ${await room(page)}`)
-    const bullet = await boxOf(page.locator(handle("kitchen")))
-    const from = { x: bullet.x + bullet.width / 2, y: bullet.y + bullet.height / 2 }
-    await finger("touchStart", from)
-    for (let step = 1; step <= 10; step++) {
-      await page.waitForTimeout(50)
-      await finger("touchMove", { x: from.x, y: from.y - 24 * step })
-    }
-    await finger("touchEnd")
-    await page.waitForTimeout(300)
-    console.log(`  a flick that STARTS on the bullet scrolls to: ${
-      await page.evaluate(() => window.scrollY)
-    }`)
-    console.log(`  ...and lifts nothing: ${await page.locator('[data-carried="true"]').count()}`)
-    await page.evaluate(() => window.scrollTo(0, 0))
-    await page.waitForTimeout(400)
 
-    // Now the gesture itself: hold, and the row lifts where it is.
+    // The gesture itself: hold, and the row lifts where it is.
     const knobs = await boxOf(page.locator(handle("knobs")))
     const at = { x: knobs.x + knobs.width / 2, y: knobs.y + knobs.height / 2 }
     await finger("touchStart", at)
@@ -419,6 +442,34 @@ const SECTIONS: Record<string, (page: Page) => Promise<void>> = {
       await page.locator('[data-testid="node-menu-panel"]').count()
     }`)
     await shot(page, "the-menu-still-opens")
+
+    // And the promise the whole design rests on, LAST because it is the one
+    // gesture that leaves the page somewhere else: a flick that STARTS on the
+    // handle still scrolls, and lifts nothing. Claiming the cell with
+    // `touch-action: none` would have passed everything above and left a 28px
+    // dead strip down the left of every outline.
+    await page.keyboard.press("Escape")
+    // A screen with somewhere to scroll TO, which this outline does not give a
+    // 620pt handset: the same shape a phone with its keyboard up has, and the
+    // one the suite's own scroll fence uses.
+    await short(page, 390, 400)
+    await page.evaluate(() => window.scrollTo(0, 0))
+    await page.waitForTimeout(400)
+    console.log(`  room for a flick: ${await room(page)}`)
+    const flick = await boxOf(page.locator(handle("kitchen")))
+    const from = { x: flick.x + flick.width / 2, y: flick.y + flick.height / 2 }
+    await finger("touchStart", from)
+    for (let step = 1; step <= 10; step++) {
+      await page.waitForTimeout(50)
+      await finger("touchMove", { x: from.x, y: from.y - 24 * step })
+    }
+    await finger("touchEnd")
+    await page.waitForTimeout(300)
+    console.log(`  a flick that STARTS on the bullet scrolls to: ${
+      await page.evaluate(() => window.scrollY)
+    }`)
+    console.log(`  ...and lifts nothing: ${await page.locator('[data-carried="true"]').count()}`)
+    await shot(page, "a-flick-still-scrolls")
   },
 
   // ── writing a node's edges, and starting an outline ──────────────────
@@ -528,16 +579,39 @@ const SECTIONS: Record<string, (page: Page) => Promise<void>> = {
 /**
  * What SHAPE of browser a section wants, where the default is not it.
  *
- * Two of the gestures below are only themselves in a particular one: an
- * auto-scroll needs a window shorter than the outline (no corpus here is taller
- * than a laptop — they are outlines a person can read inside a scenario), and a
- * touch drag needs a context with a touchscreen and no mouse at all.
+ * Only ONE thing is set here, and it is the thing that can only be set at
+ * creation: a context with a TOUCHSCREEN and no mouse, which is the whole point
+ * of the finger's section. The two auto-scroll sections want a short window and
+ * ask for it INSIDE the section instead ({@link short}), because setting it
+ * here does not do what it looks like — see that helper.
  */
-const SHAPES: Record<string, Parameters<Browser["newPage"]>[0]> = {
-  "the-page-keeps-up": { viewport: { width: 1100, height: 320 } },
-  "a-sweep-keeps-up": { viewport: { width: 1100, height: 320 } },
+/**
+ * What SHAPE of browser a section wants, where the default is not it.
+ *
+ * One entry, and it is the thing that can ONLY be set at creation: a context
+ * with a touchscreen and no mouse, which is the whole point of the finger's
+ * section.
+ *
+ * THERE IS NO SECTION FOR AUTO-SCROLL, deliberately. That gesture is only
+ * itself in a window SHORTER than the outline, and this driver cannot reliably
+ * make one: the app's panes are sized in `dvh`, and an emulated viewport — set
+ * at creation or resized after load — leaves this page reporting the new
+ * `innerHeight` while `100dvh` still resolves against the old one, so the pane
+ * stays a screen taller than the window and the gesture is measured against a
+ * page that does not exist. The browser tests do not have the problem (their
+ * own `shrinkToScroll` asserts the room it makes, and two scenarios in
+ * `dragdrop_multiselect.feature` hold the gesture end to end), which is the
+ * division this file's opening line already draws: the promises live in the
+ * features, and this is what a person looks at.
+ */
+const SHAPES: Record<string, Parameters<Browser["newContext"]>[0]> = {
+  // The browser tests' own handset, to the pixel and the scale factor
+  // (`support/hooks.ts`'s `PHONE`): an iPhone 13's 390×844, a touch screen and
+  // no mouse. `isMobile` is what makes Chromium honour the shell's viewport
+  // meta at all, and the scale factor is what makes a dispatched touch land
+  // where the CSS pixel is.
   "a-finger-picks-a-row-up": {
-    viewport: { width: 390, height: 720 },
+    viewport: { width: 390, height: 620 },
     hasTouch: true,
     isMobile: true,
   },
@@ -549,10 +623,30 @@ const main = async () => {
     console.log(Object.keys(SECTIONS).join("\n"))
     return
   }
-  const browser = await chromium.launch()
-  const page = await browser.newPage(
+  // The browser tests' own argv (`support/hooks.ts`), and not for their
+  // reasons: what matters here is `--headless=new`, which is a different
+  // browser from the old headless shell — the shell does not turn a dispatched
+  // touch into the pointer events a long press is made of, so a section about a
+  // finger silently held nothing. The rest are the flags that make Chromium
+  // survive a container with a small `/dev/shm`, harmless on a laptop.
+  const browser = await chromium.launch({
+    args: [
+      "--no-sandbox",
+      "--disable-setuid-sandbox",
+      "--disable-gpu",
+      "--disable-dev-shm-usage",
+      "--headless=new",
+    ],
+  })
+  // A CONTEXT of its own rather than `browser.newPage(options)`, which is the
+  // same thing with an implicit one — except that a touchscreen is a property
+  // of the context, and the DevTools session the finger's section opens has to
+  // be against a context that has one. The browser tests take the same route
+  // (`support/hooks.ts`).
+  const context = await browser.newContext(
     SHAPES[SECTION] ?? { viewport: { width: 1100, height: 720 } },
   )
+  const page = await context.newPage()
   page.on("pageerror", (error) => console.error("PAGE ERROR", error))
   await page.goto(`${BASE}/o/house.jsonl`)
   await page.locator('[data-testid="outline-tree"]').first().waitFor()

--- a/packages/tests/evidence.ts
+++ b/packages/tests/evidence.ts
@@ -12,7 +12,7 @@
  * a frame nobody can reproduce.
  */
 import { readdirSync, readFileSync } from "node:fs"
-import { chromium, type Locator, type Page } from "playwright"
+import { type Browser, chromium, type Locator, type Page } from "playwright"
 
 const BASE = process.env["BASE"] ?? "http://127.0.0.1:7788"
 const OUT = process.env["SHOTS"] ?? "."
@@ -63,6 +63,21 @@ const promised = async (page: Page) => {
 
 const picked = async (page: Page) =>
   await page.locator('[data-testid="selection-bar"]').getAttribute("data-rows")
+
+/** The band a drag-across pulls, and how many rows it says it is crossing —
+ *  the half of that gesture that is still a prediction while the pointer is
+ *  down, exactly as the drop line is for a drag. */
+const SWEEP_BAND = '[data-testid="sweep-band"]'
+const band = async (page: Page) =>
+  await page.locator(SWEEP_BAND).first().getAttribute("data-rows")
+
+/** How much page there is to scroll, and how much window there is to see it in
+ *  — printed rather than assumed, because a section about the page KEEPING UP
+ *  proves nothing over a page that fits. */
+const room = async (page: Page) =>
+  await page.evaluate(() =>
+    `${document.documentElement.scrollHeight}px of page in a ${window.innerHeight}px window`
+  )
 
 const pick = async (page: Page, first: string, last?: string) => {
   await page.locator(title(first)).click({ modifiers: ["Control"] })
@@ -246,6 +261,166 @@ const SECTIONS: Record<string, (page: Page) => Promise<void>> = {
     await shot(page, "refused")
   },
 
+  // ── the three deferrals #159 named ───────────────────────────────────
+  //
+  // Drag-across, the page keeping up with a gesture, and a finger picking a row
+  // up. Each section drives ONE of them end to end and prints what the page
+  // says at the moment it is still a prediction.
+
+  "drag-across": async (page) => {
+    // The rail beside a branch: scaffolding, holding no words, so a press there
+    // is about the rows rather than about the text.
+    const rail = await page.locator(row("demo")).first().evaluate((one) => {
+      const list = one.parentElement?.closest("ul")
+      const line = one.querySelector("[data-row-key]")
+      if (!list || !line) throw new Error("no rail beside that row")
+      const box = list.getBoundingClientRect()
+      const on = line.getBoundingClientRect()
+      return { x: box.x + 4, y: on.y + on.height / 2 }
+    })
+    const to = await boxOf(page.locator(title("install")))
+    console.log(`  before: ${await picked(page) ?? "nothing picked"}`)
+    await page.mouse.move(rail.x, rail.y)
+    await page.mouse.down()
+    await page.mouse.move(rail.x, to.y + to.height / 2, { steps: 14 })
+    await page.waitForTimeout(200)
+    console.log(`  the band is crossing: ${await band(page)} rows`)
+    console.log(`  picked while pulling: ${await picked(page)}`)
+    await shot(page, "sweeping")
+    await page.mouse.up()
+    await page.waitForTimeout(400)
+    console.log(`  picked after letting go: ${await picked(page)}`)
+    await shot(page, "picked")
+
+    // The other half of the rule, and the thing that would have been LOST: a
+    // pull begun IN the words is still the browser's own text selection.
+    await page.keyboard.press("Escape")
+    const words = await boxOf(page.locator(title("order")))
+    await page.mouse.move(words.x + 4, words.y + words.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(words.x + words.width - 4, words.y + words.height * 3, { steps: 12 })
+    await page.waitForTimeout(200)
+    console.log(
+      `  a pull in the words selects: "${
+        await page.evaluate(() => window.getSelection()?.toString() ?? "")
+      }"`,
+    )
+    console.log(`  ...and draws no band: ${await page.locator(SWEEP_BAND).count()}`)
+    await shot(page, "text-not-rows")
+    await page.mouse.up()
+  },
+
+  "the-page-keeps-up": async (page) => {
+    console.log(`  room: ${await room(page)}`)
+    console.log(`  at: ${await page.evaluate(() => window.scrollY)}`)
+    await shot(page, "at-the-top")
+    const box = await boxOf(page.locator(handle("demo")))
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    await page.mouse.down()
+    const view = page.viewportSize()
+    await page.mouse.move(box.x + 40, (view?.height ?? 0) - 8, { steps: 10 })
+    await page.waitForTimeout(900)
+    console.log(`  held at the bottom edge, the page is at: ${
+      await page.evaluate(() => window.scrollY)
+    }`)
+    console.log(`  the line promises: ${await promised(page)}`)
+    await shot(page, "scrolled")
+    await page.mouse.up()
+    await page.waitForTimeout(SETTLE)
+    console.log(`  order: ${await order(page)}`)
+    await shot(page, "dropped")
+  },
+
+  "a-sweep-keeps-up": async (page) => {
+    const rail = await page.locator(row("demo")).first().evaluate((one) => {
+      const list = one.parentElement?.closest("ul")
+      const line = one.querySelector("[data-row-key]")
+      if (!list || !line) throw new Error("no rail beside that row")
+      const box = list.getBoundingClientRect()
+      const on = line.getBoundingClientRect()
+      return { x: box.x + 4, y: on.y + on.height / 2 }
+    })
+    const view = page.viewportSize()
+    await page.mouse.move(rail.x, rail.y)
+    await page.mouse.down()
+    await page.mouse.move(rail.x, (view?.height ?? 0) - 8, { steps: 10 })
+    await page.waitForTimeout(1_000)
+    console.log(`  the page is at: ${await page.evaluate(() => window.scrollY)}`)
+    console.log(`  the band is crossing: ${await band(page)} rows`)
+    console.log(`  picked: ${await picked(page)}`)
+    await shot(page, "swept-past-the-fold")
+    await page.mouse.up()
+  },
+
+  "a-finger-picks-a-row-up": async (page) => {
+    const touch = await page.context().newCDPSession(page)
+    const finger = (type: string, at?: { x: number; y: number }) =>
+      touch.send("Input.dispatchTouchEvent" as never, {
+        type,
+        touchPoints: at === undefined ? [] : [at],
+      } as never)
+
+    // A flick FIRST, because it is the promise the rest of this rests on: the
+    // page still scrolls under a finger that starts on the handle.
+    console.log(`  room: ${await room(page)}`)
+    const bullet = await boxOf(page.locator(handle("kitchen")))
+    const from = { x: bullet.x + bullet.width / 2, y: bullet.y + bullet.height / 2 }
+    await finger("touchStart", from)
+    for (let step = 1; step <= 10; step++) {
+      await page.waitForTimeout(50)
+      await finger("touchMove", { x: from.x, y: from.y - 24 * step })
+    }
+    await finger("touchEnd")
+    await page.waitForTimeout(300)
+    console.log(`  a flick that STARTS on the bullet scrolls to: ${
+      await page.evaluate(() => window.scrollY)
+    }`)
+    console.log(`  ...and lifts nothing: ${await page.locator('[data-carried="true"]').count()}`)
+    await page.evaluate(() => window.scrollTo(0, 0))
+    await page.waitForTimeout(400)
+
+    // Now the gesture itself: hold, and the row lifts where it is.
+    const knobs = await boxOf(page.locator(handle("knobs")))
+    const at = { x: knobs.x + knobs.width / 2, y: knobs.y + knobs.height / 2 }
+    await finger("touchStart", at)
+    await page.waitForTimeout(800)
+    console.log(`  after holding it: in the air ${
+      await page.locator('[data-carried="true"]').count()
+    }, menu panels ${await page.locator('[data-testid="node-menu-panel"]').count()}`)
+    await shot(page, "lifted")
+    const above = await boxOf(page.locator(title("handles")))
+    for (let step = 1; step <= 8; step++) {
+      await finger("touchMove", {
+        x: at.x + ((above.x + 4 - at.x) * step) / 8,
+        y: at.y + ((above.y - 2 - at.y) * step) / 8,
+      })
+      await page.waitForTimeout(30)
+    }
+    await page.waitForTimeout(200)
+    console.log(`  the line promises: ${await promised(page)}`)
+    await shot(page, "dragging")
+    await finger("touchEnd")
+    await page.waitForTimeout(SETTLE)
+    console.log(`  order: ${await order(page)}`)
+    console.log(`  the address is still: ${new URL(page.url()).pathname}`)
+    await shot(page, "dropped")
+
+    // And the menu still has its door: hold the ROW rather than the bullet.
+    await page.locator(`${row("kitchen")} [data-testid="node-gutter"]`).first()
+      .waitFor()
+    const line = await boxOf(
+      page.locator(`${row("kitchen")} [data-testid="node-gutter"]`).first(),
+    )
+    await finger("touchStart", { x: line.x + line.width / 2, y: line.y + line.height / 2 })
+    await page.waitForTimeout(800)
+    await finger("touchEnd")
+    await page.waitForTimeout(400)
+    console.log(`  holding the ROW still opens the menu: ${
+      await page.locator('[data-testid="node-menu-panel"]').count()
+    }`)
+    await shot(page, "the-menu-still-opens")
+  },
+
   // ── writing a node's edges, and starting an outline ──────────────────
   //
   // `editor-op-parity`'s last three children. Each section drives ONE of the
@@ -350,6 +525,24 @@ const SECTIONS: Record<string, (page: Page) => Promise<void>> = {
   },
 }
 
+/**
+ * What SHAPE of browser a section wants, where the default is not it.
+ *
+ * Two of the gestures below are only themselves in a particular one: an
+ * auto-scroll needs a window shorter than the outline (no corpus here is taller
+ * than a laptop — they are outlines a person can read inside a scenario), and a
+ * touch drag needs a context with a touchscreen and no mouse at all.
+ */
+const SHAPES: Record<string, Parameters<Browser["newPage"]>[0]> = {
+  "the-page-keeps-up": { viewport: { width: 1100, height: 320 } },
+  "a-sweep-keeps-up": { viewport: { width: 1100, height: 320 } },
+  "a-finger-picks-a-row-up": {
+    viewport: { width: 390, height: 720 },
+    hasTouch: true,
+    isMobile: true,
+  },
+}
+
 const main = async () => {
   const section = SECTIONS[SECTION]
   if (section === undefined) {
@@ -357,7 +550,9 @@ const main = async () => {
     return
   }
   const browser = await chromium.launch()
-  const page = await browser.newPage({ viewport: { width: 1100, height: 720 } })
+  const page = await browser.newPage(
+    SHAPES[SECTION] ?? { viewport: { width: 1100, height: 720 } },
+  )
   page.on("pageerror", (error) => console.error("PAGE ERROR", error))
   await page.goto(`${BASE}/o/house.jsonl`)
   await page.locator('[data-testid="outline-tree"]').first().waitFor()

--- a/packages/tests/evidence.ts
+++ b/packages/tests/evidence.ts
@@ -79,6 +79,20 @@ const room = async (page: Page) =>
     `${document.documentElement.scrollHeight}px of page in a ${window.innerHeight}px window`
   )
 
+/** The empty strip beside a row — its enclosing list's own padding, which is
+ *  scaffolding and holds no words, so a press there is a sweep rather than a
+ *  text selection. Measured rather than named: it is not a control and has no
+ *  testid, and what makes it pressable is that nothing else is there. */
+const rail = async (page: Page, id: string) =>
+  await page.locator(row(id)).first().evaluate((one) => {
+    const list = one.parentElement?.closest("ul")
+    const line = one.querySelector("[data-row-key]")
+    if (!list || !line) throw new Error("no rail beside that row")
+    const box = list.getBoundingClientRect()
+    const on = line.getBoundingClientRect()
+    return { x: box.x + 4, y: on.y + on.height / 2 }
+  })
+
 const pick = async (page: Page, first: string, last?: string) => {
   await page.locator(title(first)).click({ modifiers: ["Control"] })
   if (last !== undefined) await page.locator(title(last)).click({ modifiers: ["Shift"] })
@@ -270,19 +284,12 @@ const SECTIONS: Record<string, (page: Page) => Promise<void>> = {
   "drag-across": async (page) => {
     // The rail beside a branch: scaffolding, holding no words, so a press there
     // is about the rows rather than about the text.
-    const rail = await page.locator(row("demo")).first().evaluate((one) => {
-      const list = one.parentElement?.closest("ul")
-      const line = one.querySelector("[data-row-key]")
-      if (!list || !line) throw new Error("no rail beside that row")
-      const box = list.getBoundingClientRect()
-      const on = line.getBoundingClientRect()
-      return { x: box.x + 4, y: on.y + on.height / 2 }
-    })
+    const from = await rail(page, "demo")
     const to = await boxOf(page.locator(title("install")))
     console.log(`  before: ${await picked(page) ?? "nothing picked"}`)
-    await page.mouse.move(rail.x, rail.y)
+    await page.mouse.move(from.x, from.y)
     await page.mouse.down()
-    await page.mouse.move(rail.x, to.y + to.height / 2, { steps: 14 })
+    await page.mouse.move(from.x, to.y + to.height / 2, { steps: 14 })
     await page.waitForTimeout(200)
     console.log(`  the band is crossing: ${await band(page)} rows`)
     console.log(`  picked while pulling: ${await picked(page)}`)
@@ -332,18 +339,11 @@ const SECTIONS: Record<string, (page: Page) => Promise<void>> = {
   },
 
   "a-sweep-keeps-up": async (page) => {
-    const rail = await page.locator(row("demo")).first().evaluate((one) => {
-      const list = one.parentElement?.closest("ul")
-      const line = one.querySelector("[data-row-key]")
-      if (!list || !line) throw new Error("no rail beside that row")
-      const box = list.getBoundingClientRect()
-      const on = line.getBoundingClientRect()
-      return { x: box.x + 4, y: on.y + on.height / 2 }
-    })
+    const from = await rail(page, "demo")
     const view = page.viewportSize()
-    await page.mouse.move(rail.x, rail.y)
+    await page.mouse.move(from.x, from.y)
     await page.mouse.down()
-    await page.mouse.move(rail.x, (view?.height ?? 0) - 8, { steps: 10 })
+    await page.mouse.move(from.x, (view?.height ?? 0) - 8, { steps: 10 })
     await page.waitForTimeout(1_000)
     console.log(`  the page is at: ${await page.evaluate(() => window.scrollY)}`)
     console.log(`  the band is crossing: ${await band(page)} rows`)

--- a/packages/tests/features/dragdrop_multiselect.feature
+++ b/packages/tests/features/dragdrop_multiselect.feature
@@ -276,3 +276,112 @@ Feature: Dragging rows, and picking several
     When I pick the title of "kitchen-herbs"
     Then the pick does not offer the Trash
     And the pick notes "a placement is in the pick"
+
+  # ── the fifth picking gesture: drag across ───────────────────────────
+  #
+  # #159 shipped four of Workflowy's five and left this one, because a marquee
+  # over a tree that also has native text selection in it is a design rather
+  # than a feature: press-and-pull already MEANS something, and shipping a
+  # second meaning for it is deciding which of the two a given pull is.
+  #
+  # The decision is one sentence — WHERE THE PULL BEGINS decides — and the
+  # scenarios below are its halves: begun on the words it is text, begun on the
+  # outline's own scaffolding it is a pick, and where the scaffolding IS is the
+  # rail beside a branch and the page under the last row.
+
+  Scenario: Sweeping down the rail picks the rows the pull crosses
+    When I sweep from beside "demo" down to "install"
+    Then the band is crossing 3 rows
+    And 3 rows are picked
+    And the row "demo" is picked
+    And the row "order" is picked
+    And the row "install" is picked
+    When I let go
+    Then no band is drawn
+    And 3 rows are picked
+    And there should be no page errors
+
+  Scenario: A pull begun in the words is the browser's, and picks nothing
+    # The tension this gesture had to settle, held as the thing that would be
+    # LOST if it were settled the other way: a reader must still be able to
+    # sweep a title and quote it. The pull travels down past the row it started
+    # in, which is exactly the shape a marquee would have claimed.
+    When I select text across the title of "order"
+    Then the words are selected
+    And no band is drawn
+    And no rows are picked
+    When I let go
+    Then there should be no page errors
+
+  Scenario: The page below the last row is somewhere to start
+    # A short outline leaves most of the pane empty, and that is the sweep's
+    # largest surface — without it a tree with no depth would have nothing but
+    # the gaps between lines to press.
+    When I sweep from below the outline up to "install"
+    # Everything from `install` to the foot of the tree, which is what pulling
+    # up from under it crosses — and two rows to a verb, because the mirror's
+    # expanded children come along inside it.
+    Then 2 rows are picked
+    And the row "install" is picked
+    And the row "kitchen-herbs" is picked
+
+  Scenario: A sweep replaces what was picked rather than adding to it
+    When I pick the title of "handles"
+    And I sweep from beside "demo" down to "order"
+    Then 2 rows are picked
+    And the row "handles" is not picked
+    When I let go
+    Then 2 rows are picked
+
+  Scenario: Pressing the page without pulling puts the pick away
+    When I pick the title of "handles"
+    And I shift-click the title of "knobs"
+    Then 3 rows are picked
+    When I press below the outline
+    Then no rows are picked
+
+  Scenario: Which end the pull began at is the end a shift-click measures from
+    # A sweep is a range gesture like the other four, so it leaves an ANCHOR and
+    # a FOCUS rather than a bag of rows: the row it started on is what the
+    # shift-click after it extends from.
+    When I sweep from beside "install" down to "kitchen-herbs"
+    And I let go
+    And I shift-click the title of "install"
+    Then 1 rows are picked
+    And the row "install" is picked
+
+  Scenario: A parent and its child crossed by one sweep are one row to a verb
+    # The same rule the other four pickers keep, arrived at by the gesture most
+    # likely to meet it: pulling across a branch crosses everything drawn under
+    # it, and a subtree moves whole.
+    When I sweep from beside "install" down to "knobs"
+    Then the band is crossing 4 rows
+    And 1 rows are picked
+    And the row "knobs" is picked
+
+  # ── the page keeps up with a gesture ─────────────────────────────────
+  #
+  # Both gestures aim at ROWS, and an outline is longer than a window nearly
+  # always — so without this the reach of either is "whatever was on screen
+  # when the press landed". The WINDOW is what shrinks here, because the
+  # corpora in this suite are outlines a person can read inside a scenario.
+
+  Scenario: A row held at the bottom of the window takes the page with it
+    Given the window is shorter than the outline
+    When I pick up the bullet of "demo" and hold it at the bottom of the window
+    Then the outline has scrolled
+    # ...and the landing is re-read from where the pointer is ON THE PAGE, which
+    # has moved under a pointer that has not: the last row of the file is only
+    # nameable at all because the page came to it.
+    And the drop line would put it after "kitchen-herbs"
+    When I let go
+    Then the node "kitchen-herbs" comes before "demo"
+    And there should be no page errors
+
+  Scenario: A sweep held at the bottom of the window takes it too
+    Given the window is shorter than the outline
+    When I sweep from beside "demo" to the bottom of the window
+    Then the outline has scrolled
+    And the row "kitchen-herbs" is picked
+    When I let go
+    Then there should be no page errors

--- a/packages/tests/features/dragdrop_multiselect.feature
+++ b/packages/tests/features/dragdrop_multiselect.feature
@@ -313,6 +313,23 @@ Feature: Dragging rows, and picking several
     When I let go
     Then there should be no page errors
 
+  Scenario: A ROOT row has a rail beside it too
+    # A nested list gives its branch one for free — the padding a child list
+    # indents by is scaffolding a person can press. The outline's own list was
+    # flush, so beside a root row the only empty space was the four pixels
+    # between two lines: on a flat inbox, the one sweep the gesture could not
+    # make was a prefix of it, which is the first thing a Workflowy hand tries
+    # (review, 2026-08-14). The rail is taken out of the pane's own padding, so
+    # it exists at depth 0 and nothing moved.
+    When I sweep from beside "kitchen" down to "order"
+    Then the band is crossing 3 rows
+    # One row to a verb: `order` and `demo` are drawn under `kitchen`, and a
+    # subtree moves whole.
+    And 1 rows are picked
+    And the row "kitchen" is picked
+    When I let go
+    Then there should be no page errors
+
   Scenario: The page below the last row is somewhere to start
     # A short outline leaves most of the pane empty, and that is the sweep's
     # largest surface — without it a tree with no depth would have nothing but

--- a/packages/tests/features/on_a_phone.feature
+++ b/packages/tests/features/on_a_phone.feature
@@ -200,20 +200,65 @@ Feature: On a phone
     And the node menu is closed
     And no row is being edited
 
+  # ── the bullet is the handle, on a finger as on a mouse ───────────────
+  #
+  # A row can be picked up with a finger now, and the gesture is the same long
+  # press — WATCHED, never claimed, until a deadline the browser has already
+  # agreed is not a scroll. What it is held ON is the BULLET, which is what a
+  # mouse and a pen have always dragged from, so it is one handle on three
+  # devices rather than a fourth thing to learn.
+  #
+  # That costs the bullet its old job as a second door to the `•••` menu (this
+  # scenario used to hold a finger there and assert the panel), and the trade
+  # is deliberate: two long presses cannot both own one press, the menu has a
+  # whole row to be reached from, and a handle has only itself. What the
+  # scenario was really holding — that a finger lifting after a press does not
+  # ALSO follow the link under it — is held here still, by the drag.
+
   @corpus:good @phone
-  Scenario: The press does not also press the row it landed on
-    # A finger lifting after a long press still produces a click, and under it
-    # is a link: the bullet zooms. So the press that opened the menu eats that
-    # one tap — and only that one, which is what the last two steps are for.
+  Scenario: A finger held on the bullet picks the row up, and does not follow its link
     Given I open the outline "house.jsonl"
-    When I hold a finger on the bullet of "kitchen"
-    Then the node menu is open
-    And the address is "/o/house.jsonl"
+    And I mark the page
+    When I hold a finger on the bullet of "kitchen" and keep it there
+    Then the row "kitchen" is in the air
+    And the node menu is closed
     And no row is being edited
-    When I tap away from the node menu
-    Then the node menu is closed
+    When I let the finger go
+    Then no row is in the air
+    # The click a lift synthesises, eaten: under this finger is an `<a href>`.
+    And the address is "/o/house.jsonl"
+    And the page has not reloaded
+    # ...and only that one. A plain tap is still the navigation it always was.
     When I tap the bullet of "kitchen"
     Then the zoomed node is "kitchen"
+
+  @scratch:good @phone
+  Scenario: A held row follows the finger and lands where it is let go
+    Given I open the outline "house.jsonl"
+    And I mark the page
+    When I hold a finger on the bullet of "knobs" and keep it there
+    And I drag that finger above the title of "handles"
+    Then the drop line would put it under "install"
+    And the drop line would put it first
+    When I let the finger go
+    Then the node "knobs" comes before "handles"
+    And the address is "/o/house.jsonl"
+    And there should be no page errors
+
+  @corpus:good @phone
+  Scenario: A flick that STARTS on the bullet still scrolls the page
+    # The cost this design refused to pay. Claiming the handle with
+    # `touch-action: none` would have passed every scenario above and left a
+    # 28px dead strip down the left of every outline — so the claim is a
+    # non-passive `touchmove` put up at the DEADLINE instead, and a finger that
+    # moved before it never reaches one. Sister of the row's own fence below,
+    # aimed at the one cell that could have broken it.
+    Given I open the outline "house.jsonl"
+    And the screen is shorter than the outline
+    When I flick the bullet of "kitchen" up the screen
+    Then the outline has scrolled
+    And no row is in the air
+    And the node menu is closed
 
   @corpus:good @phone
   Scenario: A tap on an outline entry opens that outline

--- a/packages/tests/step_definitions/dragdrop_steps.ts
+++ b/packages/tests/step_definitions/dragdrop_steps.ts
@@ -40,7 +40,7 @@ import {
   SELECTION_TRASH,
   SWEEP_BAND,
 } from "../support/world.ts";
-import type { OlaiWorld } from "../support/world.ts";
+import type { Box, OlaiWorld } from "../support/world.ts";
 
 /** How far in one level is drawn, near enough: the pointer only has to land
  *  closer to one step than to the next, and the client rounds. */
@@ -50,6 +50,16 @@ const ONE_STEP = 40;
  *  inside the scope too, and the row's own is rendered before any child's. */
 const handleOf = (world: OlaiWorld, id: string) =>
   world.node(id).locator(DRAG_HANDLE).first();
+
+/** Put the pointer on a row's bullet and press. Answers with the box it landed
+ *  on, because every gesture that starts here then travels somewhere measured
+ *  from it. */
+const pressBullet = async (world: OlaiWorld, id: string): Promise<Box> => {
+  const box = await world.box(handleOf(world, id), `the bullet of "${id}"`);
+  await world.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await world.page.mouse.down();
+  return box;
+};
 
 /** Press the bullet and travel to a point, without letting go. The travel is
  *  in STEPS because the client only starts a drag once the pointer has moved
@@ -62,9 +72,7 @@ const carry = async (
   x: number,
   y: number,
 ): Promise<void> => {
-  const box = await world.box(handleOf(world, id), `the bullet of "${id}"`);
-  await world.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-  await world.page.mouse.down();
+  await pressBullet(world, id);
   await world.page.mouse.move(x, y, { steps: 12 });
   await world.page
     .locator(DROP_LINE)
@@ -191,59 +199,76 @@ Then(
   },
 );
 
-// ── the page keeping up ────────────────────────────────────────────────
+// ── picking ────────────────────────────────────────────────────────────
 
-/** How near the bottom of the window a gesture has to be held before the page
- *  starts moving under it. Inside the client's own zone with room to spare —
- *  the number there is a design decision, and a scenario pinned to its exact
- *  value would fail on a change that made the affordance better. */
-const AT_THE_EDGE = 8;
-
-/**
- * A window with somewhere to scroll TO, which no fixture here gives a laptop
- * on its own: the corpora are outlines a person can read inside a scenario.
- *
- * So the WINDOW shrinks rather than the corpus growing — which is a real shape
- * too (a short laptop, a split screen) — and the step asserts what it has just
- * claimed rather than trusting it, exactly as the phone's own version does.
- */
-Given("the window is shorter than the outline", async function (this: OlaiWorld) {
-  await this.page.setViewportSize({ width: 1_100, height: 260 });
+When("I pick the title of {string}", async function (this: OlaiWorld, id: string) {
+  // The modifier-click: adds this row to the pick, or takes it back out.
+  // `ControlOrMeta` is Playwright's own spelling of the platform's modifier,
+  // which is the same split `keys.ts` makes.
+  await this.nodeTitle(id).click({ modifiers: ["ControlOrMeta"] });
   await this.waitForFrame();
-  const room = await this.page.evaluate(() => ({
-    page: document.documentElement.scrollHeight,
-    screen: window.innerHeight,
-    at: window.scrollY,
-  }));
-  assert.ok(
-    room.page > room.screen,
-    `the outline is ${room.page}px in a ${room.screen}px window, so there is nothing to scroll`,
-  );
-  assert.strictEqual(room.at, 0, "this scenario starts at the top of the page");
 });
 
-/** The bottom of the window, at the same x the gesture started at. Held there
- *  long enough for the page to actually move — the scroll is a frame loop, not
- *  a jump, which is what makes it something a hand can steer. */
-const holdAtTheEdge = async (world: OlaiWorld, x: number): Promise<void> => {
-  const view = world.page.viewportSize();
-  assert.ok(view !== null, "this scenario has no viewport size");
-  await world.page.mouse.move(x, view.height - AT_THE_EDGE, { steps: 10 });
-  await world.page.waitForTimeout(700);
-  await world.waitForFrame();
-};
+When("I shift-click the title of {string}", async function (this: OlaiWorld, id: string) {
+  await this.nodeTitle(id).click({ modifiers: ["Shift"] });
+  await this.waitForFrame();
+});
 
-When(
-  "I pick up the bullet of {string} and hold it at the bottom of the window",
-  async function (this: OlaiWorld, id: string) {
-    const box = await this.box(handleOf(this, id), `the bullet of "${id}"`);
-    await this.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-    await this.page.mouse.down();
-    await holdAtTheEdge(this, box.x + ONE_STEP);
-  },
-);
+Then("{int} rows are picked", async function (this: OlaiWorld, many: number) {
+  // The BAR's count rather than the toned rows, because they are two different
+  // claims and this is the one the verbs follow: what a bulk verb is asked of
+  // is the picked rows nothing else picked contains.
+  await this.expectAttribute(
+    SELECTION_BAR,
+    "data-rows",
+    String(many),
+    "the pick",
+  );
+});
 
-// ── picking ────────────────────────────────────────────────────────────
+Then("no rows are picked", async function (this: OlaiWorld) {
+  await this.waitUntil(
+    async () => (await this.page.locator(SELECTION_BAR).count()) === 0,
+    "the pick to be put away",
+  );
+});
+
+Then("the row {string} is picked", async function (this: OlaiWorld, id: string) {
+  await this.expectNodeAttribute(id, "data-picked", "true");
+});
+
+Then("the row {string} is not picked", async function (this: OlaiWorld, id: string) {
+  await this.expectAttributeAbsent(
+    nodeSelector(id),
+    "data-picked",
+    `node "${id}"`,
+  );
+});
+
+Then("the pick says {string}", async function (this: OlaiWorld, said: string) {
+  await saysThat(this, SELECTION_SAID, said, "pick", "alarm");
+});
+
+Then("the pick notes {string}", async function (this: OlaiWorld, said: string) {
+  await saysThat(this, SELECTION_NOTE, said, "pick");
+});
+
+Then("nothing is said about the pick", async function (this: OlaiWorld) {
+  await saysNothing(
+    this,
+    [SELECTION_SAID],
+    "the pick to have nothing said about it",
+  );
+});
+
+Then("the pick is not asking anything", async function (this: OlaiWorld) {
+  // The confirm is about the rows it was opened over, so it must not outlive
+  // them — the bar is always mounted, and only its `Show` goes away.
+  await this.waitUntil(
+    async () => (await this.page.locator(SELECTION_CONFIRM).count()) === 0,
+    "the Trash question to have been put away with its rows",
+  );
+});
 
 // ── drag-across ────────────────────────────────────────────────────────
 //
@@ -368,74 +393,60 @@ Then("the words are selected", async function (this: OlaiWorld) {
   );
 });
 
-When("I pick the title of {string}", async function (this: OlaiWorld, id: string) {
-  // The modifier-click: adds this row to the pick, or takes it back out.
-  // `ControlOrMeta` is Playwright's own spelling of the platform's modifier,
-  // which is the same split `keys.ts` makes.
-  await this.nodeTitle(id).click({ modifiers: ["ControlOrMeta"] });
-  await this.waitForFrame();
+// ── the page keeping up ────────────────────────────────────────────────
+
+/** How near the bottom of the window a gesture has to be held before the page
+ *  starts moving under it. Inside the client's own zone with room to spare —
+ *  the number there is a design decision, and a scenario pinned to its exact
+ *  value would fail on a change that made the affordance better. */
+const AT_THE_EDGE = 8;
+
+/**
+ * A window with somewhere to scroll TO — the WINDOW shrinking rather than the
+ * corpus growing, which is a real shape too (a short laptop, a split screen).
+ *
+ * A separate step from the phone's, because 390px would change the layout a
+ * desktop scenario is testing; the same claim underneath it, because "there is
+ * really something to scroll" is what gives either of them their value
+ * (`support/world.ts`).
+ */
+Given("the window is shorter than the outline", async function (this: OlaiWorld) {
+  await this.shrinkToScroll(SHORT_WINDOW.width, SHORT_WINDOW.height);
 });
 
-When("I shift-click the title of {string}", async function (this: OlaiWorld, id: string) {
-  await this.nodeTitle(id).click({ modifiers: ["Shift"] });
-  await this.waitForFrame();
-});
+/** A laptop with an outline taller than it. Wide enough that the sidebar is
+ *  still a column and the gutter still has its `•••`, so nothing but the height
+ *  is different from every other desktop scenario. */
+const SHORT_WINDOW = { width: 1_100, height: 260 };
 
-Then("{int} rows are picked", async function (this: OlaiWorld, many: number) {
-  // The BAR's count rather than the toned rows, because they are two different
-  // claims and this is the one the verbs follow: what a bulk verb is asked of
-  // is the picked rows nothing else picked contains.
-  await this.expectAttribute(
-    SELECTION_BAR,
-    "data-rows",
-    String(many),
-    "the pick",
+/**
+ * The bottom of the window, at the same x the gesture started at — and held
+ * until the page has actually moved.
+ *
+ * WAITED FOR rather than slept through: the scroll is a frame loop, not a jump
+ * (which is what makes it something a hand can steer), so what a step here has
+ * to do is stay put until it has begun. A flat sleep would be the same wait on
+ * every run, long enough for the slowest, and it would pass silently on a
+ * gesture that scrolled once and stopped.
+ */
+const holdAtTheEdge = async (world: OlaiWorld, x: number): Promise<void> => {
+  const view = world.page.viewportSize();
+  assert.ok(view !== null, "this scenario has no viewport size");
+  await world.page.mouse.move(x, view.height - AT_THE_EDGE, { steps: 10 });
+  await world.waitUntil(
+    async () => (await world.page.evaluate(() => window.scrollY)) > 0,
+    "the page to start moving under the gesture",
   );
-});
+  await world.waitForFrame();
+};
 
-Then("no rows are picked", async function (this: OlaiWorld) {
-  await this.waitUntil(
-    async () => (await this.page.locator(SELECTION_BAR).count()) === 0,
-    "the pick to be put away",
-  );
-});
-
-Then("the row {string} is picked", async function (this: OlaiWorld, id: string) {
-  await this.expectNodeAttribute(id, "data-picked", "true");
-});
-
-Then("the row {string} is not picked", async function (this: OlaiWorld, id: string) {
-  await this.expectAttributeAbsent(
-    nodeSelector(id),
-    "data-picked",
-    `node "${id}"`,
-  );
-});
-
-Then("the pick says {string}", async function (this: OlaiWorld, said: string) {
-  await saysThat(this, SELECTION_SAID, said, "pick", "alarm");
-});
-
-Then("the pick notes {string}", async function (this: OlaiWorld, said: string) {
-  await saysThat(this, SELECTION_NOTE, said, "pick");
-});
-
-Then("nothing is said about the pick", async function (this: OlaiWorld) {
-  await saysNothing(
-    this,
-    [SELECTION_SAID],
-    "the pick to have nothing said about it",
-  );
-});
-
-Then("the pick is not asking anything", async function (this: OlaiWorld) {
-  // The confirm is about the rows it was opened over, so it must not outlive
-  // them — the bar is always mounted, and only its `Show` goes away.
-  await this.waitUntil(
-    async () => (await this.page.locator(SELECTION_CONFIRM).count()) === 0,
-    "the Trash question to have been put away with its rows",
-  );
-});
+When(
+  "I pick up the bullet of {string} and hold it at the bottom of the window",
+  async function (this: OlaiWorld, id: string) {
+    const box = await pressBullet(this, id);
+    await holdAtTheEdge(this, box.x + ONE_STEP);
+  },
+);
 
 // ── the Trash ──────────────────────────────────────────────────────────
 

--- a/packages/tests/step_definitions/dragdrop_steps.ts
+++ b/packages/tests/step_definitions/dragdrop_steps.ts
@@ -23,7 +23,7 @@
 
 import * as assert from "node:assert";
 
-import { Then, When } from "@cucumber/cucumber";
+import { Given, Then, When } from "@cucumber/cucumber";
 
 import { saysNothing, saysThat } from "../support/said.ts";
 import {
@@ -31,12 +31,14 @@ import {
   DROP_LINE,
   NODE,
   nodeSelector,
+  OUTLINE_TREE,
   POLL_TIMEOUT,
   SELECTION_BAR,
   SELECTION_CONFIRM,
   SELECTION_NOTE,
   SELECTION_SAID,
   SELECTION_TRASH,
+  SWEEP_BAND,
 } from "../support/world.ts";
 import type { OlaiWorld } from "../support/world.ts";
 
@@ -189,7 +191,182 @@ Then(
   },
 );
 
+// ── the page keeping up ────────────────────────────────────────────────
+
+/** How near the bottom of the window a gesture has to be held before the page
+ *  starts moving under it. Inside the client's own zone with room to spare —
+ *  the number there is a design decision, and a scenario pinned to its exact
+ *  value would fail on a change that made the affordance better. */
+const AT_THE_EDGE = 8;
+
+/**
+ * A window with somewhere to scroll TO, which no fixture here gives a laptop
+ * on its own: the corpora are outlines a person can read inside a scenario.
+ *
+ * So the WINDOW shrinks rather than the corpus growing — which is a real shape
+ * too (a short laptop, a split screen) — and the step asserts what it has just
+ * claimed rather than trusting it, exactly as the phone's own version does.
+ */
+Given("the window is shorter than the outline", async function (this: OlaiWorld) {
+  await this.page.setViewportSize({ width: 1_100, height: 260 });
+  await this.waitForFrame();
+  const room = await this.page.evaluate(() => ({
+    page: document.documentElement.scrollHeight,
+    screen: window.innerHeight,
+    at: window.scrollY,
+  }));
+  assert.ok(
+    room.page > room.screen,
+    `the outline is ${room.page}px in a ${room.screen}px window, so there is nothing to scroll`,
+  );
+  assert.strictEqual(room.at, 0, "this scenario starts at the top of the page");
+});
+
+/** The bottom of the window, at the same x the gesture started at. Held there
+ *  long enough for the page to actually move — the scroll is a frame loop, not
+ *  a jump, which is what makes it something a hand can steer. */
+const holdAtTheEdge = async (world: OlaiWorld, x: number): Promise<void> => {
+  const view = world.page.viewportSize();
+  assert.ok(view !== null, "this scenario has no viewport size");
+  await world.page.mouse.move(x, view.height - AT_THE_EDGE, { steps: 10 });
+  await world.page.waitForTimeout(700);
+  await world.waitForFrame();
+};
+
+When(
+  "I pick up the bullet of {string} and hold it at the bottom of the window",
+  async function (this: OlaiWorld, id: string) {
+    const box = await this.box(handleOf(this, id), `the bullet of "${id}"`);
+    await this.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await this.page.mouse.down();
+    await holdAtTheEdge(this, box.x + ONE_STEP);
+  },
+);
+
 // ── picking ────────────────────────────────────────────────────────────
+
+// ── drag-across ────────────────────────────────────────────────────────
+//
+// The fifth picking gesture. Where a pull BEGINS is what decides whether it is
+// a sweep or the browser's own text selection (`client/drag/sweeping.ts`), so
+// every step here is really a statement about where it started — the rail
+// beside a branch, the page below the last row, or the words themselves.
+
+/**
+ * The empty strip beside a row: its nearest enclosing list's own padding,
+ * which is scaffolding and holds no words.
+ *
+ * Measured rather than named, because it is not a control and has no testid to
+ * find — it is the indent rail a reader sees, and what makes it pressable is
+ * that nothing else is there.
+ */
+const railBeside = async (
+  world: OlaiWorld,
+  id: string,
+): Promise<{ x: number; y: number }> => {
+  const at = await world.node(id).first().evaluate((row) => {
+    const list = row.parentElement?.closest("ul")
+    const line = row.querySelector("[data-row-key]")
+    if (list === null || list === undefined || line === null) return null
+    const box = list.getBoundingClientRect()
+    const on = line.getBoundingClientRect()
+    return { x: box.x + 4, y: on.y + on.height / 2 }
+  });
+  assert.ok(at !== null, `the row "${id}" is not inside a list with a rail beside it`);
+  return at;
+};
+
+/** The page BELOW the outline — the largest empty surface an editable page
+ *  has, and the one a short tree leaves most of. */
+const belowTheOutline = async (world: OlaiWorld): Promise<{ x: number; y: number }> => {
+  const tree = await world.box(world.page.locator(OUTLINE_TREE).first(), "the outline");
+  return { x: tree.x + ONE_STEP, y: tree.y + tree.height + 24 };
+};
+
+/** Press, travel in steps, and DO NOT let go — the sweep is only a prediction
+ *  while the pointer is down, which is when its band can be asked about. */
+const sweepFrom = async (
+  world: OlaiWorld,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+): Promise<void> => {
+  await world.page.mouse.move(from.x, from.y);
+  await world.page.mouse.down();
+  await world.page.mouse.move(to.x, to.y, { steps: 12 });
+  await world.waitForFrame();
+};
+
+When(
+  "I sweep from beside {string} down to {string}",
+  async function (this: OlaiWorld, from: string, to: string) {
+    const start = await railBeside(this, from);
+    const end = await railBeside(this, to);
+    await sweepFrom(this, start, { x: start.x, y: end.y });
+  },
+);
+
+When(
+  "I sweep from below the outline up to {string}",
+  async function (this: OlaiWorld, to: string) {
+    const start = await belowTheOutline(this);
+    const end = await railBeside(this, to);
+    await sweepFrom(this, start, { x: start.x, y: end.y });
+  },
+);
+
+When(
+  "I sweep from beside {string} to the bottom of the window",
+  async function (this: OlaiWorld, from: string) {
+    const start = await railBeside(this, from);
+    await this.page.mouse.move(start.x, start.y);
+    await this.page.mouse.down();
+    await holdAtTheEdge(this, start.x);
+  },
+);
+
+/** A press on the page that never travels: not a sweep, and still the gesture
+ *  that means "nothing here is picked". */
+When("I press below the outline", async function (this: OlaiWorld) {
+  const at = await belowTheOutline(this);
+  await this.page.mouse.click(at.x, at.y);
+  await this.waitForFrame();
+});
+
+/** A pull that begins IN THE WORDS — the browser's gesture, and the whole of
+ *  what the sweep had to leave alone. Held down, because a released one lands
+ *  as a click on the title and opens the editor over it. */
+When(
+  "I select text across the title of {string}",
+  async function (this: OlaiWorld, id: string) {
+    const box = await this.box(this.nodeTitle(id), `the title of "${id}"`);
+    await this.page.mouse.move(box.x + 4, box.y + box.height / 2);
+    await this.page.mouse.down();
+    await this.page.mouse.move(box.x + box.width - 4, box.y + box.height * 3, { steps: 12 });
+    await this.waitForFrame();
+  },
+);
+
+Then("the band is crossing {int} rows", async function (this: OlaiWorld, many: number) {
+  await this.expectAttribute(SWEEP_BAND, "data-rows", String(many), "the sweep's band");
+});
+
+Then("no band is drawn", async function (this: OlaiWorld) {
+  await this.waitUntil(
+    async () => (await this.page.locator(SWEEP_BAND).count()) === 0,
+    "the sweep's band not to be drawn",
+  );
+});
+
+/** The browser still has its own gesture. Asked of the SELECTION rather than of
+ *  a screenshot: what a sweep would have taken away is the ability to quote a
+ *  line, and that is what `getSelection` answers. */
+Then("the words are selected", async function (this: OlaiWorld) {
+  const said = await this.page.evaluate(() => window.getSelection()?.toString() ?? "");
+  assert.ok(
+    said.trim().length > 0,
+    "the pull selected no text at all — the marquee has taken the browser's own gesture",
+  );
+});
 
 When("I pick the title of {string}", async function (this: OlaiWorld, id: string) {
   // The modifier-click: adds this row to the pick, or takes it back out.

--- a/packages/tests/step_definitions/menu_steps.ts
+++ b/packages/tests/step_definitions/menu_steps.ts
@@ -117,14 +117,11 @@ When(
   },
 );
 
-/** The same, on the row's BULLET — which is a link, so a press that leaked
- *  through as a tap would navigate. */
-When(
-  "I hold a finger on the bullet of {string}",
-  async function (this: OlaiWorld, id: string) {
-    await this.hold(this.within(id, ZOOM));
-  },
-);
+// There is no "hold a finger on the BULLET" step here any more, and its absence
+// is the ruling: the bullet is the handle a finger picks a row up by
+// (`client/drag/dragging.ts`), so holding it opens no menu. What that gesture
+// does now is `phone_steps.ts`'s — "…and keep it there", because a drag is what
+// the finger does after the deadline.
 
 /** UP, and the panel is really on screen: `visible`, not merely mounted. */
 Then("the node menu is open", async function (this: OlaiWorld) {

--- a/packages/tests/step_definitions/phone_steps.ts
+++ b/packages/tests/step_definitions/phone_steps.ts
@@ -126,29 +126,22 @@ When("I flick the bullet of {string} up the screen", async function (this: OlaiW
 // down, held, moved — and a scenario has to be able to stop between them
 // (`client/drag/dragging.ts`, `support/world.ts`'s `holdDown`).
 
-/** Where the finger that is currently down went in. Held across steps because
- *  a drag is measured from where it started, and cucumber's `this` is the only
- *  thing that lives that long. */
-let finger: { readonly x: number; readonly y: number } | undefined;
-
 When(
   "I hold a finger on the bullet of {string} and keep it there",
   async function (this: OlaiWorld, id: string) {
-    finger = await this.holdDown(this.within(id, ZOOM));
+    await this.holdDown(this.within(id, ZOOM));
   },
 );
 
 When(
   "I drag that finger above the title of {string}",
   async function (this: OlaiWorld, id: string) {
-    assert.ok(finger !== undefined, "no finger is down to drag");
     const box = await this.box(this.nodeTitle(id), `the title of "${id}"`);
-    await this.dragFinger(finger, { x: box.x + 4, y: box.y - 2 });
+    await this.dragFinger({ x: box.x + 4, y: box.y - 2 });
   },
 );
 
 When("I let the finger go", async function (this: OlaiWorld) {
-  finger = undefined;
   await this.letGo();
 });
 

--- a/packages/tests/step_definitions/phone_steps.ts
+++ b/packages/tests/step_definitions/phone_steps.ts
@@ -168,18 +168,7 @@ Then("no row is in the air", async function (this: OlaiWorld) {
  * leave the scenario after it passing over nothing.
  */
 Given("the screen is shorter than the outline", async function (this: OlaiWorld) {
-  await this.page.setViewportSize({ width: PHONE_WIDTH, height: SHORT_PHONE_HEIGHT });
-  await this.waitForFrame();
-  const room = await this.page.evaluate(() => ({
-    page: document.documentElement.scrollHeight,
-    screen: window.innerHeight,
-    at: window.scrollY,
-  }));
-  assert.ok(
-    room.page > room.screen,
-    `the outline is ${room.page}px on a ${room.screen}px screen, so there is nothing to scroll`,
-  );
-  assert.strictEqual(room.at, 0, "this scenario starts at the top of the page");
+  await this.shrinkToScroll(PHONE_WIDTH, SHORT_PHONE_HEIGHT);
 });
 
 /** It MOVED, which is the half that no assertion about the menu can carry: a

--- a/packages/tests/step_definitions/phone_steps.ts
+++ b/packages/tests/step_definitions/phone_steps.ts
@@ -111,6 +111,58 @@ When("I flick the node {string} up the screen", async function (this: OlaiWorld,
   await this.flick(this.within(id, NODE_GUTTER));
 });
 
+/** The same gesture aimed at the BULLET — the cell a finger picks a row up by
+ *  (`client/drag/Handle.tsx`), and therefore the one place a claimed gesture
+ *  could have cost a reader the page. A flick that starts here must still
+ *  scroll, which is what makes the claim a long press rather than a style. */
+When("I flick the bullet of {string} up the screen", async function (this: OlaiWorld, id: string) {
+  await this.flick(this.within(id, ZOOM));
+});
+
+// ── picking a row up with a finger ─────────────────────────────────────
+//
+// The touch half of drag-and-drop. A press is WATCHED until the deadline and
+// only then claimed, so every one of these is a real gesture in three parts —
+// down, held, moved — and a scenario has to be able to stop between them
+// (`client/drag/dragging.ts`, `support/world.ts`'s `holdDown`).
+
+/** Where the finger that is currently down went in. Held across steps because
+ *  a drag is measured from where it started, and cucumber's `this` is the only
+ *  thing that lives that long. */
+let finger: { readonly x: number; readonly y: number } | undefined;
+
+When(
+  "I hold a finger on the bullet of {string} and keep it there",
+  async function (this: OlaiWorld, id: string) {
+    finger = await this.holdDown(this.within(id, ZOOM));
+  },
+);
+
+When(
+  "I drag that finger above the title of {string}",
+  async function (this: OlaiWorld, id: string) {
+    assert.ok(finger !== undefined, "no finger is down to drag");
+    const box = await this.box(this.nodeTitle(id), `the title of "${id}"`);
+    await this.dragFinger(finger, { x: box.x + 4, y: box.y - 2 });
+  },
+);
+
+When("I let the finger go", async function (this: OlaiWorld) {
+  finger = undefined;
+  await this.letGo();
+});
+
+Then("the row {string} is in the air", async function (this: OlaiWorld, id: string) {
+  await this.expectNodeAttribute(id, "data-carried", "true");
+});
+
+Then("no row is in the air", async function (this: OlaiWorld) {
+  await this.waitUntil(
+    async () => (await this.page.locator('[data-carried="true"]').count()) === 0,
+    "every row to be back on the page",
+  );
+});
+
 /**
  * A page with somewhere to scroll TO, which no fixture in this suite gives a
  * handset on its own: the corpora are outlines a person can read inside a

--- a/packages/tests/support/world.ts
+++ b/packages/tests/support/world.ts
@@ -1045,18 +1045,24 @@ export class OlaiWorld extends World {
    * Answers with where the finger is, because everything after this is measured
    * from it.
    */
-  async holdDown(target: Locator): Promise<Point> {
-    const at = await this.middleOf(target, "held");
-    await this.finger("touchStart", at);
+  async holdDown(target: Locator): Promise<void> {
+    this.held = await this.middleOf(target, "held");
+    await this.finger("touchStart", this.held);
     await this.page.waitForTimeout(LONG_PRESS_MS + LONG_PRESS_MARGIN_MS);
     await this.waitForFrame();
-    return at;
   }
 
   /** Move the finger that is already down, in steps rather than in one jump —
    *  a hand makes a path, and a gesture that arrived as a single event would
-   *  pass over the frames the affordance is drawn in. */
-  async dragFinger(from: Point, to: Point, steps = 10): Promise<void> {
+   *  pass over the frames the affordance is drawn in.
+   *
+   *  WHERE IT STARTED IS THE WORLD'S, not a step's: a drag is three steps and
+   *  the path is measured from the press, so the alternative is a step file
+   *  keeping the point in a module-global — one per worker, outliving the
+   *  scenario that put it there. */
+  async dragFinger(to: Point, steps = 10): Promise<void> {
+    const from = this.held;
+    assert.ok(from !== undefined, "no finger is down to drag");
     for (let step = 1; step <= steps; step++) {
       await this.finger("touchMove", {
         x: from.x + ((to.x - from.x) * step) / steps,
@@ -1069,9 +1075,15 @@ export class OlaiWorld extends World {
 
   /** ...and let it go, which for a drag is the drop. */
   async letGo(): Promise<void> {
+    this.held = undefined;
     await this.finger("touchEnd");
     await this.waitForFrame();
   }
+
+  /** Where the finger that is currently down went in, for as long as it is
+   *  down. `undefined` between gestures, which is what makes "no finger is down
+   *  to drag" an assertion rather than a stale point from the last scenario. */
+  private held?: Point;
 
   /**
    * A finger that lands on something and then SCROLLS the page with it.

--- a/packages/tests/support/world.ts
+++ b/packages/tests/support/world.ts
@@ -1026,24 +1026,20 @@ export class OlaiWorld extends World {
    * every scenario here into a tap.
    */
   async hold(target: Locator): Promise<void> {
-    const at = await this.middleOf(target, "held");
-    await this.finger("touchStart", at);
-    await this.page.waitForTimeout(LONG_PRESS_MS + LONG_PRESS_MARGIN_MS);
-    await this.finger("touchEnd");
-    await this.waitForFrame();
+    await this.holdDown(target);
+    await this.letGo();
   }
 
   /**
-   * HOLD a finger, and KEEP IT DOWN — the first half of a touch drag.
+   * HOLD a finger, and KEEP IT DOWN — the first half of a touch drag, and the
+   * first half of {@link hold} above.
    *
-   * {@link hold} is this plus the lift, and the two cannot be one step: a drag
-   * is what the finger does AFTER the deadline, so a scenario about one has to
-   * be able to stop between them. What the client does at that moment is lift
-   * the row (`client/drag/dragging.ts`), which is a state on the page a step
-   * can then assert before anything has moved.
-   *
-   * Answers with where the finger is, because everything after this is measured
-   * from it.
+   * The two cannot be one method: a drag is what the finger does AFTER the
+   * deadline, so a scenario about one has to be able to stop between them —
+   * what the client does at that moment is lift the row
+   * (`client/drag/dragging.ts`), which is a state on the page a step can assert
+   * before anything has moved. But the deadline is one number and one wait, so
+   * the shorter gesture is written in terms of this one rather than beside it.
    */
   async holdDown(target: Locator): Promise<void> {
     this.held = await this.middleOf(target, "held");
@@ -1071,6 +1067,34 @@ export class OlaiWorld extends World {
       await this.page.waitForTimeout(20);
     }
     await this.waitForFrame();
+  }
+
+  /**
+   * Shrink the viewport until the page has somewhere to scroll TO, and say so
+   * if it has not.
+   *
+   * No fixture in this suite is taller than a screen on its own — the corpora
+   * are outlines a person can read inside a scenario — so every scenario about
+   * the page MOVING has to make its own room, and two of them do (a phone, and
+   * a short laptop). The dimensions are each caller's, because 390px would
+   * change the layout a desktop scenario is testing; the ASSERTION is not, and
+   * it is the half that gives those steps their value: a fixture that grew past
+   * one of the two heights, or a layout that stopped scrolling the document,
+   * would otherwise leave the scenario after it passing over nothing.
+   */
+  async shrinkToScroll(width: number, height: number): Promise<void> {
+    await this.page.setViewportSize({ width, height });
+    await this.waitForFrame();
+    const room = await this.page.evaluate(() => ({
+      page: document.documentElement.scrollHeight,
+      screen: window.innerHeight,
+      at: window.scrollY,
+    }));
+    assert.ok(
+      room.page > room.screen,
+      `the outline is ${room.page}px on a ${room.screen}px screen, so there is nothing to scroll`,
+    );
+    assert.strictEqual(room.at, 0, "this scenario starts at the top of the page");
   }
 
   /** ...and let it go, which for a drag is the drop. */

--- a/packages/tests/support/world.ts
+++ b/packages/tests/support/world.ts
@@ -318,6 +318,10 @@ export const DRAG_HANDLE = selector(TESTID.dragHandle);
  *  being dragged. `data-parent`, `data-after` and `data-depth` are what it
  *  PROMISES, which is a prediction right up until the pointer is released. */
 export const DROP_LINE = selector(TESTID.dropLine);
+/** The band a drag-across pulls — present only while one is being pulled.
+ *  `data-rows` is how many rows it is crossing, which is the half of the
+ *  gesture that is still a prediction while the pointer is down. */
+export const SWEEP_BAND = selector(TESTID.sweepBand);
 /** The bar a multi-selection draws. `data-rows` is the count the bulk verbs
  *  are asked of — the picked rows nothing else picked contains. */
 export const SELECTION_BAR = selector(TESTID.selectionBar);
@@ -1025,6 +1029,46 @@ export class OlaiWorld extends World {
     const at = await this.middleOf(target, "held");
     await this.finger("touchStart", at);
     await this.page.waitForTimeout(LONG_PRESS_MS + LONG_PRESS_MARGIN_MS);
+    await this.finger("touchEnd");
+    await this.waitForFrame();
+  }
+
+  /**
+   * HOLD a finger, and KEEP IT DOWN — the first half of a touch drag.
+   *
+   * {@link hold} is this plus the lift, and the two cannot be one step: a drag
+   * is what the finger does AFTER the deadline, so a scenario about one has to
+   * be able to stop between them. What the client does at that moment is lift
+   * the row (`client/drag/dragging.ts`), which is a state on the page a step
+   * can then assert before anything has moved.
+   *
+   * Answers with where the finger is, because everything after this is measured
+   * from it.
+   */
+  async holdDown(target: Locator): Promise<Point> {
+    const at = await this.middleOf(target, "held");
+    await this.finger("touchStart", at);
+    await this.page.waitForTimeout(LONG_PRESS_MS + LONG_PRESS_MARGIN_MS);
+    await this.waitForFrame();
+    return at;
+  }
+
+  /** Move the finger that is already down, in steps rather than in one jump —
+   *  a hand makes a path, and a gesture that arrived as a single event would
+   *  pass over the frames the affordance is drawn in. */
+  async dragFinger(from: Point, to: Point, steps = 10): Promise<void> {
+    for (let step = 1; step <= steps; step++) {
+      await this.finger("touchMove", {
+        x: from.x + ((to.x - from.x) * step) / steps,
+        y: from.y + ((to.y - from.y) * step) / steps,
+      });
+      await this.page.waitForTimeout(20);
+    }
+    await this.waitForFrame();
+  }
+
+  /** ...and let it go, which for a drag is the drop. */
+  async letGo(): Promise<void> {
     await this.finger("touchEnd");
     await this.waitForFrame();
   }

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1634,17 +1634,65 @@ The pieces, and what each decides:
   does. A pick holding a PLACEMENT is not offered it and is told why, rather
   than being silently three-quarters archived.
 
-Dragging is a mouse-or-pen gesture. A touch drag on a bullet would have to claim
-the gesture that scrolls the page (`touch-action: none`), and getting that wrong
-costs a phone reader the ability to scroll past an outline — the `•••` menu is
-already a pointer-device affordance for the same kind of reason. A long-press is
-the obvious answer and is a decision rather than a line of code.
+- **`drag/sweeping.ts` + `drag/sweep.ts` — drag-across, and the argument it had
+  to settle.** Press-and-pull over a tree of prose already MEANS something (the
+  browser selects text), so shipping a marquee is deciding which of the two a
+  given pull is. The decision is one sentence and it has no modifier and no
+  state: **where the pull BEGINS decides.** On the words it is the browser's,
+  untouched, including a selection that runs down through three rows; on the
+  outline's own scaffolding — the indent rails, the strip left of a note, the
+  page below the last row — it is a pick, because there is nothing else there
+  for it to be about. The scaffolding says so itself (`data-sweep`, an
+  ALLOWLIST: a control added to a row tomorrow inherits "the browser keeps it",
+  which is the safe answer, where a blocklist would quietly turn it into empty
+  space). Nothing is `preventDefault`ed to win the argument — that would take
+  the FOCUS with it and leave a draft that never blurred; what suppresses the
+  text selection is the `user-select` guard `pointer.ts` already puts up for the
+  panel edges.
+- **it is a BAND, not a rubber-band box**, and that is `sweep.ts`'s one real
+  decision. A row is a LINE drawn as far in as its depth says, so a rectangle
+  down the left of the page would cross a root and miss the grandchild indented
+  past its right edge — a rule about pixels pretending to be a rule about the
+  tree. So the sweep reads Y and spans the rows' own width, and the band DRAWN
+  is exactly the shape the answer was computed from. What comes out is a
+  contiguous run with its two ends named, which is why it lands on the selection
+  as one `across` — a sweep is a range gesture, and a Shift-click after one
+  measures from where the pull started.
+- **`autoscroll.ts` — the page keeping up.** Both gestures aim at rows and an
+  outline is longer than a window nearly always, so without this the reach of
+  either is "whatever was on screen when the press landed". The pointer is read
+  in CLIENT coordinates (how near an edge it is, a question about the window)
+  and reported in DOCUMENT ones (where the gesture is, a question about the
+  page, and both callers measured their rows once in document coordinates) — so
+  a pointer held still inside a zone keeps producing new answers with no
+  `pointermove` behind them, which is exactly the behaviour and exactly what a
+  caller that re-planned only on `pointermove` would get wrong. The speed ramps
+  with how deep into the zone the pointer is: a constant one bolts the instant a
+  hand strays near the edge.
 
-Two more things a reader will look for and not find: **auto-scroll while
-dragging near the edge of the window** (the gesture works on what is on screen),
-and **a rubber-band drag across rows** — Workflowy's fifth picking gesture. The
-other four are here; that one wants a marquee over a tree that also has text
-selection in it, which is its own design.
+**A finger holds the bullet first.** The gesture a phone already owns on a row
+is the page scrolling under it, so a drag that took the first pixel of travel
+would cost a reader the ability to read. What claims a gesture honestly on a
+handset is a LONG PRESS — the call `longPress.ts` already made for the `•••`
+menu, and the same primitive is spent again here. Two details carry the whole
+claim:
+
+- **the handle is the BULLET**, which is what a mouse and a pen have always
+  dragged from: one handle on three devices rather than a fourth thing to learn.
+  What it costs is that the bullet is no longer a second door to the `•••` menu
+  — two long presses cannot both own one press, and the one that gives way is
+  the menu, because the menu has a whole row to be reached from and a handle has
+  only itself. The row's door is told to stand down by looking at where the
+  press LANDED (`drag/Handle.tsx`'s `HANDLE`) rather than by a `stopPropagation`
+  resting on Solid's delegation order.
+- **the scroll is claimed at the DEADLINE, not at the press.** A
+  `touch-action: none` on the handle would pass every scenario and leave a 28px
+  dead strip down the left of every outline; a non-passive `touchmove` listener
+  put up at the moment the row lifts claims exactly the gesture the browser has
+  already agreed is not a scroll — a finger that had drifted would have taken
+  the deadline with it, and one the browser took to scroll with would have
+  cancelled the pointer. `on_a_phone.feature` holds both halves: a flick that
+  STARTS on a bullet still scrolls.
 
 ## Three characters that open something
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1660,6 +1660,19 @@ The pieces, and what each decides:
   the FOCUS with it and leave a draft that never blurred; what suppresses the
   text selection is the `user-select` guard `pointer.ts` already puts up for the
   panel edges.
+- **the allowlist is read TWICE, not doubled.** A press on the scaffolding also
+  puts the pick away, and a press on anything else is about that thing: a caret
+  clears the pick where every caret comes from (`edit/editing.tsx`'s `open`),
+  and a control — a checkbox, a triangle, the `•••` — is aimed at the row rather
+  than at nothing, so it keeps it.
+- **the outline needs a rail at depth 0** (`touch.ts`'s `ROOT_RAIL`), which is
+  the one place review found the allowlist short. A nested list gives its branch
+  a pressable strip for free — the padding it indents by — but the outline's own
+  list was flush, so beside a ROOT row the only empty space was the four pixels
+  between two lines: on a flat inbox the one sweep the gesture could not make
+  was a prefix of it, which is the first thing a Workflowy hand tries. The rail
+  comes out of the PANE's padding (the negative margin and the padding are the
+  same number), so it exists at depth 0 and nothing moved by a pixel.
 - **it is a BAND, not a rubber-band box**, and that is `sweep.ts`'s one real
   decision. A row is a LINE drawn as far in as its depth says, so a rectangle
   down the left of the page would cross a root and miss the grandchild indented

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1591,10 +1591,21 @@ The pieces, and what each decides:
   a branch inside itself" is true by construction rather than by a guard — and
   what is left is still a tree, so the walk back for an ancestor always finds
   one.
+- **`drag/lines.ts` — a drawn row's LINE, measured, said once.** Both gestures
+  begin by asking the page the same question (where are the lines, in
+  coordinates that survive a scroll) and each had its own answer, with the drag
+  owning the attribute name and the sweep importing it from there — which said
+  that measuring a row belongs to dragging one. It belongs to the ROW. The mark
+  is on the row's own line and not on its `<li>`, whose box is a subtree's; the
+  coordinates are the DOCUMENT's, so the answer survives the page moving under a
+  live gesture and the affordances can be positioned against the page. `Placed`
+  is that line PLUS the four things a placement needs, rather than a second flat
+  record that happens to share five fields.
 - **`src/client/pointer.ts` — the gesture itself, which is not the outline's.**
   Window listeners (a pointer that leaves the handle is still dragging it), a
-  teardown on every way a gesture can end, the text-selection guard, and the
-  threshold that tells a drag from a click. It was written once for the panel
+  teardown on every way a gesture can end, the text-selection guard, the
+  threshold that tells a drag from a click, and — opt-in, via `onPage` — the
+  page KEEPING UP. It was written once for the panel
   edges (`layout/resize.ts`) and was about to be written a second time, which is
   the moment it becomes a thing rather than a habit; what stayed in each caller
   is the only part that is about a width or about a placement. It holds the
@@ -1668,7 +1679,11 @@ The pieces, and what each decides:
   `pointermove` behind them, which is exactly the behaviour and exactly what a
   caller that re-planned only on `pointermove` would get wrong. The speed ramps
   with how deep into the zone the pointer is: a constant one bolts the instant a
-  hand strays near the edge.
+  hand strays near the edge. **Spent through `pointer.ts`'s `onPage`** rather
+  than wired per caller: it is a paired obligation (feed it, and stop it on
+  every way a gesture can end), which is exactly the kind of thing that module
+  took over for the panel edges — and opt-in, because a panel edge scrolling the
+  outline behind it would be this used by accident.
 
 **A finger holds the bullet first.** The gesture a phone already owns on a row
 is the page scrolling under it, so a drag that took the first pixel of travel

--- a/packages/web/src/client/Tree.tsx
+++ b/packages/web/src/client/Tree.tsx
@@ -68,7 +68,8 @@ import { createMemo, createSignal, Match, Show, Switch } from "solid-js"
 import { blockedIds, WAITING_DIM } from "./blocked.ts"
 import { Bullet } from "./Bullet.tsx"
 import { Checkbox } from "./Checkbox.tsx"
-import { ROW_KEY, useDragging } from "./drag/dragging.ts"
+import { useDragging } from "./drag/dragging.ts"
+import { ROW_KEY } from "./drag/lines.ts"
 import { HANDLE, Handle } from "./drag/Handle.tsx"
 import { useSelection } from "./select/selection.ts"
 import { DatePicker } from "./date/DatePicker.tsx"
@@ -361,9 +362,10 @@ function Branch(props: {
           "opacity-40": carried(),
         }}
         data-testid={TESTID.nodeGutter}
-        // What a drag measures. On the LINE and not on the item, because an
-        // item's box contains every row nested under it and the gap arithmetic
-        // is about the lines a reader sees (`./drag/dragging.ts`).
+        // What a gesture measures — a drag's gaps, a sweep's crossings. On the
+        // LINE and not on the item, because an item's box contains every row
+        // nested under it and both are about the lines a reader sees
+        // (`./drag/lines.ts`).
         {...{ [ROW_KEY]: props.row.key }}
       >
         {/* Hover strip: triangle always (phone) / hover-reveal (pointer). The

--- a/packages/web/src/client/Tree.tsx
+++ b/packages/web/src/client/Tree.tsx
@@ -69,8 +69,7 @@ import { blockedIds, WAITING_DIM } from "./blocked.ts"
 import { Bullet } from "./Bullet.tsx"
 import { Checkbox } from "./Checkbox.tsx"
 import { useDragging } from "./drag/dragging.ts"
-import { ROW_KEY } from "./drag/lines.ts"
-import { HANDLE, Handle } from "./drag/Handle.tsx"
+import { Handle } from "./drag/Handle.tsx"
 import { useSelection } from "./select/selection.ts"
 import { DatePicker } from "./date/DatePicker.tsx"
 import { datePick } from "./date/pick.ts"
@@ -326,23 +325,16 @@ function Branch(props: {
         // only, so a mouse and a pen are untouched — and so is the page, which
         // goes on scrolling under a finger that moves (./longPress.ts).
         //
-        // ...EXCEPT ON THE BULLET, which is the handle a finger picks the row
-        // up by (./drag/Handle.tsx). Two long presses cannot both own one
-        // press, and the one that gives way is this door, because the menu has
-        // a whole row to be reached from and a handle has only itself. Asked of
-        // where the press LANDED rather than left to Solid's delegation order.
+        // ...except on the BULLET, which is the handle a finger picks the row
+        // up by — and that exception is the door's own (./menu/door.ts), not
+        // this row's, so what is wired here is still one thing.
         //
         // Named one by one rather than spread: a spread anywhere on an element
         // moves EVERY attribute of it onto Solid's runtime `spread` path,
         // where the `classList` beside them is diffed key by key on every
         // frame the store publishes — for every row in the outline. The two
         // handlers are the whole of `LongPress`.
-        onPointerDown={(event) => {
-          if (event.target instanceof Element && event.target.closest(`[${HANDLE}]`) !== null) {
-            return
-          }
-          menu.hold.onPointerDown(event)
-        }}
+        onPointerDown={menu.hold.onPointerDown}
         onContextMenu={menu.hold.onContextMenu}
         // Two ways of being THE row, drawn in one accent and told apart by
         // weight: the caret fills its row, a reference outlines the row it
@@ -365,8 +357,17 @@ function Branch(props: {
         // What a gesture measures — a drag's gaps, a sweep's crossings. On the
         // LINE and not on the item, because an item's box contains every row
         // nested under it and both are about the lines a reader sees
-        // (`./drag/lines.ts`).
-        {...{ [ROW_KEY]: props.row.key }}
+        // (`./drag/lines.ts`, whose `ROW_KEY` this is; ./claims.test.ts holds
+        // the two files that may spell it).
+        //
+        // Written out rather than spread from that constant, which is the same
+        // rule `data-sweep` above follows and matters MOST here: this element
+        // carries the `classList` beside it, and a spread anywhere on it puts
+        // every attribute — those two toggles included — on Solid's runtime
+        // spread path, diffed key by key on every frame the store publishes,
+        // for every row in the outline. A static attribute NAME with a dynamic
+        // value is compiled to one `setAttribute` effect instead.
+        data-row-key={props.row.key}
       >
         {/* Hover strip: triangle always (phone) / hover-reveal (pointer). The
             `•••` is drawn on pointer devices only; below md its root is still

--- a/packages/web/src/client/Tree.tsx
+++ b/packages/web/src/client/Tree.tsx
@@ -99,6 +99,7 @@ import {
   HOVER_GUTTER,
   HOVER_REVEAL,
   PAST_CONTROLS,
+  ROOT_RAIL,
   ROW_TITLE,
 } from "./touch.ts"
 import { applying } from "./writes.ts"
@@ -112,8 +113,23 @@ export function Tree(props: {
   // selection. Spelled as a literal for the reason that constant gives (a JSX
   // spread would put every `data-` fact a row carries on Solid's runtime spread
   // path), and held to the name by ./claims.test.ts.
+  //
+  // `ROOT_RAIL` is what gives the outline's own list the strip a nested one has
+  // by having children indent into it (./touch.ts): without it the only empty
+  // space beside a ROOT row is the four pixels between two lines, and a flat
+  // inbox is a page whose first rows cannot be swept to (review, 2026-08-14).
+  // `my-0` and no `m-0`/`p-0`: the shorthands would be racing `ROOT_RAIL`'s own
+  // `-ml-*`/`pl-*` for the same two properties, and which wins is Tailwind's
+  // emission order rather than the order they are written in (./touch.ts's
+  // `MENU_CELL` is where this app learnt that). What the shorthands were for is
+  // the browser's own list defaults — a vertical margin, which `my-0` kills,
+  // and a 40px `padding-inline-start`, which the rail's own padding replaces.
   return (
-    <ul class="m-0 list-none p-0" data-sweep="" data-testid={TESTID.outlineTree}>
+    <ul
+      class={`my-0 list-none ${ROOT_RAIL}`}
+      data-sweep=""
+      data-testid={TESTID.outlineTree}
+    >
       {/* `<Key>`, not `<For>`, and `Row.key` is why it can be: the walk mints
           fresh rows on every frame the live store publishes, and `<For>`
           compares by reference — so one character changing in one title on

--- a/packages/web/src/client/Tree.tsx
+++ b/packages/web/src/client/Tree.tsx
@@ -69,7 +69,7 @@ import { blockedIds, WAITING_DIM } from "./blocked.ts"
 import { Bullet } from "./Bullet.tsx"
 import { Checkbox } from "./Checkbox.tsx"
 import { ROW_KEY, useDragging } from "./drag/dragging.ts"
-import { Handle } from "./drag/Handle.tsx"
+import { HANDLE, Handle } from "./drag/Handle.tsx"
 import { useSelection } from "./select/selection.ts"
 import { DatePicker } from "./date/DatePicker.tsx"
 import { datePick } from "./date/pick.ts"
@@ -106,8 +106,14 @@ import { applying } from "./writes.ts"
 export function Tree(props: {
   readonly rows: ReadonlyArray<Row>
 }) {
+  // `data-sweep` below is `./drag/sweeping.ts`'s `SWEEP`: these lists hold rows
+  // and never words, so a press that lands on ONE — the gaps between lines, the
+  // indent rail beside a branch — is a drag-across rather than a text
+  // selection. Spelled as a literal for the reason that constant gives (a JSX
+  // spread would put every `data-` fact a row carries on Solid's runtime spread
+  // path), and held to the name by ./claims.test.ts.
   return (
-    <ul class="m-0 list-none p-0" data-testid={TESTID.outlineTree}>
+    <ul class="m-0 list-none p-0" data-sweep="" data-testid={TESTID.outlineTree}>
       {/* `<Key>`, not `<For>`, and `Row.key` is why it can be: the walk mints
           fresh rows on every frame the live store publishes, and `<For>`
           compares by reference — so one character changing in one title on
@@ -271,6 +277,11 @@ function Branch(props: {
   return (
     <li
       class="my-0.5"
+      // The item's own box is scaffolding too — the indent strip beside a
+      // child list, the margin left of a note — so a press there is a sweep
+      // (./drag/sweeping.ts). Everything WITH words in it is a descendant and
+      // wears no such mark, which is what keeps the rule an allowlist.
+      data-sweep=""
       data-testid={TESTID.node}
       data-node-id={props.row.at.node.id}
       data-status={props.row.status}
@@ -314,12 +325,23 @@ function Branch(props: {
         // only, so a mouse and a pen are untouched — and so is the page, which
         // goes on scrolling under a finger that moves (./longPress.ts).
         //
+        // ...EXCEPT ON THE BULLET, which is the handle a finger picks the row
+        // up by (./drag/Handle.tsx). Two long presses cannot both own one
+        // press, and the one that gives way is this door, because the menu has
+        // a whole row to be reached from and a handle has only itself. Asked of
+        // where the press LANDED rather than left to Solid's delegation order.
+        //
         // Named one by one rather than spread: a spread anywhere on an element
         // moves EVERY attribute of it onto Solid's runtime `spread` path,
         // where the `classList` beside them is diffed key by key on every
         // frame the store publishes — for every row in the outline. The two
         // handlers are the whole of `LongPress`.
-        onPointerDown={menu.hold.onPointerDown}
+        onPointerDown={(event) => {
+          if (event.target instanceof Element && event.target.closest(`[${HANDLE}]`) !== null) {
+            return
+          }
+          menu.hold.onPointerDown(event)
+        }}
         onContextMenu={menu.hold.onContextMenu}
         // Two ways of being THE row, drawn in one accent and told apart by
         // weight: the caret fills its row, a reference outlines the row it
@@ -549,7 +571,7 @@ function Branch(props: {
       </Show>
 
       <Show when={!collapsed() && props.row.children.length > 0}>
-        <ul class={CHILD_INDENT}>
+        <ul class={CHILD_INDENT} data-sweep="">
           <Key each={props.row.children} by="key">
             {(child) => <Branch row={child()} />}
           </Key>

--- a/packages/web/src/client/autoscroll.test.ts
+++ b/packages/web/src/client/autoscroll.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The edge zones' arithmetic — the sign, the ramp, and what happens PAST the
+ * edge, which is the case a naive ratio gets wrong and a mouse cannot easily
+ * be made to try.
+ *
+ * A 1000px window with 100px zones throughout, so every number below reads as
+ * a fraction without arithmetic.
+ */
+
+import { describe, expect, test } from "bun:test"
+
+import { edgeSpeed } from "./autoscroll.ts"
+
+const HEIGHT = 1_000
+const ZONE = 100
+const FASTEST = 10
+
+const speed = (y: number): number => edgeSpeed(y, HEIGHT, ZONE, FASTEST)
+
+describe("edgeSpeed", () => {
+  test("the middle of the window is not an edge", () => {
+    expect(speed(500)).toBe(0)
+  })
+
+  test("just inside a zone is a nudge, not a bolt", () => {
+    // The whole reason the speed ramps: a constant one makes the page run away
+    // the instant a hand strays near the bottom of the screen.
+    expect(speed(HEIGHT - ZONE + 1)).toBeCloseTo(0.1, 5)
+    expect(speed(ZONE - 1)).toBeCloseTo(-0.1, 5)
+  })
+
+  test("the edge itself is the fastest it goes", () => {
+    expect(speed(0)).toBe(-FASTEST)
+    expect(speed(HEIGHT)).toBe(FASTEST)
+  })
+
+  test("up is negative and down is positive", () => {
+    expect(speed(20)).toBeLessThan(0)
+    expect(speed(HEIGHT - 20)).toBeGreaterThan(0)
+  })
+
+  test("a pointer dragged OFF the window is at full speed, never past it", () => {
+    // The gesture a person actually makes when the row they want is a screen
+    // away: they keep pulling. Without the clamp this is an unbounded speed,
+    // and one frame of it jumps the page by more than a screen.
+    expect(speed(-500)).toBe(-FASTEST)
+    expect(speed(HEIGHT + 500)).toBe(FASTEST)
+  })
+
+  test("on a window shorter than two zones, the nearer edge wins", () => {
+    // 120px tall with 100px zones: every point is in both. A rule that checked
+    // the top first would make the bottom half of such a window scroll UP.
+    expect(edgeSpeed(10, 120, ZONE, FASTEST)).toBeLessThan(0)
+    expect(edgeSpeed(110, 120, ZONE, FASTEST)).toBeGreaterThan(0)
+  })
+
+  test("the boundary of a zone is not yet in it", () => {
+    expect(speed(ZONE)).toBe(0)
+    expect(speed(HEIGHT - ZONE)).toBe(0)
+  })
+})

--- a/packages/web/src/client/autoscroll.ts
+++ b/packages/web/src/client/autoscroll.ts
@@ -29,6 +29,14 @@
  * Nothing here is armed unless a gesture asks for it: the frame loop starts on
  * the first report inside a zone and stops the moment the pointer leaves one,
  * so a page nobody is dragging over schedules nothing.
+ *
+ * WHY THIS IS HAND-ROLLED, which HACKING.md's SolidJS rule makes the first
+ * question to answer: nothing in the ecosystem ships it.
+ * `@solid-primitives/scroll` reports where a page IS and
+ * `@solid-primitives/gestures` is pan, pinch, rotate, swipe and tap — neither
+ * moves a page to follow a gesture, and the drag libraries that do own the
+ * whole drag (a sortable LIST, flat, one container), which is the shape neither
+ * consumer here has (`./pointer.ts` makes the same call one layer down).
  */
 
 /** How deep the zone at each edge of the window is. About two rows' worth —
@@ -60,6 +68,10 @@ const FASTEST_PX = 14
 export const edgeSpeed = (
   y: number,
   height: number,
+  /** The two numbers above, injectable — and ONLY so the rules can be tested at
+   *  a scale a reader can check by eye (a 1000px window with 100px zones). No
+   *  caller passes them; a second policy would be a second answer to "how fast
+   *  does the page move", which is the one thing this module decides. */
   zone: number = ZONE_PX,
   fastest: number = FASTEST_PX,
 ): number => {

--- a/packages/web/src/client/autoscroll.ts
+++ b/packages/web/src/client/autoscroll.ts
@@ -64,16 +64,18 @@ const FASTEST_PX = 14
  * what happens PAST the edge (a pointer dragged off the window entirely, which
  * is a real gesture and where a naive ratio goes above 1) — are a unit test
  * rather than something to try with a mouse.
+ *
+ * The zone and the speed are ARGUMENTS rather than defaults, and the one caller
+ * passes the two constants above. It is the same policy either way; what an
+ * optional pair would add is a second arity and a knob nobody asked for, while
+ * the test — which wants a 1000px window with 100px zones so every number reads
+ * as a fraction — is served by the arguments it already has to pass.
  */
 export const edgeSpeed = (
   y: number,
   height: number,
-  /** The two numbers above, injectable — and ONLY so the rules can be tested at
-   *  a scale a reader can check by eye (a 1000px window with 100px zones). No
-   *  caller passes them; a second policy would be a second answer to "how fast
-   *  does the page move", which is the one thing this module decides. */
-  zone: number = ZONE_PX,
-  fastest: number = FASTEST_PX,
+  zone: number,
+  fastest: number,
 ): number => {
   const above = zone - y
   const below = y - (height - zone)
@@ -92,7 +94,7 @@ export interface EdgeScroll {
   /** The pointer is HERE, in client coordinates. Reports it in document ones
    *  straight away, and keeps reporting — with the page moving under it — for
    *  as long as it stays near an edge. */
-  readonly at: (client: { readonly x: number; readonly y: number }) => void
+  readonly at: (x: number, y: number) => void
   /** The gesture is over. Safe to call more than once, and on a gesture that
    *  never reached an edge. */
   readonly stop: () => void
@@ -104,47 +106,60 @@ export interface EdgeScroll {
  * One of these per gesture rather than one per page — it holds where that
  * gesture's pointer is, and two live at once would be two gestures, which is
  * not a thing either caller allows.
+ *
+ * THE WINDOW'S HEIGHT IS READ ONCE, at the press. It is the one measurement
+ * here that costs anything: asking for it re-reads a layout the gesture itself
+ * has just dirtied (the drop line's style, the band's), and a gesture spends
+ * nearly all of its life in the middle of the window, where the answer is "not
+ * near an edge". Reading it per move would be a forced layout per frame to
+ * learn nothing. A window resized mid-drag is the price, and it is a gesture
+ * long — the next one measures again.
  */
 export const edgeScrolling = (report: Report): EdgeScroll => {
+  /** The LAYOUT viewport's height, which is the box the pointer's client
+   *  coordinates are in — `innerHeight` counts a horizontal scrollbar as room
+   *  the pointer can be in, and it cannot. */
+  const height = document.documentElement.clientHeight
   /** Where the pointer was last seen, in CLIENT coordinates — the frame loop
    *  re-reads it against a page that has moved, which is the whole trick. */
-  let where: { readonly x: number; readonly y: number } | null = null
+  let atX = 0
+  let atY = 0
   /** The frame in flight, or `0` for "the loop is not running". `0` is never a
    *  real handle, which is what lets one field say both things. */
   let frame = 0
 
-  const tell = (): void => {
-    if (where !== null) report(where.x + window.scrollX, where.y + window.scrollY)
-  }
+  const tell = (scrolled: number): void => report(atX + window.scrollX, atY + scrolled)
 
   const step = (): void => {
     frame = 0
-    if (where === null) return
-    // The LAYOUT viewport's height, which is the box the pointer's client
-    // coordinates are in — `innerHeight` counts a horizontal scrollbar as room
-    // the pointer can be in, and it cannot.
-    const speed = edgeSpeed(where.y, document.documentElement.clientHeight)
+    const speed = edgeSpeed(atY, height, ZONE_PX, FASTEST_PX)
     if (speed === 0) return
     const before = window.scrollY
     // `instant` whatever the page's own scroll behaviour is: this is a gesture
     // being followed, not a place being gone to (`./scroll.ts` makes the same
     // call for the same reason).
     window.scrollBy({ top: speed, behavior: "instant" })
+    const after = window.scrollY
     // Only when the page actually MOVED. At the top or the bottom there is
     // nothing left to give, and re-reporting an unchanged point would be a
     // plan recomputed every frame for an answer that cannot have changed.
-    if (window.scrollY !== before) tell()
+    if (after !== before) tell(after)
     frame = requestAnimationFrame(step)
   }
 
   return {
-    at: (client) => {
-      where = { x: client.x, y: client.y }
-      tell()
-      if (frame === 0) frame = requestAnimationFrame(step)
+    at: (x, y) => {
+      atX = x
+      atY = y
+      tell(window.scrollY)
+      // Only when there is somewhere to go. A pointer in the middle of the
+      // window is every frame of nearly every gesture, and scheduling a frame
+      // for it would be a callback per move to decide to do nothing.
+      if (frame === 0 && edgeSpeed(y, height, ZONE_PX, FASTEST_PX) !== 0) {
+        frame = requestAnimationFrame(step)
+      }
     },
     stop: () => {
-      where = null
       cancelAnimationFrame(frame)
       frame = 0
     },

--- a/packages/web/src/client/autoscroll.ts
+++ b/packages/web/src/client/autoscroll.ts
@@ -21,6 +21,17 @@
  * the behaviour, and exactly what a caller that only re-planned on
  * `pointermove` would get wrong.
  *
+ * ONCE IT HAS SEEN THE POINTER AT ALL, which is the one exception and is worth
+ * saying rather than leaving to be discovered. {@link EdgeScroll.at} is fed
+ * from a gesture's `pointermove` (`./pointer.ts`), so a gesture that has not
+ * had one yet has nothing to be still ABOUT — and there is exactly one such
+ * gesture: a row lifted by a finger's long press, which begins where the finger
+ * already is (`./drag/dragging.ts`). Held at the edge and never moved, it does
+ * not scroll; its first pixel arms this and everything after that is the rule
+ * above. That is the same line "the first pixel after the deadline is already
+ * the drag" draws, read from the other side — a press is not a drag until it
+ * has moved once, and a gesture that has not moved has not asked for anything.
+ *
  * VERTICAL ONLY. The document is what scrolls in this app (`./scroll.ts`), and
  * an outline is a column: the horizontal overflow that exists at all is
  * `main`'s, for a long title, and nudging that sideways during a drag would

--- a/packages/web/src/client/autoscroll.ts
+++ b/packages/web/src/client/autoscroll.ts
@@ -1,0 +1,140 @@
+/**
+ * THE PAGE MOVING UNDER A GESTURE that has run out of screen.
+ *
+ * Two gestures in this client aim at rows (`./drag/dragging.ts` carries one to
+ * a place, `./drag/sweeping.ts` sweeps a run of them) and both are over an
+ * OUTLINE, which is longer than the window nearly always. Without this, the
+ * reach of either is "what happens to be on screen when the press landed" — a
+ * row cannot be dragged to a parent above the fold, and a sweep cannot pick
+ * past the last visible line — and the way out a person tries is to keep
+ * pushing at the edge. So that is what the gesture answers to.
+ *
+ * **The pointer is read in CLIENT coordinates and reported in DOCUMENT ones**,
+ * and that split is the whole of why this is a module rather than three lines
+ * in each caller. Whether the page should move is a question about the WINDOW
+ * (how near the edge the pointer is), and it is asked of a pointer that may not
+ * have moved at all; where the gesture is now is a question about the PAGE,
+ * because both callers measured their rows once in document coordinates and
+ * would otherwise be answering a scrolled question with an unscrolled point.
+ * A finger or a mouse held still in the zone therefore keeps producing new
+ * answers, frame by frame, with no `pointermove` behind them — which is exactly
+ * the behaviour, and exactly what a caller that only re-planned on
+ * `pointermove` would get wrong.
+ *
+ * VERTICAL ONLY. The document is what scrolls in this app (`./scroll.ts`), and
+ * an outline is a column: the horizontal overflow that exists at all is
+ * `main`'s, for a long title, and nudging that sideways during a drag would
+ * move the rows out from under the line promising where they land.
+ *
+ * Nothing here is armed unless a gesture asks for it: the frame loop starts on
+ * the first report inside a zone and stops the moment the pointer leaves one,
+ * so a page nobody is dragging over schedules nothing.
+ */
+
+/** How deep the zone at each edge of the window is. About two rows' worth —
+ *  wide enough that a hand aiming at the last visible line finds it without
+ *  meaning to, narrow enough that ordinary work near the bottom of the screen
+ *  is not inside it. */
+const ZONE_PX = 72
+
+/** How fast the page moves when the pointer is at the very edge, in pixels per
+ *  frame — a shade over 800px a second at 60Hz, which is about a screen and a
+ *  half. Frames rather than seconds because that is the clock this runs on, and
+ *  converting would be a number nobody can check against what they see. */
+const FASTEST_PX = 14
+
+/**
+ * How fast the page should move for a pointer this far down the window, and
+ * which way: negative is up, positive is down, `0` is "not near an edge".
+ *
+ * The speed RAMPS with how deep into the zone the pointer is, rather than being
+ * one number the moment it crosses: a constant speed makes the page bolt the
+ * instant a hand strays near the edge, and the only control a person has over
+ * a scroll they did not ask to start is to move away from it.
+ *
+ * Pure, so the two things that are easy to get subtly wrong — the sign, and
+ * what happens PAST the edge (a pointer dragged off the window entirely, which
+ * is a real gesture and where a naive ratio goes above 1) — are a unit test
+ * rather than something to try with a mouse.
+ */
+export const edgeSpeed = (
+  y: number,
+  height: number,
+  zone: number = ZONE_PX,
+  fastest: number = FASTEST_PX,
+): number => {
+  const above = zone - y
+  const below = y - (height - zone)
+  if (above <= 0 && below <= 0) return 0
+  // A window shorter than two zones has them overlapping, and then the pointer
+  // is in both: the NEARER edge is the one it means. Clamped at the edge itself
+  // so a pointer dragged off the window is at full speed rather than past it.
+  const into = Math.min(1, Math.max(above, below) / zone)
+  return (above > below ? -1 : 1) * fastest * into
+}
+
+/** Where a gesture is, in the coordinates its rows were measured in. */
+export type Report = (x: number, y: number) => void
+
+export interface EdgeScroll {
+  /** The pointer is HERE, in client coordinates. Reports it in document ones
+   *  straight away, and keeps reporting — with the page moving under it — for
+   *  as long as it stays near an edge. */
+  readonly at: (client: { readonly x: number; readonly y: number }) => void
+  /** The gesture is over. Safe to call more than once, and on a gesture that
+   *  never reached an edge. */
+  readonly stop: () => void
+}
+
+/**
+ * Follow a live gesture: where it is, and the page moving to keep up with it.
+ *
+ * One of these per gesture rather than one per page — it holds where that
+ * gesture's pointer is, and two live at once would be two gestures, which is
+ * not a thing either caller allows.
+ */
+export const edgeScrolling = (report: Report): EdgeScroll => {
+  /** Where the pointer was last seen, in CLIENT coordinates — the frame loop
+   *  re-reads it against a page that has moved, which is the whole trick. */
+  let where: { readonly x: number; readonly y: number } | null = null
+  /** The frame in flight, or `0` for "the loop is not running". `0` is never a
+   *  real handle, which is what lets one field say both things. */
+  let frame = 0
+
+  const tell = (): void => {
+    if (where !== null) report(where.x + window.scrollX, where.y + window.scrollY)
+  }
+
+  const step = (): void => {
+    frame = 0
+    if (where === null) return
+    // The LAYOUT viewport's height, which is the box the pointer's client
+    // coordinates are in — `innerHeight` counts a horizontal scrollbar as room
+    // the pointer can be in, and it cannot.
+    const speed = edgeSpeed(where.y, document.documentElement.clientHeight)
+    if (speed === 0) return
+    const before = window.scrollY
+    // `instant` whatever the page's own scroll behaviour is: this is a gesture
+    // being followed, not a place being gone to (`./scroll.ts` makes the same
+    // call for the same reason).
+    window.scrollBy({ top: speed, behavior: "instant" })
+    // Only when the page actually MOVED. At the top or the bottom there is
+    // nothing left to give, and re-reporting an unchanged point would be a
+    // plan recomputed every frame for an answer that cannot have changed.
+    if (window.scrollY !== before) tell()
+    frame = requestAnimationFrame(step)
+  }
+
+  return {
+    at: (client) => {
+      where = { x: client.x, y: client.y }
+      tell()
+      if (frame === 0) frame = requestAnimationFrame(step)
+    },
+    stop: () => {
+      where = null
+      cancelAnimationFrame(frame)
+      frame = 0
+    },
+  }
+}

--- a/packages/web/src/client/claims.test.ts
+++ b/packages/web/src/client/claims.test.ts
@@ -131,6 +131,27 @@ test("only the outline's scaffolding is marked as a sweep surface", () => {
   ])
 })
 
+// The other two attributes a row's LINE and its HANDLE wear, swept for the same
+// reason and with the same shape. Each is declared once as a constant and
+// written out once as a literal, because a JSX spread would put every attribute
+// of those elements — including the row line's `classList` — on Solid's runtime
+// spread path, per row, per frame. A literal cannot be renamed by the type
+// checker; these are what hold the two spellings together.
+test("a row's line is marked in exactly the module that reads it and the tree that draws it", () => {
+  expect(filesSpelling(/data-row-key/)).toEqual(["Tree.tsx", path.join("drag", "lines.ts")])
+})
+
+// The handle's is two rather than three, and the missing one is the point:
+// `menu/door.ts` stands down on this mark and spells it as the CONSTANT, so the
+// type checker already holds its end. Only the declaration and the cell that
+// wears it are literals, and only they need a sweep.
+test("a row's handle is marked in the gesture that owns it and the cell that wears it", () => {
+  expect(filesSpelling(/data-handle/)).toEqual([
+    path.join("drag", "Handle.tsx"),
+    path.join("drag", "dragging.ts"),
+  ])
+})
+
 // saying.ts's claim — one receptacle for how long a said-line lingers. SAID_MS
 // was pulled out beside the `Said` type because the ••• menu's dwell and the
 // Trash's "were equal only by hand-maintenance", and the constant turned out

--- a/packages/web/src/client/claims.test.ts
+++ b/packages/web/src/client/claims.test.ts
@@ -152,6 +152,16 @@ test("a row's handle is marked in the gesture that owns it and the cell that wea
   ])
 })
 
+// pointer.ts's claim — one file suppresses the text selection under a gesture.
+// It is swept because the file's own note LEANS on it: the save-and-put-back
+// there is not re-entrant, and what makes that survivable is that the value it
+// saves is always `""`, which is only true while nothing else writes the
+// property. A second writer turns a stray `user-select: none` until reload into
+// a wrong value put back, and this is what says so on the day it appears.
+test("only pointer.ts suppresses the page's text selection", () => {
+  expect(filesSpelling(/userSelect/)).toEqual(["pointer.ts"])
+})
+
 // saying.ts's claim — one receptacle for how long a said-line lingers. SAID_MS
 // was pulled out beside the `Said` type because the ••• menu's dwell and the
 // Trash's "were equal only by hand-maintenance", and the constant turned out

--- a/packages/web/src/client/claims.test.ts
+++ b/packages/web/src/client/claims.test.ts
@@ -115,6 +115,22 @@ test("only layer.ts spells a z-index", () => {
   expect(filesSpelling(/(?:^|[\s"'`])z-(?:\[\d+\]|\d+|auto)(?=$|[\s"'`])/m)).toEqual(["layer.ts"])
 })
 
+// drag/sweeping.ts's claim — the outline's SCAFFOLDING is the only thing a
+// drag-across may begin on, and the mark that says so is written as a literal
+// at each site (a JSX spread there would move every `data-` fact a row carries
+// onto Solid's runtime spread path, per row, per frame). A literal cannot be
+// renamed by the type checker, so it is swept instead: exactly the module that
+// reads the attribute and the two components that wear it. A fourth file
+// spelling it is a new surface nobody argued for — and a missing one is a rail
+// that quietly stopped being pressable, which nothing else would notice.
+test("only the outline's scaffolding is marked as a sweep surface", () => {
+  expect(filesSpelling(/data-sweep/)).toEqual([
+    "Tree.tsx",
+    path.join("drag", "sweeping.ts"),
+    path.join("edit", "Editable.tsx"),
+  ])
+})
+
 // saying.ts's claim — one receptacle for how long a said-line lingers. SAID_MS
 // was pulled out beside the `Said` type because the ••• menu's dwell and the
 // Trash's "were equal only by hand-maintenance", and the constant turned out

--- a/packages/web/src/client/drag/Handle.tsx
+++ b/packages/web/src/client/drag/Handle.tsx
@@ -18,9 +18,17 @@
  * (`./dragging.ts` and `../longPress.ts` have both halves of the argument).
  * What the finger costs is that this cell is no longer a second door to the
  * row's `•••` menu — a phone opens that by holding the row anywhere else, which
- * is nearly all of it (`../menu/door.ts`), and a handle has only itself to be
- * held by. The row's own door is told to stand down here rather than guessing:
- * {@link HANDLE} is what it looks for.
+ * is nearly all of it, and a handle has only itself to be held by. That door
+ * stands down on its own (`../menu/door.ts`), by looking for the mark this cell
+ * wears: `./dragging.ts`'s `HANDLE`, which is a fact about the GESTURE rather
+ * than about this component, and is why it is declared there.
+ *
+ * The mark is a `data-` attribute rather than the testid beside it — a testid
+ * is a contract with the browser tests, and reading one back as behaviour would
+ * make a rename a silent change of what the app does. And an attribute rather
+ * than a `stopPropagation`, which would be one gesture reaching into another's
+ * plumbing and would rest on the order Solid happens to walk delegated handlers
+ * in.
  */
 
 import type { Row } from "@olai/format"
@@ -28,18 +36,6 @@ import type { JSX } from "solid-js"
 
 import { TESTID } from "../testids.ts"
 import { useDragging } from "./dragging.ts"
-
-/**
- * The attribute this cell wears so the row's `•••` door can tell a press that
- * is already spoken for.
- *
- * A `data-` attribute rather than the testid beside it: a testid is a contract
- * with the browser tests and reading one back as behaviour would make a rename
- * a silent change of what the app does. Rather than a `stopPropagation`, too —
- * that would be one gesture reaching into another's plumbing, and it would rest
- * on the order Solid happens to walk delegated handlers in.
- */
-export const HANDLE = "data-handle"
 
 export function Handle(props: {
   readonly row: Row
@@ -50,6 +46,9 @@ export function Handle(props: {
     <span
       class="inline-flex items-center md:cursor-grab"
       data-testid={TESTID.dragHandle}
+      // `./dragging.ts`'s `HANDLE`, written out for the reason `../Tree.tsx`
+      // writes `data-row-key` out — and held to that name by
+      // `../claims.test.ts`, which is the only thing a literal can be held by.
       data-handle=""
       // THE NATIVE DRAG HAS TO BE TURNED OFF, and this is not belt and braces:
       // a bullet is an `<a href>`, and a browser makes every link draggable for

--- a/packages/web/src/client/drag/Handle.tsx
+++ b/packages/web/src/client/drag/Handle.tsx
@@ -66,7 +66,7 @@ export function Handle(props: {
       // prevented while this cell is holding a finger, so the text-selection
       // callout does not come up over a row that is about to lift. A right-click
       // with a mouse still gets the browser's menu (`../longPress.ts`).
-      onContextMenu={dragging.held.onContextMenu}
+      onContextMenu={dragging.heldMenu}
       // CAPTURE, so the link under it never sees the click at all: by the time
       // one bubbled, the browser would already be navigating to the node whose
       // bullet the reader used as a handle. Solid has no `onClickCapture`

--- a/packages/web/src/client/drag/Handle.tsx
+++ b/packages/web/src/client/drag/Handle.tsx
@@ -12,13 +12,15 @@
  * reorder. Putting the pointer handler in the bullet would have made every
  * drawing of one draggable and then needed a prop to say when it is not.
  *
- * A MOUSE OR A PEN, and deliberately not a finger. A touch drag on a bullet
- * would have to claim the gesture that scrolls the page (`touch-action: none`),
- * and getting that wrong on a phone costs the reader the ability to scroll past
- * an outline. The `•••` menu is already a pointer-device affordance for the
- * same kind of reason (`../touch.ts`), and a touch gesture for reordering
- * belongs with whatever else a phone eventually gets — a long-press, most
- * likely, which is a decision rather than a line of code.
+ * ONE HANDLE, THREE DEVICES. A mouse and a pen start the drag by travelling; a
+ * finger starts it by being HELD, because the gesture it would otherwise take
+ * is the page scrolling and no reader can be asked to give that up
+ * (`./dragging.ts` and `../longPress.ts` have both halves of the argument).
+ * What the finger costs is that this cell is no longer a second door to the
+ * row's `•••` menu — a phone opens that by holding the row anywhere else, which
+ * is nearly all of it (`../menu/door.ts`), and a handle has only itself to be
+ * held by. The row's own door is told to stand down here rather than guessing:
+ * {@link HANDLE} is what it looks for.
  */
 
 import type { Row } from "@olai/format"
@@ -26,6 +28,18 @@ import type { JSX } from "solid-js"
 
 import { TESTID } from "../testids.ts"
 import { useDragging } from "./dragging.ts"
+
+/**
+ * The attribute this cell wears so the row's `•••` door can tell a press that
+ * is already spoken for.
+ *
+ * A `data-` attribute rather than the testid beside it: a testid is a contract
+ * with the browser tests and reading one back as behaviour would make a rename
+ * a silent change of what the app does. Rather than a `stopPropagation`, too —
+ * that would be one gesture reaching into another's plumbing, and it would rest
+ * on the order Solid happens to walk delegated handlers in.
+ */
+export const HANDLE = "data-handle"
 
 export function Handle(props: {
   readonly row: Row
@@ -36,6 +50,7 @@ export function Handle(props: {
     <span
       class="inline-flex items-center md:cursor-grab"
       data-testid={TESTID.dragHandle}
+      data-handle=""
       // THE NATIVE DRAG HAS TO BE TURNED OFF, and this is not belt and braces:
       // a bullet is an `<a href>`, and a browser makes every link draggable for
       // free. Pressing one and moving therefore starts the platform's own
@@ -46,10 +61,12 @@ export function Handle(props: {
       // set.
       draggable={false}
       onDragStart={(event) => event.preventDefault()}
-      onPointerDown={(event) => {
-        if (event.pointerType === "touch") return
-        dragging.grab(event, props.row)
-      }}
+      onPointerDown={(event) => dragging.grab(event, props.row)}
+      // The platform's own long press, for the one that raises it as an event:
+      // prevented while this cell is holding a finger, so the text-selection
+      // callout does not come up over a row that is about to lift. A right-click
+      // with a mouse still gets the browser's menu (`../longPress.ts`).
+      onContextMenu={dragging.held.onContextMenu}
       // CAPTURE, so the link under it never sees the click at all: by the time
       // one bubbled, the browser would already be navigating to the node whose
       // bullet the reader used as a handle. Solid has no `onClickCapture`

--- a/packages/web/src/client/drag/Sweep.tsx
+++ b/packages/web/src/client/drag/Sweep.tsx
@@ -1,0 +1,54 @@
+/**
+ * The band a drag-across pulls, drawn.
+ *
+ * A BAND and not a rubber-band box, because that is what the gesture actually
+ * asks (`./sweep.ts` has the argument): a row is a line, so the sweep reads Y
+ * and spans the rows' own width. Drawing a rectangle that followed the pointer
+ * sideways would promise a second axis the answer does not have — a person
+ * would pull the corner in and expect the deep rows to drop out of the pick,
+ * and they would not.
+ *
+ * Positioned ABSOLUTELY out of a portal, in document coordinates, exactly as
+ * the drop line beside it is (`./DropLine.tsx`): with no positioned ancestor an
+ * absolute box lies against the initial containing block, which scrolls with
+ * the page — so the band stays over the rows it names while the gesture
+ * auto-scrolls, and nothing here listens for that.
+ *
+ * `LAYER.row`, the same claim the drop line and the `•••` panel make: over the
+ * rows, under every piece of chrome. It is a WASH rather than a fill — the rows
+ * it crosses are already wearing the pick's own accent, and a band opaque
+ * enough to hide that would be the gesture covering its own answer.
+ */
+
+import { Show } from "solid-js"
+import { Portal } from "solid-js/web"
+
+import { LAYER } from "../layer.ts"
+import { TESTID } from "../testids.ts"
+import type { Sweep } from "./sweep.ts"
+
+export function SweepBand(props: { readonly sweep: Sweep | null }) {
+  return (
+    <Show when={props.sweep}>
+      {(sweep) => (
+        <Portal>
+          <div
+            class={`pointer-events-none absolute ${LAYER.row} rounded-sm border border-accent/40 bg-accent/5`}
+            style={{
+              top: `${sweep().top}px`,
+              left: `${sweep().left}px`,
+              width: `${sweep().width}px`,
+              height: `${Math.max(0, sweep().bottom - sweep().top)}px`,
+            }}
+            data-testid={TESTID.sweepBand}
+            // How many rows it is crossing right now — the one fact about a
+            // sweep that is still a prediction while the pointer is down, said
+            // as data rather than left to be counted off the toned rows.
+            data-rows={String(sweep().run?.keys.length ?? 0)}
+            aria-hidden="true"
+          />
+        </Portal>
+      )}
+    </Show>
+  )
+}

--- a/packages/web/src/client/drag/Sweep.tsx
+++ b/packages/web/src/client/drag/Sweep.tsx
@@ -38,7 +38,9 @@ export function SweepBand(props: { readonly sweep: Sweep | null }) {
               top: `${sweep().top}px`,
               left: `${sweep().left}px`,
               width: `${sweep().width}px`,
-              height: `${Math.max(0, sweep().bottom - sweep().top)}px`,
+              // No clamp: `top` is the lesser of the pull's two ends and
+              // `bottom` the greater, so this cannot be negative.
+              height: `${sweep().bottom - sweep().top}px`,
             }}
             data-testid={TESTID.sweepBand}
             // How many rows it is crossing right now — the one fact about a

--- a/packages/web/src/client/drag/dragging.ts
+++ b/packages/web/src/client/drag/dragging.ts
@@ -31,15 +31,36 @@
  *
  * **Several rows land as several writes**, each after the one before it, which
  * is what keeps the run in the order it was picked up in (`../writes.ts`).
+ *
+ * **A FINGER HOLDS THE BULLET FIRST**, and that is the whole of what touch
+ * added. The gesture a phone already owns on a row is the page scrolling under
+ * it, so a drag that took the first pixel of travel would cost a reader the
+ * ability to read; what claims a gesture honestly on a handset is a LONG PRESS,
+ * which is the call `../longPress.ts` already made for the `•••` menu and the
+ * same primitive is spent again here. Until the deadline nothing is claimed —
+ * the browser keeps the press, a finger that drifts is a scroll and takes the
+ * deadline with it — and only a finger that is still there at 500ms lifts the
+ * row and stops the page moving under it.
+ *
+ * THE BULLET, AND NOT THE ROW, is what a finger holds for this, and that is the
+ * decision the touch half is: the bullet is already the handle for a mouse and
+ * a pen, so it is one handle on three devices rather than a fourth thing to
+ * learn. What it costs is that a phone no longer opens the `•••` menu by
+ * holding the BULLET specifically — holding anywhere else on the row still
+ * does, which is nearly all of it — and that is the trade taken, because two
+ * gestures cannot both own one press and the menu has a row to be reached from
+ * while a handle has only itself.
  */
 
 import type { Row } from "@olai/format"
 import type { Edit } from "@olai/surface"
-import { type Accessor, createContext, createSignal, useContext } from "solid-js"
+import { type Accessor, createContext, createSignal, onCleanup, useContext } from "solid-js"
 
+import { edgeScrolling } from "../autoscroll.ts"
 import { flatten } from "../edit/order.ts"
 import type { Said } from "../edit/undoing.ts"
 import { useUndo } from "../edit/undoing.ts"
+import { type LongPress, longPressOn } from "../longPress.ts"
 import { drag as pointerDrag } from "../pointer.ts"
 import { beneath, depthOf } from "../select/range.ts"
 import { applyingAll } from "../writes.ts"
@@ -49,6 +70,12 @@ import { type Landing, type Placed, planDrop } from "./plan.ts"
  *  click on the bullet's link. Four pixels is the number a hand resting on a
  *  trackpad produces without meaning to. */
 const THRESHOLD = 4
+
+/** ...and none at all once a FINGER has been held: the deadline it met is what
+ *  told the two gestures apart, so the first pixel after it is already the
+ *  drag. Asking for four more would be asking a person who has just felt the
+ *  row lift to prove they meant it. */
+const HELD_THRESHOLD = 0
 
 /** The attribute a row's LINE carries so a drag can measure it. On the line and
  *  not on the `<li>`, because an item's box contains every row nested under it
@@ -64,8 +91,14 @@ export interface Dragging {
   /** Where they would land right now, or `null` before the threshold is
    *  crossed and after the drop. */
   readonly landing: Accessor<Landing | null>
-  /** Begin a gesture on this row. Nothing happens until the pointer moves. */
+  /** Begin a gesture on this row's handle. A mouse or a pen: nothing happens
+   *  until the pointer moves. A finger: nothing happens until it has been HELD,
+   *  and then the row lifts under it. */
   readonly grab: (event: PointerEvent, row: Row) => void
+  /** The other half of the finger's door, for the platform that raises its own
+   *  menu mid-press. Wire on the handle beside {@link grab} — a right-click
+   *  with a mouse is untouched (`../longPress.ts`). */
+  readonly held: LongPress
   /** Whether the gesture that just ended was a DRAG — read by the bullet, whose
    *  click would otherwise navigate away the instant a drop lands. */
   readonly dragged: () => boolean
@@ -180,29 +213,74 @@ export const createDragging = (
     })
   }
 
-  const grab = (event: PointerEvent, row: Row) => {
-    // The secondary button opens a context menu; a drag is the primary one's.
-    if (event.button !== 0) return
-    // Every press clears it, and nothing else does — see the field's own note.
-    travelled = false
+  /**
+   * The page STOPS SCROLLING under a finger that has been held, and starts
+   * again the moment the row is put down.
+   *
+   * Claimed here rather than as `touch-action: none` on the handle, and the
+   * difference is the whole of what makes this honest: a style is in force from
+   * the instant a finger lands, so a thumb that happened to start its flick on
+   * a bullet could not scroll the page at all — a 28px-wide dead strip running
+   * down the left of every outline. A non-passive `touchmove` listener is in
+   * force from the DEADLINE, which is a moment the browser has already agreed
+   * is not a scroll (a finger that had drifted would have taken the deadline
+   * with it, and one the browser took to scroll with would have cancelled the
+   * pointer). So the page keeps every gesture it had, and this claims exactly
+   * the one that is left.
+   */
+  const stopScrolling = (event: TouchEvent): void => event.preventDefault()
+  const claimScroll = (): void =>
+    window.addEventListener("touchmove", stopScrolling, { passive: false })
+  const freeScroll = (): void => window.removeEventListener("touchmove", stopScrolling)
+  // A row dragged off the page mid-gesture would otherwise leave the whole
+  // document unable to scroll, which is the one failure here nobody could
+  // recover from without a reload.
+  onCleanup(freeScroll)
+
+  /**
+   * The gesture proper, once something has decided it IS one.
+   *
+   * `held` is which of the two decided: a pointer's THRESHOLD (the row lifts on
+   * the fourth pixel, and a press that never travels was the bullet's own link
+   * all along) or a finger's DEADLINE (the row lifts where it is, and the page
+   * stops moving under it). Everything after that moment is identical, which is
+   * why it is one function with a flag rather than two gestures that would drift.
+   */
+  const gesture = (from: PointerEvent, row: Row, held: boolean) => {
     /** What this gesture is carrying, decided when it becomes a drag rather
      *  than at the press: a press that turns out to be a click must not have
      *  cleared the selection on its way past. */
     let carried: ReadonlyArray<Row> = []
     let placed: ReadonlyArray<Placed> = []
 
-    pointerDrag(event, {
-      threshold: THRESHOLD,
-      onStart: () => {
-        travelled = true
-        const picked = page.selection.keys()
-        carried = picked.has(row.key) ? page.selection.rows() : [row]
-        if (!picked.has(row.key)) page.selection.clear()
-        setMoving(new Set(carried.map((one) => one.key)))
-        placed = measure(carried)
-      },
-      onMove: (move) => setLanding(planDrop(placed, move.pageX, move.pageY)),
+    const lift = () => {
+      travelled = true
+      const picked = page.selection.keys()
+      carried = picked.has(row.key) ? page.selection.rows() : [row]
+      if (!picked.has(row.key)) page.selection.clear()
+      setMoving(new Set(carried.map((one) => one.key)))
+      placed = measure(carried)
+    }
+
+    /** The page keeps up with a gesture that has run out of screen, and the
+     *  landing is re-planned from where the pointer now is ON THE PAGE — which
+     *  moves when the page does, with no `pointermove` behind it
+     *  (`../autoscroll.ts`). Without this the reach of a drag is whatever was
+     *  visible when the press landed, which on an outline is most of the
+     *  gesture missing. */
+    const edge = edgeScrolling((x, y) => setLanding(planDrop(placed, x, y)))
+
+    if (held) {
+      lift()
+      claimScroll()
+    }
+    pointerDrag(from, {
+      threshold: held ? HELD_THRESHOLD : THRESHOLD,
+      onStart: held ? undefined : lift,
+      onMove: (move) => edge.at({ x: move.clientX, y: move.clientY }),
       onEnd: (up) => {
+        edge.stop()
+        if (held) freeScroll()
         // A CANCELLED gesture is not a drop, and the difference is the whole
         // reason the primitive answers with `null` rather than with the last
         // move: a pointer taken away mid-drag has not chosen anything.
@@ -213,6 +291,34 @@ export const createDragging = (
         void drop(target, carried)
       },
     })
+  }
+
+  /**
+   * What a finger is on, while it is on it — read by the deadline below, which
+   * fires with no event of its own and needs the press that armed it to start
+   * the gesture from.
+   *
+   * ONE watcher for the page rather than one per row: what it is watching is
+   * whatever was pressed last, and two fingers on two bullets is a pinch the
+   * gesture already refuses (`../longPress.ts`).
+   */
+  let pressed: { readonly event: PointerEvent; readonly row: Row } | null = null
+  const held = longPressOn(() => {
+    const on = pressed
+    if (on !== null) gesture(on.event, on.row, true)
+  })
+
+  const grab = (event: PointerEvent, row: Row) => {
+    // The secondary button opens a context menu; a drag is the primary one's.
+    if (event.button !== 0) return
+    // Every press clears it, and nothing else does — see the field's own note.
+    travelled = false
+    if (event.pointerType === "touch") {
+      pressed = { event, row }
+      held.onPointerDown(event)
+      return
+    }
+    gesture(event, row, false)
   }
 
   /**
@@ -241,6 +347,7 @@ export const createDragging = (
     carrying: (key) => moving().size > 0 && beneath(moving(), key),
     landing,
     grab,
+    held,
     dragged: () => travelled,
   }
 }

--- a/packages/web/src/client/drag/dragging.ts
+++ b/packages/web/src/client/drag/dragging.ts
@@ -60,7 +60,7 @@ import { edgeScrolling } from "../autoscroll.ts"
 import { flatten } from "../edit/order.ts"
 import type { Said } from "../edit/undoing.ts"
 import { useUndo } from "../edit/undoing.ts"
-import { type LongPress, longPressOn } from "../longPress.ts"
+import { longPressOn } from "../longPress.ts"
 import { drag as pointerDrag } from "../pointer.ts"
 import { beneath, depthOf } from "../select/range.ts"
 import { applyingAll } from "../writes.ts"
@@ -95,10 +95,15 @@ export interface Dragging {
    *  until the pointer moves. A finger: nothing happens until it has been HELD,
    *  and then the row lifts under it. */
   readonly grab: (event: PointerEvent, row: Row) => void
-  /** The other half of the finger's door, for the platform that raises its own
-   *  menu mid-press. Wire on the handle beside {@link grab} — a right-click
-   *  with a mouse is untouched (`../longPress.ts`). */
-  readonly held: LongPress
+  /** The platform's OWN long press, answered: prevented while this gesture is
+   *  holding a finger, so the text-selection callout does not come up over a
+   *  row that is about to lift. Wire as `onContextMenu` on the handle beside
+   *  {@link grab}; a right-click with a mouse is untouched (`../longPress.ts`).
+   *
+   *  Only this half of the watcher is handed out. Its `onPointerDown` is
+   *  {@link grab}'s to call — a caller given both could arm the deadline twice
+   *  for one press, which is a shape nothing should be able to write. */
+  readonly heldMenu: (event: Event) => void
   /** Whether the gesture that just ended was a DRAG — read by the bullet, whose
    *  click would otherwise navigate away the instant a drop lands. */
   readonly dragged: () => boolean
@@ -238,15 +243,29 @@ export const createDragging = (
   onCleanup(freeScroll)
 
   /**
+   * The gesture in flight, so a page that goes away under one takes its window
+   * listeners, its frame loop and its claim on the scroll with it.
+   *
+   * A drag outlives the element it started on by design — the listeners are the
+   * window's, because a pointer that leaves the handle is still dragging it —
+   * which is exactly what makes an unmount mid-gesture a leak rather than a
+   * tidy-up: a frame loop nobody can reach would go on scrolling the next page.
+   */
+  let inFlight: (() => void) | undefined
+  onCleanup(() => inFlight?.())
+
+  /**
    * The gesture proper, once something has decided it IS one.
    *
-   * `held` is which of the two decided: a pointer's THRESHOLD (the row lifts on
-   * the fourth pixel, and a press that never travels was the bullet's own link
-   * all along) or a finger's DEADLINE (the row lifts where it is, and the page
-   * stops moving under it). Everything after that moment is identical, which is
-   * why it is one function with a flag rather than two gestures that would drift.
+   * `how` is WHICH of the two decided, and it is a name rather than a boolean
+   * because three unrelated things read it: a pointer's THRESHOLD (the row
+   * lifts on the fourth pixel, and a press that never travels was the bullet's
+   * own link all along) or a finger's DEADLINE (the row lifts where it is, and
+   * the page stops moving under it). Everything after that moment is identical,
+   * which is why this is one function rather than two that would drift.
    */
-  const gesture = (from: PointerEvent, row: Row, held: boolean) => {
+  const gesture = (from: PointerEvent, row: Row, how: "travelled" | "held") => {
+    const held = how === "held"
     /** What this gesture is carrying, decided when it becomes a drag rather
      *  than at the press: a press that turns out to be a click must not have
      *  cleared the selection on its way past. */
@@ -274,11 +293,12 @@ export const createDragging = (
       lift()
       claimScroll()
     }
-    pointerDrag(from, {
+    inFlight = pointerDrag(from, {
       threshold: held ? HELD_THRESHOLD : THRESHOLD,
       onStart: held ? undefined : lift,
       onMove: (move) => edge.at({ x: move.clientX, y: move.clientY }),
       onEnd: (up) => {
+        inFlight = undefined
         edge.stop()
         if (held) freeScroll()
         // A CANCELLED gesture is not a drop, and the difference is the whole
@@ -303,9 +323,9 @@ export const createDragging = (
    * gesture already refuses (`../longPress.ts`).
    */
   let pressed: { readonly event: PointerEvent; readonly row: Row } | null = null
-  const held = longPressOn(() => {
+  const watcher = longPressOn(() => {
     const on = pressed
-    if (on !== null) gesture(on.event, on.row, true)
+    if (on !== null) gesture(on.event, on.row, "held")
   })
 
   const grab = (event: PointerEvent, row: Row) => {
@@ -315,10 +335,10 @@ export const createDragging = (
     travelled = false
     if (event.pointerType === "touch") {
       pressed = { event, row }
-      held.onPointerDown(event)
+      watcher.onPointerDown(event)
       return
     }
-    gesture(event, row, false)
+    gesture(event, row, "travelled")
   }
 
   /**
@@ -347,7 +367,7 @@ export const createDragging = (
     carrying: (key) => moving().size > 0 && beneath(moving(), key),
     landing,
     grab,
-    held,
+    heldMenu: watcher.onContextMenu,
     dragged: () => travelled,
   }
 }

--- a/packages/web/src/client/drag/dragging.ts
+++ b/packages/web/src/client/drag/dragging.ts
@@ -60,22 +60,23 @@ import { flatten } from "../edit/order.ts"
 import type { Said } from "../edit/undoing.ts"
 import { useUndo } from "../edit/undoing.ts"
 import { longPressOn } from "../longPress.ts"
-import { drag as pointerDrag } from "../pointer.ts"
+import { createDrags, TRAVEL_PX } from "../pointer.ts"
 import { beneath, depthOf } from "../select/range.ts"
 import { applyingAll } from "../writes.ts"
 import { measureLines } from "./lines.ts"
 import { type Landing, type Placed, planDrop } from "./plan.ts"
 
-/** How far the pointer must travel before a press becomes a drag rather than a
- *  click on the bullet's link. Four pixels is the number a hand resting on a
- *  trackpad produces without meaning to. */
-const THRESHOLD = 4
-
-/** ...and none at all once a FINGER has been held: the deadline it met is what
- *  told the two gestures apart, so the first pixel after it is already the
- *  drag. Asking for four more would be asking a person who has just felt the
- *  row lift to prove they meant it. */
-const HELD_THRESHOLD = 0
+/**
+ * The attribute the row's HANDLE wears — the bullet, as something to pick a row
+ * up by (`./Handle.tsx`).
+ *
+ * Here rather than on the component because two other things read it and
+ * neither is drawing one: the row's `•••` door, which must not arm its own long
+ * press on a press this gesture has claimed (`../menu/door.ts`), and the
+ * browser tests. What it marks is a fact about this GESTURE — "a press here is
+ * the drag's" — so it belongs with the gesture.
+ */
+export const HANDLE = "data-handle"
 
 export interface Dragging {
   /** Is this place in the air — either picked up, or drawn under something
@@ -230,30 +231,21 @@ export const createDragging = (
   // recover from without a reload.
   onCleanup(freeScroll)
 
-  /**
-   * The gesture in flight, so a page that goes away under one takes its window
-   * listeners, its frame loop and its claim on the scroll with it.
-   *
-   * A drag outlives the element it started on by design — the listeners are the
-   * window's, because a pointer that leaves the handle is still dragging it —
-   * which is exactly what makes an unmount mid-gesture a leak rather than a
-   * tidy-up: a frame loop nobody can reach would go on scrolling the next page.
-   */
-  let inFlight: (() => void) | undefined
-  onCleanup(() => inFlight?.())
+  /** This page's gestures: one at a time, and whatever is in flight is ended
+   *  with the page that made it (`../pointer.ts`). */
+  const drags = createDrags()
 
   /**
    * The gesture proper, once something has decided it IS one.
    *
-   * `how` is WHICH of the two decided, and it is a name rather than a boolean
-   * because three unrelated things read it: a pointer's THRESHOLD (the row
-   * lifts on the fourth pixel, and a press that never travels was the bullet's
-   * own link all along) or a finger's DEADLINE (the row lifts where it is, and
-   * the page stops moving under it). Everything after that moment is identical,
-   * which is why this is one function rather than two that would drift.
+   * `held` is WHICH of the two decided — a finger's DEADLINE (the row is
+   * already lifted, and the page has stopped moving under it) rather than a
+   * pointer's THRESHOLD (the row lifts on the fourth pixel, and a press that
+   * never travels was the bullet's own link all along). Everything after that
+   * moment is identical, which is why this is one function rather than two that
+   * would drift.
    */
-  const gesture = (from: PointerEvent, row: Row, how: "travelled" | "held") => {
-    const held = how === "held"
+  const gesture = (from: PointerEvent, row: Row, held: boolean) => {
     /** What this gesture is carrying, decided when it becomes a drag rather
      *  than at the press: a press that turns out to be a click must not have
      *  cleared the selection on its way past. */
@@ -273,8 +265,12 @@ export const createDragging = (
       lift()
       claimScroll()
     }
-    inFlight = pointerDrag(from, {
-      threshold: held ? HELD_THRESHOLD : THRESHOLD,
+    drags.start(from, {
+      // No threshold at all once a finger has been HELD: the deadline it met is
+      // what told the two gestures apart, so the first pixel after it is
+      // already the drag. Asking for four more would be asking a person who has
+      // just felt the row lift to prove they meant it.
+      threshold: held ? 0 : TRAVEL_PX,
       onStart: held ? undefined : lift,
       // ON THE PAGE, which is where the rows were measured — and which moves
       // under a pointer held near an edge of the window, with no `pointermove`
@@ -283,7 +279,6 @@ export const createDragging = (
       // outline is most of the gesture missing.
       onPage: (x, y) => setLanding(planDrop(placed, x, y)),
       onEnd: (up) => {
-        inFlight = undefined
         if (held) freeScroll()
         // A CANCELLED gesture is not a drop, and the difference is the whole
         // reason the primitive answers with `null` rather than with the last
@@ -298,18 +293,17 @@ export const createDragging = (
   }
 
   /**
-   * What a finger is on, while it is on it — read by the deadline below, which
-   * fires with no event of its own and needs the press that armed it to start
-   * the gesture from.
+   * The finger's deadline, and the row it is being held over.
    *
    * ONE watcher for the page rather than one per row: what it is watching is
    * whatever was pressed last, and two fingers on two bullets is a pinch the
-   * gesture already refuses (`../longPress.ts`).
+   * gesture already refuses (`../longPress.ts`). The PRESS comes back with the
+   * deadline — neither the timer nor the platform's own `contextmenu` carries
+   * one — so the only thing kept beside the watcher is which row it was on.
    */
-  let pressed: { readonly event: PointerEvent; readonly row: Row } | null = null
-  const watcher = longPressOn(() => {
-    const on = pressed
-    if (on !== null) gesture(on.event, on.row, "held")
+  let over: Row | undefined
+  const watcher = longPressOn((from) => {
+    if (over !== undefined) gesture(from, over, true)
   })
 
   const grab = (event: PointerEvent, row: Row) => {
@@ -318,11 +312,11 @@ export const createDragging = (
     // Every press clears it, and nothing else does — see the field's own note.
     travelled = false
     if (event.pointerType === "touch") {
-      pressed = { event, row }
+      over = row
       watcher.onPointerDown(event)
       return
     }
-    gesture(event, row, "travelled")
+    gesture(event, row, false)
   }
 
   /**

--- a/packages/web/src/client/drag/dragging.ts
+++ b/packages/web/src/client/drag/dragging.ts
@@ -56,7 +56,6 @@ import type { Row } from "@olai/format"
 import type { Edit } from "@olai/surface"
 import { type Accessor, createContext, createSignal, onCleanup, useContext } from "solid-js"
 
-import { edgeScrolling } from "../autoscroll.ts"
 import { flatten } from "../edit/order.ts"
 import type { Said } from "../edit/undoing.ts"
 import { useUndo } from "../edit/undoing.ts"
@@ -64,6 +63,7 @@ import { longPressOn } from "../longPress.ts"
 import { drag as pointerDrag } from "../pointer.ts"
 import { beneath, depthOf } from "../select/range.ts"
 import { applyingAll } from "../writes.ts"
+import { measureLines } from "./lines.ts"
 import { type Landing, type Placed, planDrop } from "./plan.ts"
 
 /** How far the pointer must travel before a press becomes a drag rather than a
@@ -76,11 +76,6 @@ const THRESHOLD = 4
  *  drag. Asking for four more would be asking a person who has just felt the
  *  row lift to prove they meant it. */
 const HELD_THRESHOLD = 0
-
-/** The attribute a row's LINE carries so a drag can measure it. On the line and
- *  not on the `<li>`, because an item's box contains every row nested under it
- *  and the gap arithmetic is about the lines a reader sees. */
-export const ROW_KEY = "data-row-key"
 
 export interface Dragging {
   /** Is this place in the air — either picked up, or drawn under something
@@ -180,13 +175,13 @@ export const createDragging = (
    *
    * What may be dropped INTO is the other half, and it rides on each row
    * ({@link Placed.into}).
+   *
+   * WHERE the lines are is not asked here: that is one reading of the page
+   * (`./lines.ts`), shared with the sweep, and what is left in this file is the
+   * only part that is about a PLACEMENT.
    */
   const measure = (carried: ReadonlyArray<Row>): ReadonlyArray<Placed> => {
-    const lines = new Map<string, Element>()
-    for (const line of document.querySelectorAll(`[${ROW_KEY}]`)) {
-      const key = line.getAttribute(ROW_KEY)
-      if (key !== null) lines.set(key, line)
-    }
+    const lines = new Map(measureLines().map((line) => [line.key, line]))
     const keys = new Set(carried.map((one) => one.key))
     // The file the drag is ABOUT — the carried rows', not the page's, which is
     // what makes a mirror's children draggable among themselves. A pick that
@@ -194,26 +189,19 @@ export const createDragging = (
     // left out, and the ops layer refuses them by name on the bar, which is the
     // same way every other half-legal run ends here.
     const file = carried[0]?.at.file
-    const scrollX = window.scrollX
-    const scrollY = window.scrollY
     return flatten(page.rows(), page.collapsed()).flatMap((row): ReadonlyArray<Placed> => {
       if (row.at.file !== file || beneath(keys, row.key)) return []
       const line = lines.get(row.key)
       if (line === undefined) return []
-      const box = line.getBoundingClientRect()
       const shows = row.kind === "node" || row.kind === "mirror" ? row.shows : undefined
       return [{
-        key: row.key,
+        ...line,
         id: row.at.node.id,
         parent: row.at.node.parent ?? null,
         // A placement is not a parent; the node it SHOWS is, and only when that
         // node is in this file. Same rule, same reason, as `move in`'s.
         into: shows !== undefined && shows.file === file ? shows.node.id : null,
         depth: depthOf(row.key),
-        top: box.top + scrollY,
-        bottom: box.bottom + scrollY,
-        left: box.left + scrollX,
-        right: box.right + scrollX,
       }]
     })
   }
@@ -281,14 +269,6 @@ export const createDragging = (
       placed = measure(carried)
     }
 
-    /** The page keeps up with a gesture that has run out of screen, and the
-     *  landing is re-planned from where the pointer now is ON THE PAGE — which
-     *  moves when the page does, with no `pointermove` behind it
-     *  (`../autoscroll.ts`). Without this the reach of a drag is whatever was
-     *  visible when the press landed, which on an outline is most of the
-     *  gesture missing. */
-    const edge = edgeScrolling((x, y) => setLanding(planDrop(placed, x, y)))
-
     if (held) {
       lift()
       claimScroll()
@@ -296,10 +276,14 @@ export const createDragging = (
     inFlight = pointerDrag(from, {
       threshold: held ? HELD_THRESHOLD : THRESHOLD,
       onStart: held ? undefined : lift,
-      onMove: (move) => edge.at({ x: move.clientX, y: move.clientY }),
+      // ON THE PAGE, which is where the rows were measured — and which moves
+      // under a pointer held near an edge of the window, with no `pointermove`
+      // behind it (`../pointer.ts`, `../autoscroll.ts`). Without that the reach
+      // of a drag is whatever was visible when the press landed, which on an
+      // outline is most of the gesture missing.
+      onPage: (x, y) => setLanding(planDrop(placed, x, y)),
       onEnd: (up) => {
         inFlight = undefined
-        edge.stop()
         if (held) freeScroll()
         // A CANCELLED gesture is not a drop, and the difference is the whole
         // reason the primitive answers with `null` rather than with the last

--- a/packages/web/src/client/drag/lines.ts
+++ b/packages/web/src/client/drag/lines.ts
@@ -1,0 +1,69 @@
+/**
+ * A DRAWN ROW'S LINE, as something a gesture can measure — the attribute it
+ * carries, the box it occupies, and where every one of them is.
+ *
+ * Two gestures aim at rows and both begin by asking the page the same question:
+ * where are the lines, in coordinates that survive a scroll. Each had its own
+ * answer — the same `querySelectorAll`, the same `getBoundingClientRect`, the
+ * same `+ scrollX/scrollY` — with the drag owning the attribute name and the
+ * sweep importing it from there, which said that measuring a row belongs to
+ * dragging one. It does not. It belongs to the ROW, and this is where.
+ *
+ * **THE LINE AND NOT THE ITEM**, which is the whole reason the attribute is
+ * where it is: an `<li>` in this tree contains every row nested under it, so its
+ * box is a subtree's box. Both gestures are about the lines a reader SEES — the
+ * gaps between them for a drop, the ones a pull passes over for a sweep — so the
+ * mark sits on the row's own line (`../Tree.tsx`).
+ *
+ * **DOCUMENT COORDINATES**, for two reasons that arrive together: the answer
+ * survives the page scrolling under a live gesture (which the gestures now do
+ * on purpose — `../autoscroll.ts`), and the affordances that promise it are
+ * positioned absolutely against the page rather than the window.
+ *
+ * MEASURED ONCE, when a gesture begins. Nothing here is optimistic, so nothing
+ * on screen moves while a row is in the air — the tree redraws when the file
+ * says so. Measuring per `pointermove` would be a forced layout per frame over
+ * every row of the tree for an answer that cannot have changed.
+ */
+
+/** The attribute a row's LINE carries so a gesture can find it. */
+export const ROW_KEY = "data-row-key"
+
+/** One drawn row's line, measured. What a gesture needs about a row BEFORE it
+ *  needs anything about the node — the drop planner's extra facts ride on top
+ *  of this rather than beside it (`./plan.ts`'s `Placed`). */
+export interface Line {
+  /** `Row.key` — the PLACE, which is what a selection and the caret name. */
+  readonly key: string
+  readonly top: number
+  readonly bottom: number
+  /** The left edge of the line, which is what the depth of a gap is read
+   *  against and what the width of a sweep's band starts at. */
+  readonly left: number
+  readonly right: number
+}
+
+/**
+ * Every drawn line on the page, in the order they are drawn.
+ *
+ * Document order IS drawn order — that is what `querySelectorAll` answers in —
+ * which is what lets the sweep's crossed rows be a contiguous run without a
+ * second sort, and what lets the drop planner's walk back for an ancestor
+ * always find one.
+ */
+export const measureLines = (): ReadonlyArray<Line> => {
+  const scrollX = window.scrollX
+  const scrollY = window.scrollY
+  return [...document.querySelectorAll(`[${ROW_KEY}]`)].flatMap((line): ReadonlyArray<Line> => {
+    const key = line.getAttribute(ROW_KEY)
+    if (key === null) return []
+    const box = line.getBoundingClientRect()
+    return [{
+      key,
+      top: box.top + scrollY,
+      bottom: box.bottom + scrollY,
+      left: box.left + scrollX,
+      right: box.right + scrollX,
+    }]
+  })
+}

--- a/packages/web/src/client/drag/plan.ts
+++ b/packages/web/src/client/drag/plan.ts
@@ -35,10 +35,17 @@
  * twice: a place the write could not go is a place the pointer cannot ask for.
  */
 
-/** One row the drop can land beside, as measured on screen. */
-export interface Placed {
-  /** `Row.key` — the place, which is what a selection and the caret name. */
-  readonly key: string
+import type { Line } from "./lines.ts"
+
+/**
+ * One row the drop can land beside: a measured LINE (`./lines.ts`), plus the
+ * four things a PLACEMENT needs that a box cannot say.
+ *
+ * Built ON the line rather than beside it, because "where the row is drawn" is
+ * one fact with one reading — the sweep asks for exactly the same one, and two
+ * flat records sharing five fields is one concept written twice.
+ */
+export interface Placed extends Line {
   /** The RECORD's id: what a `place` names, so a placement moves as itself. */
   readonly id: string
   /** The record it sits under, `null` at the top level of the page. */
@@ -65,17 +72,6 @@ export interface Placed {
   readonly into: string | null
   /** How far in it is drawn, counted from the roots of this page. */
   readonly depth: number
-  readonly top: number
-  readonly bottom: number
-  /** The left edge of its line, which is what the depth of a gap is read
-   *  against. */
-  readonly left: number
-  /** The right edge of it. Nothing here reads it — a placement is decided by
-   *  the gap and the depth — but the indicator drawn to promise the answer has
-   *  to end somewhere, and this is the measurement it ends at. Carried on the
-   *  measured row rather than taken a second time, so the line and the answer
-   *  are read off one look at the page. */
-  readonly right: number
 }
 
 /**

--- a/packages/web/src/client/drag/sweep.test.ts
+++ b/packages/web/src/client/drag/sweep.test.ts
@@ -8,7 +8,8 @@
 
 import { describe, expect, test } from "bun:test"
 
-import { type Line, planSweep } from "./sweep.ts"
+import type { Line } from "./lines.ts"
+import { planSweep } from "./sweep.ts"
 
 /** Four rows down the page, the second and third indented — the shape that
  *  makes "a band is not a box" checkable: a rectangle drawn down the left of

--- a/packages/web/src/client/drag/sweep.test.ts
+++ b/packages/web/src/client/drag/sweep.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The band's arithmetic: which rows a pull crosses, and which end is which.
+ *
+ * Rows are laid out at 20px each with no gap, so a y is easy to read as a row
+ * number — the point of every case below is a RULE, and a fixture nobody can
+ * hold in their head turns a failing rule into a puzzle about the fixture.
+ */
+
+import { describe, expect, test } from "bun:test"
+
+import { type Line, planSweep } from "./sweep.ts"
+
+/** Four rows down the page, the second and third indented — the shape that
+ *  makes "a band is not a box" checkable: a rectangle drawn down the left of
+ *  this would miss them. */
+const ROWS: ReadonlyArray<Line> = [
+  { key: "/a", top: 0, bottom: 20, left: 100, right: 500 },
+  { key: "/a/b", top: 20, bottom: 40, left: 132, right: 500 },
+  { key: "/a/b/c", top: 40, bottom: 60, left: 164, right: 500 },
+  { key: "/d", top: 60, bottom: 80, left: 100, right: 500 },
+]
+
+describe("planSweep", () => {
+  test("an empty page has nothing to sweep and nothing to draw", () => {
+    expect(planSweep([], 10, 90)).toBeNull()
+  })
+
+  test("crosses every row the pull passed over, in drawn order", () => {
+    expect(planSweep(ROWS, 10, 50)?.run?.keys).toEqual(["/a", "/a/b", "/a/b/c"])
+  })
+
+  test("the end it began at is the anchor, pulling down", () => {
+    const run = planSweep(ROWS, 10, 50)?.run
+    expect(run?.from).toBe("/a")
+    expect(run?.to).toBe("/a/b/c")
+  })
+
+  test("...and pulling UP the two ends swap, which is what a person means", () => {
+    const run = planSweep(ROWS, 50, 10)?.run
+    expect(run?.keys).toEqual(["/a", "/a/b", "/a/b/c"])
+    expect(run?.from).toBe("/a/b/c")
+    expect(run?.to).toBe("/a")
+  })
+
+  test("depth is not read at all: the deepest row is crossed like any other", () => {
+    // The whole of "a band, not a box". The pull is entirely to the LEFT of the
+    // indented rows' own left edge, and they are crossed regardless — a
+    // rectangle would have had to miss them.
+    expect(planSweep(ROWS, 45, 55)?.run?.keys).toEqual(["/a/b/c"])
+  })
+
+  test("a band that touches a row's edge has crossed it", () => {
+    // Clipping the top pixel of a row and not picking it is the answer nobody
+    // means — this is deliberately not the drop planner's middle-crossing rule,
+    // which is choosing between two gaps rather than passing over a line.
+    expect(planSweep(ROWS, 58, 60)?.run?.keys).toEqual(["/a/b/c", "/d"])
+  })
+
+  test("a live sweep that has crossed nothing is still a band", () => {
+    const sweep = planSweep(ROWS, 100, 140)
+    expect(sweep?.run).toBeNull()
+    expect(sweep?.top).toBe(100)
+    expect(sweep?.bottom).toBe(140)
+  })
+
+  test("the band spans the rows' own width, whichever way it was pulled", () => {
+    const down = planSweep(ROWS, 10, 50)
+    const up = planSweep(ROWS, 50, 10)
+    expect(down?.left).toBe(100)
+    expect(down?.width).toBe(400)
+    expect({ top: up?.top, bottom: up?.bottom }).toEqual({ top: 10, bottom: 50 })
+  })
+
+  test("a pull that has not left its own row yet is one row, read downward", () => {
+    const run = planSweep(ROWS, 30, 30)?.run
+    expect(run?.keys).toEqual(["/a/b"])
+    expect(run?.from).toBe("/a/b")
+    expect(run?.to).toBe("/a/b")
+  })
+})

--- a/packages/web/src/client/drag/sweep.ts
+++ b/packages/web/src/client/drag/sweep.ts
@@ -1,0 +1,122 @@
+/**
+ * Which rows a SWEEP crosses — the whole of drag-across that is arithmetic.
+ *
+ * Workflowy's fifth picking gesture: press where the outline is not and pull,
+ * and the rows the pull passes over are picked. Pure over measured rows, the
+ * way `./plan.ts` is and for the same reason: what a gesture reaches, and where
+ * the shape promising it goes, are one answer computed once rather than two
+ * readings of the page that could disagree.
+ *
+ * **IT IS A BAND, NOT A BOX**, and that is the one real decision in here. A
+ * rubber-band rectangle asks about two axes, and the second one has no meaning
+ * over an outline: a row is a LINE, drawn as far in as its depth says, so a
+ * rectangle drawn down the left of the page would cross a root and miss the
+ * grandchild indented past its right edge — which is a rule about pixels
+ * pretending to be a rule about the tree. So the sweep reads Y and spans the
+ * rows' own width, and what is DRAWN is exactly that (`./Sweep.tsx`): the shape
+ * on screen is the shape the answer was computed from, which is the promise
+ * every affordance in this client is held to.
+ *
+ * **WHAT COMES OUT IS A RUN WITH TWO ENDS**, and the ends are not
+ * interchangeable. A sweep is a range gesture, so where it BEGAN is the anchor
+ * a later shift-click or Shift+arrow measures from and where it ENDED is the
+ * focus those move — the same two ends `./../select/selection.ts` already keeps
+ * for the other four gestures. Sweeping upward and sweeping downward over the
+ * same rows are therefore different answers, which is what a person means by
+ * them.
+ *
+ * The run is always CONTIGUOUS in drawn order, because a band is: that is what
+ * lets the whole gesture land on the selection as one `across` rather than as a
+ * set nothing else here could describe.
+ */
+
+/** One drawn row, as measured on screen — in the document coordinates the rows
+ *  were measured in, so the answer survives the page scrolling under a live
+ *  gesture (`../autoscroll.ts`). */
+export interface Line {
+  /** `Row.key` — the PLACE, which is what a selection names. */
+  readonly key: string
+  readonly top: number
+  readonly bottom: number
+  readonly left: number
+  readonly right: number
+}
+
+/** The rows a band crosses, with its two ends named. */
+export interface Run {
+  /** Every place it crosses, in drawn order. */
+  readonly keys: ReadonlyArray<string>
+  /** The end the press began at — the anchor. */
+  readonly from: string
+  /** The end the pointer is at — the focus. */
+  readonly to: string
+}
+
+/**
+ * A live sweep: what it would pick, and where the band that promises it goes.
+ *
+ * ONE value, for the reason {@link ./plan.ts}'s `Landing` is one: a caller that
+ * took the run and then measured the band for itself would be reading the same
+ * rows twice.
+ */
+export interface Sweep {
+  readonly top: number
+  readonly bottom: number
+  readonly left: number
+  readonly width: number
+  /** `null` while the band crosses nothing — which is a real state and not an
+   *  absence: a sweep that has begun below the last row and not yet reached it
+   *  is a live gesture picking nothing, and the band still has to be drawn. */
+  readonly run: Run | null
+}
+
+/**
+ * What a sweep from `fromY` to `toY` over these rows is asking for.
+ *
+ * `null` when there are no rows at all — an empty outline has nothing to sweep,
+ * so there is nothing to draw either, and a band over an empty page would be a
+ * gesture promising a pick it cannot make.
+ *
+ * A row is CROSSED when the band touches it anywhere, edges included. Not the
+ * middle-crossing rule the drop planner uses: that one is choosing between two
+ * gaps and wants a snap, and this one is asking "did the pull pass over this
+ * line", where clipping the top of a row and not picking it is the answer
+ * nobody means.
+ */
+export const planSweep = (
+  rows: ReadonlyArray<Line>,
+  fromY: number,
+  toY: number,
+): Sweep | null => {
+  if (rows.length === 0) return null
+  const top = Math.min(fromY, toY)
+  const bottom = Math.max(fromY, toY)
+  const keys: Array<string> = []
+  // One pass for both halves: which rows are crossed, and how wide the rows
+  // are. A reduce per edge would be three walks of the same array per frame.
+  let left = Infinity
+  let right = -Infinity
+  for (const row of rows) {
+    if (row.left < left) left = row.left
+    if (row.right > right) right = row.right
+    if (row.bottom >= top && row.top <= bottom) keys.push(row.key)
+  }
+  const first = keys[0]
+  const last = keys[keys.length - 1]
+  const ends = first === undefined || last === undefined
+    ? null
+    // Which end is the anchor is which way the pull went, and a sweep that has
+    // not left its own line yet (`toY === fromY`) is read as downward — the
+    // direction the next pixel of an unfinished gesture is most likely to go,
+    // and a one-row run where both ends are the same row either way.
+    : toY >= fromY
+    ? { from: first, to: last }
+    : { from: last, to: first }
+  return {
+    top,
+    bottom,
+    left,
+    width: Math.max(0, right - left),
+    run: ends === null ? null : { keys, from: ends.from, to: ends.to },
+  }
+}

--- a/packages/web/src/client/drag/sweep.ts
+++ b/packages/web/src/client/drag/sweep.ts
@@ -30,17 +30,7 @@
  * set nothing else here could describe.
  */
 
-/** One drawn row, as measured on screen — in the document coordinates the rows
- *  were measured in, so the answer survives the page scrolling under a live
- *  gesture (`../autoscroll.ts`). */
-export interface Line {
-  /** `Row.key` — the PLACE, which is what a selection names. */
-  readonly key: string
-  readonly top: number
-  readonly bottom: number
-  readonly left: number
-  readonly right: number
-}
+import type { Line } from "./lines.ts"
 
 /** The rows a band crosses, with its two ends named. */
 export interface Run {

--- a/packages/web/src/client/drag/sweep.ts
+++ b/packages/web/src/client/drag/sweep.ts
@@ -106,7 +106,9 @@ export const planSweep = (
     top,
     bottom,
     left,
-    width: Math.max(0, right - left),
+    // No clamp: `left` is the least of every row's and `right` the greatest of
+    // every row's, over the same non-empty list, so this cannot be negative.
+    width: right - left,
     run: ends === null ? null : { keys, from: ends.from, to: ends.to },
   }
 }

--- a/packages/web/src/client/drag/sweeping.ts
+++ b/packages/web/src/client/drag/sweeping.ts
@@ -52,9 +52,9 @@
  * than half-built, and the four other pickers already reach any set it would.
  */
 
-import { type Accessor, createSignal, onCleanup } from "solid-js"
+import { type Accessor, createSignal } from "solid-js"
 
-import { drag as pointerDrag } from "../pointer.ts"
+import { createDrags, TRAVEL_PX } from "../pointer.ts"
 import { type Line, measureLines } from "./lines.ts"
 import { planSweep, type Run, type Sweep } from "./sweep.ts"
 
@@ -74,12 +74,6 @@ import { planSweep, type Run, type Sweep } from "./sweep.ts"
  */
 export const SWEEP = "data-sweep"
 
-/** How far the pointer must travel before a press becomes a sweep. The bullet's
- *  own number (`./dragging.ts`), and for the same reason: a press that never
- *  travels is a click on the page, and a hand resting on a trackpad produces
- *  about this much without meaning to. */
-const THRESHOLD = 4
-
 export interface Sweeping {
   /** The live band, or `null` when nothing is being swept. */
   readonly band: Accessor<Sweep | null>
@@ -88,24 +82,19 @@ export interface Sweeping {
   readonly begin: (event: PointerEvent) => void
 }
 
-export const createSweeping = (
-  page: {
-    readonly selection: {
-      /** The whole of what a sweep asks of the pick: this run, with these two
-       *  ends. */
-      readonly across: (keys: Iterable<string>, from: string, to: string) => void
-      readonly clear: () => void
-    }
-  },
-): Sweeping => {
+/** The whole of what a sweep asks of the pick: what is held, this run with its
+ *  two ends, and putting it away. */
+interface Picked {
+  readonly keys: Accessor<ReadonlySet<string>>
+  readonly across: (keys: Iterable<string>, from: string, to: string) => void
+  readonly clear: () => void
+}
+
+export const createSweeping = (selection: Picked): Sweeping => {
   const [band, setBand] = createSignal<Sweep | null>(null)
-  /** The sweep in flight, so a page that goes away under one takes its window
-   *  listeners and its frame loop with it. The listeners are the WINDOW's by
-   *  design — a pointer that leaves the page is still pulling — which is what
-   *  makes an unmount mid-gesture a leak rather than a tidy-up
-   *  (`./dragging.ts` holds the same line for the same reason). */
-  let inFlight: (() => void) | undefined
-  onCleanup(() => inFlight?.())
+  /** This page's gestures: one at a time, and whatever is in flight is ended
+   *  with the page that made it (`../pointer.ts`). */
+  const drags = createDrags()
 
   const begin = (event: PointerEvent): void => {
     // The secondary button opens a context menu, and a finger is scrolling.
@@ -115,7 +104,12 @@ export const createSweeping = (
     // A press on the page puts the pick away, whether or not it becomes a
     // sweep — which is what pressing outside a selection means everywhere, and
     // the same statement the drag makes when it starts on an unpicked row.
-    page.selection.clear()
+    //
+    // ...and only when there IS one. A press on the page is the most ordinary
+    // thing that happens on it, and clearing an empty pick still writes a fresh
+    // set into the signal every row of the tree reads — the tree flattened and
+    // re-keyed, per background click, to reach the state it was already in.
+    if (selection.keys().size > 0) selection.clear()
 
     /** Where the pull began, in the page's own coordinates — fixed while the
      *  page scrolls under it, which is what makes an auto-scrolled sweep keep
@@ -134,11 +128,11 @@ export const createSweeping = (
       const run = next?.run ?? null
       if (run?.from === told?.from && run?.to === told?.to) return
       told = run
-      if (run === null) page.selection.clear()
-      else page.selection.across(run.keys, run.from, run.to)
+      if (run === null) selection.clear()
+      else selection.across(run.keys, run.from, run.to)
     }
-    inFlight = pointerDrag(event, {
-      threshold: THRESHOLD,
+    drags.start(event, {
+      threshold: TRAVEL_PX,
       // Measured when it BECOMES a sweep rather than at the press: a press that
       // turns out to be a click must not have walked the tree on its way past.
       //
@@ -157,10 +151,7 @@ export const createSweeping = (
       // rule turned round: a drop is a WRITE and half of one is a shape nobody
       // asked for, while a pick is a reading — the rows are still on screen,
       // still toned, and Escape is right there.
-      onEnd: () => {
-        inFlight = undefined
-        setBand(null)
-      },
+      onEnd: () => setBand(null),
     })
   }
 

--- a/packages/web/src/client/drag/sweeping.ts
+++ b/packages/web/src/client/drag/sweeping.ts
@@ -1,0 +1,186 @@
+/**
+ * DRAG-ACROSS: Workflowy's fifth picking gesture, and the one that had to
+ * settle an argument with the browser before it could exist.
+ *
+ * ## Text, or rows — and how the two stop competing
+ *
+ * A tree of prose has a gesture already: press and pull selects TEXT, and that
+ * is the browser's, older than this app and the thing a person does when they
+ * want to quote a line. A marquee is the same two motions meaning something
+ * else, so shipping one is deciding which of them a given pull is — and PR #159
+ * left the gesture out rather than decide it by accident.
+ *
+ * **WHERE THE PULL BEGINS DECIDES, and nothing else does.** A press that lands
+ * ON something — a title, a note, a badge, any control — is about that thing,
+ * and the browser keeps it: text selects exactly as it always did, including a
+ * selection that runs from one row's title down through three more. A press
+ * that lands on the outline's own SCAFFOLDING — the indent rails beside a
+ * branch, the strip left of a note, the gaps between rows, the page below the
+ * last one — is about the rows as things, because there is nothing else there
+ * for it to be about. One sentence, no modifier to hold, and no state: the same
+ * press means the same thing every time it lands in the same place.
+ *
+ * The scaffolding says so itself ({@link SWEEP}) rather than being inferred
+ * from what a press is NOT. An allowlist is the honest direction for this
+ * question: a control added to a row tomorrow inherits "the browser keeps it",
+ * which is the safe answer, where a blocklist would quietly turn that control
+ * into empty space until somebody noticed.
+ *
+ * Nothing is `preventDefault`ed to win the argument, and that is worth saying
+ * because it is the obvious way to write this and it is wrong: preventing the
+ * press also prevents the FOCUS it carries, so a row being typed in would keep
+ * its caret through a gesture that has just cleared the pick — and a draft that
+ * never blurred is a draft that never committed. What suppresses the text
+ * selection instead is the guard the shared gesture primitive already puts up
+ * for the panel edges (`../pointer.ts` sets `user-select: none` for the life of
+ * a press), so the browser declines to start one and everything else about the
+ * press behaves exactly as it does today.
+ *
+ * ## A finger is not doing this
+ *
+ * `pointerType === "touch"` is left alone, deliberately and permanently: a
+ * finger on the empty part of a page is scrolling it, which is the one gesture
+ * a reader cannot be asked to give up (`../longPress.ts` is the whole argument,
+ * and `on_a_phone.feature`'s scroll fence is where it is held). A phone reaches
+ * every pick this gesture makes through the four that came before it.
+ *
+ * ## What it is not
+ *
+ * The band picks a RUN, replacing whatever was picked before — it does not add
+ * to a pick the way ⌘-click does. A modifier that unioned a sweep with the
+ * standing selection is a real gesture and a further one; it is left out rather
+ * than half-built, and the four other pickers already reach any set it would.
+ */
+
+import { type Accessor, createSignal } from "solid-js"
+
+import { edgeScrolling } from "../autoscroll.ts"
+import { drag as pointerDrag } from "../pointer.ts"
+import { ROW_KEY } from "./dragging.ts"
+import { type Line, planSweep, type Run, type Sweep } from "./sweep.ts"
+
+/**
+ * The attribute the outline's own scaffolding wears, saying a press that lands
+ * on it is a sweep rather than a text selection.
+ *
+ * On the elements that hold rows and never words: the two `<ul>`s, the `<li>`,
+ * and the box the page draws them in (`../Tree.tsx`, `../edit/Editable.tsx`).
+ * Written as a literal at those sites rather than spread from this constant,
+ * and that is a performance rule rather than a style one — a JSX spread moves
+ * EVERY attribute of an element onto Solid's runtime spread path, where the
+ * `data-` facts a row carries would be diffed key by key on every frame the
+ * store publishes (`../longPress.ts` says the same about the two handlers it
+ * hands out). `claims.test.ts` is what keeps the literals and this name from
+ * drifting: exactly three files may spell it.
+ */
+export const SWEEP = "data-sweep"
+
+/** How far the pointer must travel before a press becomes a sweep. The bullet's
+ *  own number (`./dragging.ts`), and for the same reason: a press that never
+ *  travels is a click on the page, and a hand resting on a trackpad produces
+ *  about this much without meaning to. */
+const THRESHOLD = 4
+
+export interface Sweeping {
+  /** The live band, or `null` when nothing is being swept. */
+  readonly band: Accessor<Sweep | null>
+  /** A press on the page. Answers for it only when it landed on the
+   *  scaffolding; every other press goes past untouched. */
+  readonly begin: (event: PointerEvent) => void
+}
+
+export const createSweeping = (
+  page: {
+    readonly selection: {
+      /** The whole of what a sweep asks of the pick: this run, with these two
+       *  ends. */
+      readonly across: (keys: Iterable<string>, from: string, to: string) => void
+      readonly clear: () => void
+    }
+  },
+): Sweeping => {
+  const [band, setBand] = createSignal<Sweep | null>(null)
+
+  /**
+   * Every drawn row, measured ONCE when the sweep begins, in document
+   * coordinates.
+   *
+   * The drag's rules about what to leave out are not this gesture's: a drop
+   * has places it cannot go, and a PICK has none — a run of rows from two files
+   * is a legal thing to have picked, and the bulk verbs refuse what they must
+   * by name on the bar (`../select/SelectionBar.tsx`) rather than by the
+   * gesture pretending those rows are not on screen.
+   *
+   * Document order is drawn order, which is what `querySelectorAll` answers in
+   * and what makes the run below contiguous without a second sort.
+   */
+  const measure = (): ReadonlyArray<Line> => {
+    const scrollX = window.scrollX
+    const scrollY = window.scrollY
+    return [...document.querySelectorAll(`[${ROW_KEY}]`)].flatMap((line): ReadonlyArray<Line> => {
+      const key = line.getAttribute(ROW_KEY)
+      if (key === null) return []
+      const box = line.getBoundingClientRect()
+      return [{
+        key,
+        top: box.top + scrollY,
+        bottom: box.bottom + scrollY,
+        left: box.left + scrollX,
+        right: box.right + scrollX,
+      }]
+    })
+  }
+
+  const begin = (event: PointerEvent): void => {
+    // The secondary button opens a context menu, and a finger is scrolling.
+    if (event.button !== 0 || event.pointerType === "touch") return
+    const on = event.target
+    if (!(on instanceof Element) || !on.hasAttribute(SWEEP)) return
+    // A press on the page puts the pick away, whether or not it becomes a
+    // sweep — which is what pressing outside a selection means everywhere, and
+    // the same statement the drag makes when it starts on an unpicked row.
+    page.selection.clear()
+
+    /** Where the pull began, in the page's own coordinates — fixed while the
+     *  page scrolls under it, which is what makes an auto-scrolled sweep keep
+     *  growing rather than sliding. */
+    const from = event.pageY
+    let rows: ReadonlyArray<Line> = []
+    /** What the pick was last told. The band is re-planned on every frame the
+     *  page moves, and nearly all of those cross the same rows as the one
+     *  before — writing the pick anyway would re-key every row of the tree per
+     *  frame for an answer that has not changed. */
+    let told: Run | null = null
+
+    const plan = (y: number): void => {
+      const next = planSweep(rows, from, y)
+      setBand(next)
+      const run = next?.run ?? null
+      if (run?.from === told?.from && run?.to === told?.to) return
+      told = run
+      if (run === null) page.selection.clear()
+      else page.selection.across(run.keys, run.from, run.to)
+    }
+    const edge = edgeScrolling((_x, y) => plan(y))
+
+    pointerDrag(event, {
+      threshold: THRESHOLD,
+      // Measured when it BECOMES a sweep rather than at the press: a press that
+      // turns out to be a click must not have walked the tree on its way past.
+      onStart: () => {
+        rows = measure()
+      },
+      onMove: (move) => edge.at({ x: move.clientX, y: move.clientY }),
+      // A cancelled sweep keeps what it picked, and that is not the drop's
+      // rule turned round: a drop is a WRITE and half of one is a shape nobody
+      // asked for, while a pick is a reading — the rows are still on screen,
+      // still toned, and Escape is right there.
+      onEnd: () => {
+        edge.stop()
+        setBand(null)
+      },
+    })
+  }
+
+  return { band, begin }
+}

--- a/packages/web/src/client/drag/sweeping.ts
+++ b/packages/web/src/client/drag/sweeping.ts
@@ -101,12 +101,22 @@ export const createSweeping = (selection: Picked): Sweeping => {
     if (event.button !== 0 || event.pointerType === "touch") return
     const on = event.target
     if (!(on instanceof Element) || !on.hasAttribute(SWEEP)) return
-    // A press on the page puts the pick away, whether or not it becomes a
-    // sweep — which is what pressing outside a selection means everywhere, and
-    // the same statement the drag makes when it starts on an unpicked row.
+    // A press on the SCAFFOLDING puts the pick away, whether or not it becomes
+    // a sweep — which is what pressing outside a selection means everywhere,
+    // and the same statement the drag makes when it starts on an unpicked row.
     //
-    // ...and only when there IS one. A press on the page is the most ordinary
-    // thing that happens on it, and clearing an empty pick still writes a fresh
+    // ON THE SCAFFOLDING, and not on every press that looks like empty space,
+    // which is a boundary worth stating because it is the same allowlist read
+    // twice rather than two rules. A press that lands on SOMETHING is about
+    // that thing, and the two answers between them cover it: anything that
+    // opens a caret puts the pick away where every caret comes from
+    // (`../edit/editing.tsx`'s `open`), and anything else — a checkbox, a
+    // triangle, a badge, the `•••` — is aimed at the row rather than at
+    // nothing, so keeping the pick is the honest reading of it (review,
+    // 2026-08-14).
+    //
+    // ...and only when there IS one. A press here is the most ordinary thing
+    // that happens on a page, and clearing an empty pick still writes a fresh
     // set into the signal every row of the tree reads — the tree flattened and
     // re-keyed, per background click, to reach the state it was already in.
     if (selection.keys().size > 0) selection.clear()

--- a/packages/web/src/client/drag/sweeping.ts
+++ b/packages/web/src/client/drag/sweeping.ts
@@ -54,10 +54,9 @@
 
 import { type Accessor, createSignal, onCleanup } from "solid-js"
 
-import { edgeScrolling } from "../autoscroll.ts"
 import { drag as pointerDrag } from "../pointer.ts"
-import { ROW_KEY } from "./dragging.ts"
-import { type Line, planSweep, type Run, type Sweep } from "./sweep.ts"
+import { type Line, measureLines } from "./lines.ts"
+import { planSweep, type Run, type Sweep } from "./sweep.ts"
 
 /**
  * The attribute the outline's own scaffolding wears, saying a press that lands
@@ -108,36 +107,6 @@ export const createSweeping = (
   let inFlight: (() => void) | undefined
   onCleanup(() => inFlight?.())
 
-  /**
-   * Every drawn row, measured ONCE when the sweep begins, in document
-   * coordinates.
-   *
-   * The drag's rules about what to leave out are not this gesture's: a drop
-   * has places it cannot go, and a PICK has none — a run of rows from two files
-   * is a legal thing to have picked, and the bulk verbs refuse what they must
-   * by name on the bar (`../select/SelectionBar.tsx`) rather than by the
-   * gesture pretending those rows are not on screen.
-   *
-   * Document order is drawn order, which is what `querySelectorAll` answers in
-   * and what makes the run below contiguous without a second sort.
-   */
-  const measure = (): ReadonlyArray<Line> => {
-    const scrollX = window.scrollX
-    const scrollY = window.scrollY
-    return [...document.querySelectorAll(`[${ROW_KEY}]`)].flatMap((line): ReadonlyArray<Line> => {
-      const key = line.getAttribute(ROW_KEY)
-      if (key === null) return []
-      const box = line.getBoundingClientRect()
-      return [{
-        key,
-        top: box.top + scrollY,
-        bottom: box.bottom + scrollY,
-        left: box.left + scrollX,
-        right: box.right + scrollX,
-      }]
-    })
-  }
-
   const begin = (event: PointerEvent): void => {
     // The secondary button opens a context menu, and a finger is scrolling.
     if (event.button !== 0 || event.pointerType === "touch") return
@@ -168,23 +137,28 @@ export const createSweeping = (
       if (run === null) page.selection.clear()
       else page.selection.across(run.keys, run.from, run.to)
     }
-    const edge = edgeScrolling((_x, y) => plan(y))
-
     inFlight = pointerDrag(event, {
       threshold: THRESHOLD,
       // Measured when it BECOMES a sweep rather than at the press: a press that
       // turns out to be a click must not have walked the tree on its way past.
+      //
+      // EVERY drawn line, with none of the drag's exclusions: a drop has places
+      // it cannot go and a PICK has none — a run of rows from two files is a
+      // legal thing to have picked, and the bulk verbs refuse what they must by
+      // name on the bar (`../select/SelectionBar.tsx`) rather than by the
+      // gesture pretending those rows are not on screen.
       onStart: () => {
-        rows = measure()
+        rows = measureLines()
       },
-      onMove: (move) => edge.at({ x: move.clientX, y: move.clientY }),
+      // Y only, and ON THE PAGE — which moves under a pointer held near an edge
+      // of the window, so a sweep reaches past the fold (`../pointer.ts`).
+      onPage: (_x, y) => plan(y),
       // A cancelled sweep keeps what it picked, and that is not the drop's
       // rule turned round: a drop is a WRITE and half of one is a shape nobody
       // asked for, while a pick is a reading — the rows are still on screen,
       // still toned, and Escape is right there.
       onEnd: () => {
         inFlight = undefined
-        edge.stop()
         setBand(null)
       },
     })

--- a/packages/web/src/client/drag/sweeping.ts
+++ b/packages/web/src/client/drag/sweeping.ts
@@ -52,7 +52,7 @@
  * than half-built, and the four other pickers already reach any set it would.
  */
 
-import { type Accessor, createSignal } from "solid-js"
+import { type Accessor, createSignal, onCleanup } from "solid-js"
 
 import { edgeScrolling } from "../autoscroll.ts"
 import { drag as pointerDrag } from "../pointer.ts"
@@ -100,6 +100,13 @@ export const createSweeping = (
   },
 ): Sweeping => {
   const [band, setBand] = createSignal<Sweep | null>(null)
+  /** The sweep in flight, so a page that goes away under one takes its window
+   *  listeners and its frame loop with it. The listeners are the WINDOW's by
+   *  design — a pointer that leaves the page is still pulling — which is what
+   *  makes an unmount mid-gesture a leak rather than a tidy-up
+   *  (`./dragging.ts` holds the same line for the same reason). */
+  let inFlight: (() => void) | undefined
+  onCleanup(() => inFlight?.())
 
   /**
    * Every drawn row, measured ONCE when the sweep begins, in document
@@ -163,7 +170,7 @@ export const createSweeping = (
     }
     const edge = edgeScrolling((_x, y) => plan(y))
 
-    pointerDrag(event, {
+    inFlight = pointerDrag(event, {
       threshold: THRESHOLD,
       // Measured when it BECOMES a sweep rather than at the press: a press that
       // turns out to be a click must not have walked the tree on its way past.
@@ -176,6 +183,7 @@ export const createSweeping = (
       // asked for, while a pick is a reading — the rows are still on screen,
       // still toned, and Escape is right there.
       onEnd: () => {
+        inFlight = undefined
         edge.stop()
         setBand(null)
       },

--- a/packages/web/src/client/edit/Editable.tsx
+++ b/packages/web/src/client/edit/Editable.tsx
@@ -16,10 +16,20 @@
  * are two: an outline and a zoomed node. A day lists nodes from all over the
  * set and a document is not an outline at all, so neither draws one.
  *
- * THE ORDER THE THREE ARE MADE IN IS THE DEPENDENCY between them, and it is
+ * THE ORDER THE FOUR ARE MADE IN IS THE DEPENDENCY between them, and it is
  * one way: the selection knows nothing about the caret, the editor hands the
- * caret over to it for the three keys that leave a row, and the drag reads the
- * selection to find out whether it is carrying one row or all of them.
+ * caret over to it for the three keys that leave a row, the drag reads the
+ * selection to find out whether it is carrying one row or all of them, and the
+ * sweep writes a run into it.
+ *
+ * THE PAGE'S BOX IS THE SWEEP'S SURFACE, and that is the one piece of markup
+ * this component owns. A drag-across begins where the outline is NOT
+ * (`../drag/sweeping.ts` decides what that means and why), so it needs a box
+ * that reaches the bottom of the pane rather than stopping at the last row —
+ * otherwise the only empty space on a short outline is a two-pixel gap between
+ * lines. One `pointerdown` listener for the whole page rather than one per
+ * surface: every scaffolding element bubbles to here, and the gesture answers
+ * only for the presses that landed on one.
  *
  * The SELECTION LAYER'S ONE WINDOW LISTENER is here for the reason the editor's
  * keys are on the editor's own element: a pick has no focused element to hang a
@@ -35,6 +45,8 @@ import { type Accessor, type JSX, onCleanup, onMount } from "solid-js"
 import { collapsedNodes } from "../fold/memory.ts"
 import { createDragging, DraggingProvider } from "../drag/dragging.ts"
 import { DropLine } from "../drag/DropLine.tsx"
+import { SweepBand } from "../drag/Sweep.tsx"
+import { createSweeping } from "../drag/sweeping.ts"
 import { isEditingTarget, type SelectAction, selectKey } from "../keys.ts"
 import { createSelection, type Selection, SelectionProvider } from "../select/selection.ts"
 import { SelectionBar } from "../select/SelectionBar.tsx"
@@ -56,6 +68,7 @@ export function Editable(props: {
   const selection = createSelection(page)
   const editor = createEditor(page, selection)
   const dragging = createDragging({ ...page, selection })
+  const sweeping = createSweeping({ selection })
 
   onMount(() => {
     const onKey = (event: KeyboardEvent) => {
@@ -79,8 +92,18 @@ export function Editable(props: {
     <SelectionProvider value={selection}>
       <DraggingProvider value={dragging}>
         <EditorProvider editor={editor}>
-          {props.children}
+          {/* `min-h-full` so the box reaches the foot of the pane: the page
+              below a short outline is the sweep's largest surface, and a
+              wrapper that stopped at the last row would leave a reader nothing
+              to press. `data-sweep` is `../drag/sweeping.ts`'s `SWEEP`, spelled
+              as a literal for the reason that constant gives (a JSX spread
+              would put every attribute of this box on Solid's runtime spread
+              path) and held to that name by `../claims.test.ts`. */}
+          <div class="min-h-full" data-sweep="" onPointerDown={sweeping.begin}>
+            {props.children}
+          </div>
           <DropLine landing={dragging.landing()} />
+          <SweepBand sweep={sweeping.band()} />
           <SelectionBar />
         </EditorProvider>
       </DraggingProvider>

--- a/packages/web/src/client/edit/Editable.tsx
+++ b/packages/web/src/client/edit/Editable.tsx
@@ -68,7 +68,7 @@ export function Editable(props: {
   const selection = createSelection(page)
   const editor = createEditor(page, selection)
   const dragging = createDragging({ ...page, selection })
-  const sweeping = createSweeping({ selection })
+  const sweeping = createSweeping(selection)
 
   onMount(() => {
     const onKey = (event: KeyboardEvent) => {

--- a/packages/web/src/client/focus.ts
+++ b/packages/web/src/client/focus.ts
@@ -29,11 +29,13 @@
  * that MOVES the page stays here and the one that changes the ADDRESS stays
  * with the router.
  *
- * The scroll is the third statement in this client that moves the page, and the
- * other two are `./scroll.ts`'s — which says so in its own header. It is
+ * The scroll is one of four statements in this client that move the page. Two
+ * are `./scroll.ts`'s — which says so in its own header — and it is
  * deliberately not one of them: those two are what a NAVIGATION does, and this
  * is a page staying exactly where it is except for the row somebody asked to
- * see.
+ * see. The fourth is `./autoscroll.ts`'s, which is neither: a page keeping up
+ * with a gesture that has run out of screen, moving for as long as a hand holds
+ * it near an edge.
  */
 
 import { type Accessor, createSignal } from "solid-js"

--- a/packages/web/src/client/longPress.ts
+++ b/packages/web/src/client/longPress.ts
@@ -102,7 +102,11 @@ type Finger =
   /** Down, still, and the deadline is running. */
   | {
     readonly kind: "holding"
-    readonly from: { readonly x: number; readonly y: number }
+    /** The press that armed it — which is also WHERE it landed, read off the
+     *  event rather than copied beside it. A consumer that has to start
+     *  something from the press gets it back ({@link longPressOn}) instead of
+     *  keeping a second copy in a field this union cannot see. */
+    readonly from: PointerEvent
     readonly until: ReturnType<typeof setTimeout>
   }
   /** Down, but no longer a press: it drifted, or a second finger joined it
@@ -118,14 +122,14 @@ type Finger =
  * Call it in the owner that draws the element — a row — so a row that goes
  * away mid-press takes its timer and its transient listeners with it.
  */
-export const longPressOn = (press: () => void): LongPress => {
+export const longPressOn = (press: (from: PointerEvent) => void): LongPress => {
   let finger: Finger = { kind: "gone" }
 
   const move = (event: PointerEvent): void => {
     if (finger.kind !== "holding") return
     const drift = Math.hypot(
-      event.clientX - finger.from.x,
-      event.clientY - finger.from.y,
+      event.clientX - finger.from.clientX,
+      event.clientY - finger.from.clientY,
     )
     // Adrift, not gone: the finger is still down, and it is its LIFT that
     // takes the listeners off.
@@ -163,10 +167,15 @@ export const longPressOn = (press: () => void): LongPress => {
     if (opened) swallowGhost()
   }
 
-  /** Fire it, from whichever deadline arrived — ours or the platform's. */
+  /** Fire it, from whichever deadline arrived — ours or the platform's. The
+   *  press that armed it goes with it: neither deadline carries an event of its
+   *  own, and a consumer that starts something from the press would otherwise
+   *  have to keep a copy of it outside this union. */
   const fire = (): void => {
+    if (finger.kind !== "holding") return
+    const from = finger.from
     finger = stop({ kind: "held" })
-    press()
+    press(from)
   }
 
   onCleanup(release)
@@ -192,7 +201,7 @@ export const longPressOn = (press: () => void): LongPress => {
       window.addEventListener("pointercancel", release)
       finger = {
         kind: "holding",
-        from: { x: event.clientX, y: event.clientY },
+        from: event,
         until: setTimeout(fire, LONG_PRESS_MS),
       }
     },

--- a/packages/web/src/client/menu/door.ts
+++ b/packages/web/src/client/menu/door.ts
@@ -49,6 +49,7 @@
 
 import { type Accessor, createSignal } from "solid-js"
 
+import { HANDLE } from "../drag/dragging.ts"
 import { type LongPress, longPressOn } from "../longPress.ts"
 
 /** All of what a row's menu is. */
@@ -56,7 +57,8 @@ type Door = "unasked" | "shut" | "open"
 
 export interface MenuDoor {
   /** The phone's door, as the two handlers that make it. Put them on the row's
-   *  own line, which is what a finger is held on. */
+   *  own line, which is what a finger is held on — everywhere but the handle,
+   *  and that exception is answered in here rather than by the row. */
   readonly hold: LongPress
   /** Wire as `ref` on that same line. It is the same element twice for a
    *  reason: what a finger is held ON is what the panel then hangs OFF, since
@@ -79,6 +81,29 @@ export interface MenuDoor {
   readonly setOpen: (open: boolean) => void
 }
 
+/**
+ * ...EXCEPT ON THE ROW'S HANDLE, and this is the door's answer rather than the
+ * row's.
+ *
+ * A phone picks a row up by HOLDING its bullet (`../drag/dragging.ts`), which
+ * is the same gesture on the same row — and two long presses cannot both own
+ * one press. The one that gives way is this door, because the menu has a whole
+ * row to be reached from and a handle has only itself. It is answered HERE for
+ * the reason everything else about this door is: "how this menu is reached" is
+ * this module's question, and a rule spelled at the row is a rule the next row
+ * forgets.
+ *
+ * TOUCH ONLY, which is not belt and braces: below the deadline this watcher
+ * still has bookkeeping to do for a mouse or a pen (`../longPress.ts` resets
+ * itself on one), and skipping it wholesale would leave that state stale — as
+ * well as walking the ancestors of every press on every device to answer a
+ * question only a finger can ask.
+ */
+const onTheHandle = (event: PointerEvent): boolean =>
+  event.pointerType === "touch" &&
+  event.target instanceof Element &&
+  event.target.closest(`[${HANDLE}]`) !== null
+
 /** Call it in the row's own owner: the gesture's timer and its listeners are
  *  disposed with the row that was being pressed. */
 export const createMenuDoor = (): MenuDoor => {
@@ -86,12 +111,19 @@ export const createMenuDoor = (): MenuDoor => {
   const show = (): void => {
     setDoor("open")
   }
+  const press = longPressOn(show)
   /** Not a signal: it is read when the panel is placed, which is after the row
    *  has been drawn, and nothing re-runs when it arrives. */
   let line: HTMLElement | undefined
 
   return {
-    hold: longPressOn(show),
+    hold: {
+      onPointerDown: (event) => {
+        if (onTheHandle(event)) return
+        press.onPointerDown(event)
+      },
+      onContextMenu: press.onContextMenu,
+    },
     line: (el) => {
       line = el
     },

--- a/packages/web/src/client/pointer.ts
+++ b/packages/web/src/client/pointer.ts
@@ -38,6 +38,8 @@
  * scrolling the outline behind it would be this used by accident.
  */
 
+import { onCleanup } from "solid-js"
+
 import { edgeScrolling } from "./autoscroll.ts"
 
 export interface Gesture {
@@ -71,9 +73,23 @@ export interface Gesture {
   readonly onEnd: (event: PointerEvent | null) => void
   /** How far the pointer must travel, in pixels, before any of this counts.
    *  `0` (the default) is "immediately", which is what a handle that is only a
-   *  handle wants. */
+   *  handle wants; {@link TRAVEL_PX} is what a handle that is also something
+   *  else wants. */
   readonly threshold?: number
 }
+
+/**
+ * How far a pointer must travel before a press on a handle that is ALSO
+ * something else counts as a drag. Four pixels is what a hand resting on a
+ * trackpad produces without meaning to.
+ *
+ * Here rather than at the call sites for the reason the threshold itself is
+ * here: two gestures over the outline ask the same question of the same kind of
+ * handle — a bullet that is a link, a page that is text — and a number each of
+ * them spelled for itself is a number they could answer differently. (A panel
+ * edge is the other case, and it wants no threshold at all.)
+ */
+export const TRAVEL_PX = 4
 
 /**
  * Start listening. Answers with the teardown, for a caller that has to end the
@@ -106,7 +122,7 @@ export const drag = (from: PointerEvent, gesture: Gesture): (() => void) => {
       gesture.onStart?.(event)
     }
     gesture.onMove?.(event)
-    following?.at({ x: event.clientX, y: event.clientY })
+    following?.at(event.clientX, event.clientY)
   }
 
   const end = (event: PointerEvent | null) => {
@@ -124,4 +140,45 @@ export const drag = (from: PointerEvent, gesture: Gesture): (() => void) => {
   window.addEventListener("pointerup", onUp)
   window.addEventListener("pointercancel", onCancel)
   return () => end(null)
+}
+
+/**
+ * ONE GESTURE AT A TIME, belonging to whoever made this.
+ *
+ * {@link drag} answers with its teardown and leaves the caller holding it, and
+ * that turned out to be a three-part rule every consumer wrote out for itself:
+ * keep the handle, `onCleanup` it, and clear it when the gesture ends. The
+ * parts are separable — forget the third and a stale teardown cancels a gesture
+ * that already finished — and forgetting the second leaks a window listener set
+ * and, now, a frame loop past the page that made them. That is the same shape
+ * as {@link Gesture.onPage}, and it belongs in the same place.
+ *
+ * It cannot be {@link drag}'s own `onCleanup`: a drag begins in an EVENT
+ * HANDLER, which in Solid runs under no owner at all, so a cleanup registered
+ * there would be registered against nothing. So the owner is captured where
+ * there is one — call this in the component that will start the gestures — and
+ * spent at the press.
+ *
+ * A second press while one is in flight ENDS the first, as a cancellation. Two
+ * pointers over one thing is not two gestures.
+ */
+export interface Drags {
+  readonly start: (from: PointerEvent, gesture: Gesture) => void
+}
+
+export const createDrags = (): Drags => {
+  let inFlight: (() => void) | undefined
+  onCleanup(() => inFlight?.())
+  return {
+    start: (from, gesture) => {
+      inFlight?.()
+      inFlight = drag(from, {
+        ...gesture,
+        onEnd: (event) => {
+          inFlight = undefined
+          gesture.onEnd(event)
+        },
+      })
+    },
+  }
 }

--- a/packages/web/src/client/pointer.ts
+++ b/packages/web/src/client/pointer.ts
@@ -30,13 +30,41 @@
  * `addEventListener`, and the SolidJS drag libraries in reach own a sortable
  * LIST — flat, one container, no depth — which is the shape neither consumer
  * has.
+ *
+ * THE PAGE KEEPING UP is here for the same reason the threshold is
+ * ({@link Gesture.onPage}): it is a paired obligation — feed it, and stop it on
+ * every way a gesture can end — and it was about to be wired identically by the
+ * two consumers that want it. Opt-in, because the third does not: a panel edge
+ * scrolling the outline behind it would be this used by accident.
  */
+
+import { edgeScrolling } from "./autoscroll.ts"
 
 export interface Gesture {
   /** The pointer has travelled far enough to be a drag rather than a press.
    *  Called at most once, before the first {@link onMove}. */
   readonly onStart?: (event: PointerEvent) => void
-  readonly onMove: (event: PointerEvent) => void
+  /** The pointer moved. Where it is in the WINDOW, which is what a width is
+   *  computed from; a gesture aimed at the page wants {@link onPage} instead. */
+  readonly onMove?: (event: PointerEvent) => void
+  /**
+   * Where the pointer is ON THE PAGE, in document coordinates — and, because
+   * asking that is what a gesture aimed at rows does, the page KEEPS UP: held
+   * near an edge of the window it scrolls, and this is called again on every
+   * frame it moves (`./autoscroll.ts`).
+   *
+   * It is here rather than in each caller because both gestures that want it
+   * were wiring the same two lines, and it is a PAIRED obligation — feed it on
+   * every move, and stop it on every way the gesture can end — which is exactly
+   * the kind of thing this module took over for the panel edges. Composed here,
+   * a caller cannot forget the second half, and the frame loop dies with the
+   * gesture rather than with whoever remembered.
+   *
+   * Absent means the page does not move, which is the right answer for a
+   * gesture that is not about the page at all: a panel edge scrolling the
+   * outline behind it would be this option used by accident.
+   */
+  readonly onPage?: (x: number, y: number) => void
   /** The gesture is over. `null` means it was CANCELLED — the pointer was
    *  taken away rather than released — which is a different answer from "let
    *  go here" and the one a caller must not read as a drop. */
@@ -65,6 +93,11 @@ export const drag = (from: PointerEvent, gesture: Gesture): (() => void) => {
   // The press must not select the text under it while the pointer travels.
   const selection = document.body.style.userSelect
   document.body.style.userSelect = "none"
+  /** Only for a gesture that asked to follow the page. Nothing is scheduled and
+   *  nothing is listened for otherwise. */
+  const following = gesture.onPage === undefined
+    ? undefined
+    : edgeScrolling(gesture.onPage)
 
   const onMove = (event: PointerEvent) => {
     if (!started) {
@@ -72,7 +105,8 @@ export const drag = (from: PointerEvent, gesture: Gesture): (() => void) => {
       started = true
       gesture.onStart?.(event)
     }
-    gesture.onMove(event)
+    gesture.onMove?.(event)
+    following?.at({ x: event.clientX, y: event.clientY })
   }
 
   const end = (event: PointerEvent | null) => {
@@ -80,6 +114,7 @@ export const drag = (from: PointerEvent, gesture: Gesture): (() => void) => {
     window.removeEventListener("pointerup", onUp)
     window.removeEventListener("pointercancel", onCancel)
     document.body.style.userSelect = selection
+    following?.stop()
     gesture.onEnd(event)
   }
   const onUp = (event: PointerEvent) => end(event)

--- a/packages/web/src/client/pointer.ts
+++ b/packages/web/src/client/pointer.ts
@@ -106,7 +106,29 @@ export const drag = (from: PointerEvent, gesture: Gesture): (() => void) => {
   const originY = from.pageY
   const threshold = gesture.threshold ?? 0
   let started = false
-  // The press must not select the text under it while the pointer travels.
+  /**
+   * The press must not select the text under it while the pointer travels.
+   *
+   * SAVED AND PUT BACK PER GESTURE, WHICH IS NOT RE-ENTRANT, and that is
+   * recorded rather than fixed. Two gestures live at once from different owners
+   * — a pen holding a panel edge while a mouse begins a sweep, which is two
+   * hands — would nest their save and restore: the inner one saves `none`, the
+   * outer one puts back `""` while the inner is still travelling, and the inner
+   * one then puts `none` back on the body for good. One gesture per owner is
+   * already serialised ({@link createDrags} ends whatever was in flight), so
+   * the reachable case is that pair of hands.
+   *
+   * A counter here would close it, and it is not one line: it is module state,
+   * a token per gesture and a release that must be idempotent — machinery no
+   * test in this repo can exercise, guarding a case no hand can reach by
+   * accident. What makes the leak survivable meanwhile is that this is the only
+   * file in the client that touches `body.style.userSelect` (`claims.test.ts`
+   * neighbours sweep exactly this kind of monopoly), so the saved value is
+   * always `""`: the failure is a stray `user-select: none` until the next
+   * reload, never a wrong value put back. Reachable by a real hand, or a second
+   * writer of this property, is when it becomes a counter. (Review, 2026-08-14,
+   * carrying a shape #159 shipped.)
+   */
   const selection = document.body.style.userSelect
   document.body.style.userSelect = "none"
   /** Only for a gesture that asked to follow the page. Nothing is scheduled and

--- a/packages/web/src/client/scroll.ts
+++ b/packages/web/src/client/scroll.ts
@@ -9,9 +9,10 @@
  * one. This is the decision: a page you go TO starts at the top, a page you go
  * BACK to is where you left it, and every statement a NAVIGATION makes about
  * where the page is is in here — including telling the browser to stop moving
- * it itself. (The one statement outside it is ./focus.ts's, which moves a page
- * that is not navigating anywhere: a row somebody asked to be shown, brought
- * into view where they are.) ./router.tsx
+ * it itself. (The two statements outside it move a page that is not navigating
+ * anywhere: ./focus.ts's, a row somebody asked to be shown brought into view
+ * where they are; and ./autoscroll.ts's, a page keeping up with a gesture that
+ * has run out of screen.) ./router.tsx
  * says WHICH of the two a navigation gets, because a push and a pop are the one
  * thing it knows that this module does not.
  *

--- a/packages/web/src/client/select/selection.ts
+++ b/packages/web/src/client/select/selection.ts
@@ -192,7 +192,10 @@ export const createSelection = (
       const at = anchor() ?? key
       pick(spanning(drawn(), at, key), at, key)
     },
-    across: (keys, from, to) => pick(keys, from, to),
+    // The private verb, handed out: a sweep names the run and both its ends,
+    // which is exactly what a pick IS — where the other gestures have to derive
+    // one or both of those from the rows on screen first.
+    across: pick,
     grow: (by) => {
       const end = focus() ?? anchor()
       if (end === null) return

--- a/packages/web/src/client/select/selection.ts
+++ b/packages/web/src/client/select/selection.ts
@@ -66,6 +66,13 @@ export interface Selection {
   readonly toggle: (key: string) => void
   /** Shift-click: everything between the anchor and this row. */
   readonly extend: (key: string) => void
+  /** Drag-across: exactly this run, with the two ends the sweep gave it — where
+   *  the pull began is the anchor a later shift-click measures from, and where
+   *  it ended is the focus an arrow moves (`../drag/sweeping.ts`). It takes the
+   *  KEYS rather than the two ends alone because the sweep has already walked
+   *  the rows it crossed, and asking `spanning` for them again would be that
+   *  walk a second time, per frame. */
+  readonly across: (keys: Iterable<string>, from: string, to: string) => void
   /** Shift+arrow: one row further, in the direction pressed. */
   readonly grow: (by: 1 | -1) => void
   /** The ⌘A ladder: this row's siblings first, then every row on the page.
@@ -185,6 +192,7 @@ export const createSelection = (
       const at = anchor() ?? key
       pick(spanning(drawn(), at, key), at, key)
     },
+    across: (keys, from, to) => pick(keys, from, to),
     grow: (by) => {
       const end = focus() ?? anchor()
       if (end === null) return

--- a/packages/web/src/client/testids.ts
+++ b/packages/web/src/client/testids.ts
@@ -352,6 +352,12 @@ export const TESTID = {
    *  first among them), and `data-depth` how far in the line is drawn — the
    *  three facts that are still a prediction until the pointer is released. */
   dropLine: "drop-line",
+  /** The band a drag-across pulls, while it is being pulled and never
+   *  otherwise. `data-rows` is how many rows it is crossing right now — the one
+   *  thing about a sweep that is still a prediction while the pointer is down.
+   *  A BAND rather than a rubber-band box, because a row is a line and the
+   *  gesture reads only Y (`drag/sweep.ts`). */
+  sweepBand: "sweep-band",
   /** The bar a multi-selection draws: how many rows are picked, the one verb
    *  that has no key, and what the last bulk write said. `data-rows` is the
    *  count the verbs are asked of — the picked rows nothing else picked

--- a/packages/web/src/client/touch.ts
+++ b/packages/web/src/client/touch.ts
@@ -170,3 +170,21 @@ export const ROW_NOTE = "text-[0.875rem] leading-snug text-muted"
 
 /** How far a child list indents from its parent, and the vertical guide. */
 export const CHILD_INDENT = "ml-3 list-none border-l border-rule pl-3 md:ml-4 md:pl-4"
+
+/**
+ * The outline's own left RAIL: the strip a press can land on beside a row that
+ * has no list above it to indent from.
+ *
+ * A nested list gives its branch one for free — the padding half of
+ * {@link CHILD_INDENT} is scaffolding a person can press, which is what makes a
+ * drag-across startable beside any indented row (`../client/drag/sweeping.ts`).
+ * A ROOT row had none: the outline's own list is flush, so the leftmost
+ * empty-looking band on a flat inbox belonged to the row's hover controls, and
+ * the one sweep such a page could not make was a prefix of it.
+ *
+ * Taken out of the PANE's padding rather than out of the page — the negative
+ * margin and the padding are the same number — so the rail exists at depth 0
+ * and nothing moves by a pixel. The numbers are the nested list's own, because
+ * it is the same strip one level up.
+ */
+export const ROOT_RAIL = "-ml-3 pl-3 md:-ml-4 md:pl-4"

--- a/website/index.html
+++ b/website/index.html
@@ -629,11 +629,19 @@ The corner unit is the **risky one** — see
     everything under it. A line shows where it would land before you let go —
     and it moves sideways as well as up and down, because a gap between two rows
     reads the same whether you are joining that level or becoming the last child
-    of the row above it. Where the line starts is the answer.</p>
+    of the row above it. Where the line starts is the answer. Hold a row near
+    the top or bottom of the window and the page comes to you; with a finger,
+    hold the bullet until the row lifts and then it follows your thumb — until
+    that moment nothing is claimed, so a flick still scrolls the page.</p>
     <p>Everything works on <strong>more than one row</strong> too:
     <kbd>⌘</kbd>-click a title to add it to the pick, <kbd>Shift</kbd>-click to
     take everything between, <kbd>Shift</kbd>+<kbd>↑</kbd>/<kbd>↓</kbd> to start
-    picking from a caret, <kbd>⌘</kbd>+<kbd>A</kbd> to widen. Then the keys are
+    picking from a caret, <kbd>⌘</kbd>+<kbd>A</kbd> to widen, or drag across the
+    rows. That last one has a rule worth knowing, because press-and-pull already
+    means something: <strong>where the pull begins decides</strong>. Start on the
+    words and it is the browser’s own text selection, unchanged. Start on the
+    outline’s empty space — the rail beside an indented branch, the page below
+    the last row — and it picks every row it passes over. Then the keys are
     the keys you already know, several times over — <kbd>Tab</kbd>,
     <kbd>Shift</kbd>+<kbd>Tab</kbd>,
     <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>↑</kbd>/<kbd>↓</kbd>,
@@ -655,7 +663,8 @@ The corner unit is the **risky one** — see
     text, because a tag lives in the title.</p>
     <p>Not everything has a key. Hover a row and the <strong>•••</strong> in the
     gutter carries the rest — on a phone there is no room for one, so hold a
-    finger on the row and the same menu opens: the three marks and clearing one, setting,
+    finger on the row (anywhere but the bullet, which is the handle) and the
+    same menu opens: the three marks and clearing one, setting,
     changing or clearing a date — the same picker the row’s own pill opens —
     retiring one placement of a mirrored node, moving a subtree to the Trash —
     it asks first, and says how many rows go with it — and copying the subtree


### PR DESCRIPTION
`dragdrop-multiselect` (#159) shipped four of Workflowy's five picking gestures
and named three things it deliberately did not do. This is all three.

**None of them needed a wire verb, an op, or a change to the planner.** A sweep
writes a run into the pick the other four gestures already write to; a touch
drag sends the `place` a mouse drag sends. HACKING's consistency rule is kept
by construction again, and for the same reason: there is no gesture here that
MCP cannot make.

## Evidence

**📎 [Gesture by gesture, with the console output beside each](https://claude.ai/code/artifact/005d54ac-c0de-4d20-a540-936e5b27994b)**
— the band mid-pull, the same two motions four pixels to the right selecting
text instead, the page coming to a pointer held at the edge, and a row lifting
under a finger on a handset.

Reproduce it with `SHOTS=/tmp/shots bash evidence.sh` in `packages/tests`
(inside `nix develop .#e2e`, after `just build-client`). Three new sections,
and two things the driver needed that were the harness rather than the app:
`--headless=new` (the old headless shell does not turn a dispatched touch into
the pointer events a long press is made of, so a section about a finger
silently held nothing), and a window that shrinks AFTER the page is drawn and
says how much room that made.

**Tests**: 11 new e2e scenarios (8 in `dragdrop_multiselect.feature`, 3 in
`on_a_phone.feature`), unit tests for the two new pure modules, and a
`claims.test.ts` sweep per literal attribute. Full suite: **550 scenarios,
4102 steps, green**; 1538 unit tests.

## Drag-across is one sentence, not a marquee

The tension #159 refused to settle by accident is that press-and-pull already
MEANS something over a tree of prose, so shipping a second meaning is deciding
which of the two a given pull is. The decision has no modifier and no state:

> **Where the pull begins decides.**

On the words the browser keeps it, unchanged, including a selection that runs
from one row's title down through three more. On the outline's own
SCAFFOLDING — the indent rails beside a branch, the strip left of a note, the
gaps between rows, the page below the last one — there is nothing else there
for the press to be about. The scaffolding says so itself (`data-sweep`), an
ALLOWLIST rather than an inference from what a press is not: a control added to
a row tomorrow inherits "the browser keeps it", which is the safe answer.

**Nothing is `preventDefault`ed to win the argument**, and that is worth saying
because it is the obvious way to write this and it is wrong. Preventing the
press also prevents the FOCUS it carries, so a row being typed in would keep
its caret through a gesture that has just cleared the pick — and a draft that
never blurred is a draft that never committed. What suppresses the selection is
the `user-select` guard `pointer.ts` already puts up for the panel edges.

**And it is a BAND, not a box.** A row is a LINE drawn as far in as its depth
says, so a rectangle down the left of the page would cross a root and miss the
grandchild indented past its right edge — a rule about pixels pretending to be
a rule about the tree. `drag/sweep.ts` reads Y, spans the rows' own width, and
what is drawn is the shape the answer came from. A sweep leaves the two ends
every other picking gesture leaves, so a shift-click after one carries on from
where the pull started.

## Auto-scroll is a coordinate-space split

Whether the page should move is a question about the WINDOW; where the gesture
now is is a question about the PAGE, which is how both gestures measured their
rows. So a pointer held still inside an edge zone keeps producing new answers
with no `pointermove` behind it — which is the behaviour, and exactly what a
caller re-planning only on `pointermove` would miss. The speed ramps with how
deep into the zone the pointer is; a constant one bolts the instant a hand
strays near the edge.

## A finger holds the bullet

The long press #159 predicted, spent through the same primitive the `•••` menu
uses. Two details carry the claim:

- **The handle is the BULLET**, which is what a mouse and a pen have always
  dragged from: one handle on three devices rather than a fourth thing to
  learn.
- **The scroll is claimed at the DEADLINE**, with a non-passive `touchmove`
  rather than `touch-action: none` — which would have passed every scenario
  and left a 28px dead strip down the left of every outline. A finger that had
  drifted would have taken the deadline with it, and one the browser took to
  scroll with would have cancelled the pointer, so this claims exactly the
  gesture that is left.

### What that costs, and the one scenario it changed

The bullet stops being a second door to the row's `•••` menu. Two long presses
cannot both own one press, and the one that gives way is the menu — it has a
whole row to be reached from and a handle has only itself. `on_a_phone.feature`'s
"The press does not also press the row it landed on" held a finger on the
bullet and asserted the panel; it now asserts the row LIFTS, and keeps every
claim it was really making (the click a lift synthesises is eaten, the address
does not change, and a plain tap still zooms). **The scroll fence is untouched
and green**, and a sister scenario now aims the same mutation at the handle
itself: a flick that STARTS on a bullet still scrolls.

If the human would rather keep the bullet as a menu door, the alternative is
"hold the bullet, and releasing without moving opens the menu" — it keeps the
old scenario verbatim, at the price of the row visibly lifting for somebody who
only wanted the menu. Say the word and it is a small change.

## The commits after the feature

Three refactor passes, each isolated:

- **(a) architecture-first-principles** — four findings, and one was a real
  leak: both gestures hold window listeners and one holds a `requestAnimationFrame`
  loop, and neither was tied to the page that made it. `pointerDrag` has always
  answered with its own teardown for exactly this and nobody was holding it.
  Plus a module-global in the step files, half a watcher handed out where only
  the guard is wanted, and a boolean standing in for a name.
- **(b) hickey + lowy** — "where the lines are" was written twice, with the
  drag owning the attribute name and the sweep importing it, which SAID that
  measuring a row belongs to dragging one. It belongs to the ROW:
  `drag/lines.ts`, and `Placed` extends `Line` rather than repeating five of
  its fields. And the paired obligation two callers were hand-composing
  (`autoscroll` + `pointer`) became `Gesture.onPage`, opt-in because the third
  consumer must not have it.
- **(c) /simplify** — twelve fixes from four cleanup passes, including one that
  walks back a line of (a): the `"travelled" | "held"` union was collapsed to a
  boolean on the function's first line, so it bought a second name for one bit.
  Also: the row line came off Solid's runtime spread path (`data-row-key` was
  spread on the busiest element in the tree, beside a live `classList`), the
  `•••` door now stands down on its own rather than being arbitrated in the
  row's JSX, and `edgeScrolling` stopped forcing a layout per frame to learn
  "not near an edge".

## Docs

`docs/editing.md`'s pick inventory is five gestures now, with the rule stated;
`packages/web/README.md` gains the module walk-through for `sweeping`/`sweep`,
`lines`, `autoscroll` and the touch half; the research notes
(`docs/brainstorming/editing-web.md`) get an "as they shipped" section and
their two deferral rows flipped; and the website says the rule.

## Deliberately not here

- **A delete key** — still open, still the human's, which is exactly why the
  bulk put-away asks first rather than answering to a chord.
- **The bulk bar's tone/role unification** — not this branch's.
- **A modifier that unions a sweep with the standing pick** — a real gesture and
  a further one, left out rather than half-built.
- **A sweep with a finger** — permanently: a finger on the empty part of a page
  is scrolling it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
