### PR TITLE
The header says how full the context is

### DIFF
--- a/60
+++ b/60
@@ -1,3 +1,0 @@
-{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{"fs":{"readTextFile":false,"writeTextFile":false}}}}
-{"jsonrpc":"2.0","method":"initialized","params":{}}
-{"jsonrpc":"2.0","id":1,"method":"session/new","params":{"cwd":"/tmp/opencode/pr178/vault","mcpServers":[]}}

--- a/60
+++ b/60
@@ -1,0 +1,3 @@
+{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{"fs":{"readTextFile":false,"writeTextFile":false}}}}
+{"jsonrpc":"2.0","method":"initialized","params":{}}
+{"jsonrpc":"2.0","id":1,"method":"session/new","params":{"cwd":"/tmp/opencode/pr178/vault","mcpServers":[]}}

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -107,7 +107,9 @@ Two things follow from it being the agent's number:
   the agent revising something it told us, and the header follows it.
 - **an agent that reports nothing gets no line.** The header simply says nothing
   about room, which is different from a conversation that has spent nothing —
-  that one says `0/200k`.
+  that one says `0/200k`. You will see this twice: before the first turn of a
+  fresh conversation, and after **opening a stored one**, which replays its
+  messages without a usage report. In both cases the next turn fills it in.
 
 What a session has **cost** is on the wire too, and is deliberately not drawn:
 it is a different question, asked at a different moment, and a second number

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -82,6 +82,37 @@ naming a window five times the real one, in the line you would read to decide
 whether to `/compact`, is worse than naming nothing. You get `claude-opus-5`,
 and what it does not say, it does not say.
 
+## How full the context is
+
+Beside the model, the header says how much room is left: **`22k/1M`** — tokens
+in the conversation, and how many fit. It is the other half of the model's own
+sentence, and it answers the question the panel used to have no answer to at
+all: *is it time to `/compact`?* Before this, the way you found out was by
+watching the agent start forgetting.
+
+It comes from the agent, not from a count kept here — ACP carries it
+(`usage_update`), and olai draws what it is told. Several arrive per turn and
+the newest wins, so the number moves as a turn runs rather than only at the end.
+
+A **fraction rather than a percentage**, because the window is not a constant:
+200k and 1M are both ordinary, and a session moves between them when the model
+does. "2%" would read identically in both and mean quite different amounts of
+work left, so both numbers are shown and the division is yours.
+
+Two things follow from it being the agent's number:
+
+- **the window itself can move under a conversation.** The agent seeds it from
+  what it last knew for the model and corrects it when a turn ends, so the first
+  turn after a `/model` can report the old window and then the true one. That is
+  the agent revising something it told us, and the header follows it.
+- **an agent that reports nothing gets no line.** The header simply says nothing
+  about room, which is different from a conversation that has spent nothing —
+  that one says `0/200k`.
+
+What a session has **cost** is on the wire too, and is deliberately not drawn:
+it is a different question, asked at a different moment, and a second number
+there would buy nothing for the one this line exists to answer.
+
 ## What it can touch
 
 **Olai hands the agent no filesystem.** What olai itself gives it is a closed

--- a/packages/acp/README.md
+++ b/packages/acp/README.md
@@ -1,5 +1,4 @@
-
-| `usage.ts` | the protocol's `usage_update`, read as data: how full the conversation's context is, and how big the window is. Here rather than in `@olai/chat`'s `interpret.ts` because it is ACP's own update kind — any agent may send one — and the cost it also carries is deliberately not read |)| `wire.ts` | the vocabulary that travels olai's wire: `AskChoice` / `AskField` / `AskAnswer` / `AskOutcome`, the `YES_NO` spelling both ends must agree on, `FileDiff` and `Usage`.# @olai/acp — the protocol's words, owned by the wall that speaks them
+# @olai/acp — the protocol's words, owned by the wall that speaks them
 
 The [Agent Client Protocol](https://agentclientprotocol.com)'s vocabulary as
 olai spells it, and the pure projections between ACP's own payloads and that

--- a/packages/acp/README.md
+++ b/packages/acp/README.md
@@ -1,4 +1,5 @@
-# @olai/acp — the protocol's words, owned by the wall that speaks them
+
+| `usage.ts` | the protocol's `usage_update`, read as data: how full the conversation's context is, and how big the window is. Here rather than in `@olai/chat`'s `interpret.ts` because it is ACP's own update kind — any agent may send one — and the cost it also carries is deliberately not read |)| `wire.ts` | the vocabulary that travels olai's wire: `AskChoice` / `AskField` / `AskAnswer` / `AskOutcome`, the `YES_NO` spelling both ends must agree on, `FileDiff` and `Usage`.# @olai/acp — the protocol's words, owned by the wall that speaks them
 
 The [Agent Client Protocol](https://agentclientprotocol.com)'s vocabulary as
 olai spells it, and the pure projections between ACP's own payloads and that
@@ -13,9 +14,10 @@ owns its words** (`@olai/git` declares the repository vocabulary,
 
 | file | what it owns |
 |---|---|
-| `wire.ts` | the vocabulary that travels olai's wire: `AskChoice` / `AskField` / `AskAnswer` / `AskOutcome`, the `YES_NO` spelling both ends must agree on, and `FileDiff`. On its own `./wire` subpath — the half `@olai/surface` re-exports, with no protocol payload in sight — the way `@olai/git`'s wire half sits on `./state` |
+| `wire.ts` | the vocabulary that travels olai's wire: `AskChoice` / `AskField` / `AskAnswer` / `AskOutcome`, the `YES_NO` spelling both ends must agree on, `FileDiff` and `Usage`. On its own `./wire` subpath — the half `@olai/surface` re-exports, with no protocol payload in sight — the way `@olai/git`'s wire half sits on `./state` |
 | `asks.ts` | the protocol's two ways of asking a PERSON something (`elicitation/create` form mode, `session/request_permission`), projected into one drawable form — and the answers projected back, typed the way the schema asked |
 | `diffs.ts` | the protocol's `diff` content blocks, read as data: which file a call rewrote, what was there, what is there now |
+| `usage.ts` | the protocol's `usage_update`, read as data: how full the conversation's context is, and how big the window is. Here rather than in `@olai/chat`'s `interpret.ts` because it is ACP's own update kind — any agent may send one — and the cost it also carries is deliberately not read |
 
 Everything is a pure function over a payload. Nothing here waits, spawns, or
 knows a subprocess exists — the subprocess that speaks these words is

--- a/packages/acp/src/index.ts
+++ b/packages/acp/src/index.ts
@@ -7,10 +7,10 @@
  * subpath, RE-EXPORTED by `@olai/surface`, on the precedent `RepoState` set
  * from `@olai/git`: the package that speaks the foreign thing owns its words,
  * and consumers above go on importing them from the spec they already import.
- * THIS entry is the other half and only this half — {@link ./asks.ts} and
- * {@link ./diffs.ts}, the projections between the protocol's own payloads and
- * that vocabulary, which only `@olai/chat` — the package that runs an ACP
- * subprocess — consumes. The two entries are disjoint on purpose: everyone
+ * THIS entry is the other half and only this half — {@link ./asks.ts},
+ * {@link ./diffs.ts} and {@link ./usage.ts}, the projections between the
+ * protocol's own payloads and that vocabulary, which only `@olai/chat` — the
+ * package that runs an ACP subprocess — consumes. The two entries are disjoint on purpose: everyone
  * who wants the vocabulary has it through the surface, so a wire shape
  * offered here as well would be a third path to the same word.
  *
@@ -30,3 +30,4 @@ export {
   Refused,
 } from "./asks.ts"
 export { diffsOf, relativeTo } from "./diffs.ts"
+export { usageIn } from "./usage.ts"

--- a/packages/acp/src/manifest.test.ts
+++ b/packages/acp/src/manifest.test.ts
@@ -152,6 +152,7 @@ describe("the manifest", () => {
       "formOf",
       "permissionFormOf",
       "relativeTo",
+      "usageIn",
     ])
     // ... and the wire half carries the vocabulary alone: no payload reader
     // rides the subpath the surface re-exports.
@@ -161,6 +162,7 @@ describe("the manifest", () => {
       "AskField",
       "AskOutcome",
       "FileDiff",
+      "Usage",
       "YES_NO",
     ])
   })

--- a/packages/acp/src/usage.test.ts
+++ b/packages/acp/src/usage.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The usage report, over values.
+ *
+ * The payloads here are what the pinned Claude Code adapter (0.66.0) actually
+ * sends — captured off the wire across four turns and a `/model` — plus the
+ * near misses, which are the whole reason this is a function rather than a
+ * field access: a fraction with a broken half in it is worse on screen than no
+ * fraction at all.
+ */
+
+import { describe, expect, test } from "bun:test"
+
+import { usageIn } from "./usage.ts"
+
+describe("how full the context is", () => {
+  test("the two numbers a report states", () => {
+    // Verbatim off the wire: the mid-stream frame, which carries no cost.
+    expect(usageIn({ sessionUpdate: "usage_update", used: 22102, size: 1000000 }))
+      .toEqual({ used: 22102, size: 1000000 })
+  })
+
+  test("the turn's last frame is read for the same two, and its cost dropped", () => {
+    // The final frame adds a cumulative session cost and an origin `_meta`.
+    // Neither is drawn, and neither may leak into the shape the panel holds:
+    // what a session has SPENT is a different question from whether it is
+    // about to run out of room.
+    expect(usageIn({
+      sessionUpdate: "usage_update",
+      used: 22925,
+      size: 200000,
+      cost: { amount: 0.175023, currency: "USD" },
+      _meta: { "_claude/origin": { kind: "human" } },
+    })).toEqual({ used: 22925, size: 200000 })
+  })
+
+  test("a window that is not a window is nothing to draw", () => {
+    // `0` and `NaN` are values the adapter has met from third-party backends —
+    // it guards its own writes with `> 0` for this reason. `22k/0` on screen
+    // would be inviting arithmetic on nonsense.
+    expect(usageIn({ used: 22102, size: 0 })).toBeNull()
+    expect(usageIn({ used: 22102, size: -1 })).toBeNull()
+    expect(usageIn({ used: 22102, size: Number.NaN })).toBeNull()
+    expect(usageIn({ used: 22102, size: Number.POSITIVE_INFINITY })).toBeNull()
+  })
+
+  test("a spent-nothing conversation is a fact, and a negative one is not", () => {
+    // Zero is the number every session opens on, so it must survive the guard
+    // that a negative one does not.
+    expect(usageIn({ used: 0, size: 200000 })).toEqual({ used: 0, size: 200000 })
+    expect(usageIn({ used: -1, size: 200000 })).toBeNull()
+  })
+
+  test("more used than fits is reported, not tidied away", () => {
+    // The surprising case is the one a person most needs to see; clamping it
+    // to a neat 100% would hide exactly that.
+    expect(usageIn({ used: 240000, size: 200000 }))
+      .toEqual({ used: 240000, size: 200000 })
+  })
+
+  test("a payload that does not say is not guessed at", () => {
+    expect(usageIn({ used: 22102 })).toBeNull()
+    expect(usageIn({ size: 200000 })).toBeNull()
+    expect(usageIn({ used: "22102", size: "200000" })).toBeNull()
+    expect(usageIn({ used: 22102.5, size: 200000 })).toBeNull()
+    expect(usageIn({})).toBeNull()
+    expect(usageIn(null)).toBeNull()
+    expect(usageIn(undefined)).toBeNull()
+  })
+})

--- a/packages/acp/src/usage.ts
+++ b/packages/acp/src/usage.ts
@@ -1,0 +1,48 @@
+/**
+ * The protocol's usage report, read as data.
+ *
+ * `usage_update` is ACP's own — it sits in the `SessionUpdate` union beside
+ * `tool_call` and `config_option_update`, and any agent may send one — so it is
+ * read HERE rather than in the chat package's `interpret.ts`, which is the file
+ * for values only the Claude Code adapter means anything by. The boundary is
+ * not which payload a reader touches but who has to have sent it.
+ *
+ * What it carries is two numbers ({@link Usage}) and, on the turn's last frame,
+ * a cost this does not read. What this file adds is the one judgement between
+ * the payload and the panel: WHETHER THERE IS ANYTHING TO SAY.
+ *
+ * PURE, and tested as such — the {@link ./diffs.ts} pattern, for the same
+ * reason: a reading of somebody else's payload is a function over a value, not
+ * a branch reachable only by talking a subprocess into sending one.
+ */
+
+import type { Usage } from "./wire.ts"
+
+/**
+ * The usage a report states, or `null` for one that states none.
+ *
+ * The refusals are all the same shape and all the same reason — a fraction is
+ * only worth drawing when both halves of it are real:
+ *
+ *   - a `size` that is not POSITIVE is not a window. The adapter guards its own
+ *     writes with `> 0` for the same reason (it has met third-party backends
+ *     answering `0` and `NaN`), and a header reading `22k/0` would be inviting
+ *     a person to do arithmetic on nonsense;
+ *   - a non-integer, infinite or absent number on either side is somebody
+ *     else's payload not saying what it claims to say;
+ *   - a NEGATIVE `used` is the same, and `0` is not: a conversation that has
+ *     spent nothing is a fact, and it is the fact every session opens on.
+ *
+ * `used` is deliberately NOT clamped to `size`. A report where it exceeds the
+ * window is the agent telling us something surprising about the conversation,
+ * and the surprise is the point — folding it down to a tidy 100% would hide
+ * exactly the state a person most needs to see.
+ */
+export const usageIn = (update: unknown): Usage | null => {
+  const report = update as { readonly used?: unknown; readonly size?: unknown } | null
+  const used = report?.used
+  const size = report?.size
+  if (!Number.isSafeInteger(used) || !Number.isSafeInteger(size)) return null
+  if ((used as number) < 0 || (size as number) <= 0) return null
+  return { used: used as number, size: size as number }
+}

--- a/packages/acp/src/wire.ts
+++ b/packages/acp/src/wire.ts
@@ -135,3 +135,41 @@ export const FileDiff = Schema.Struct({
   newText: Schema.String,
 })
 export type FileDiff = typeof FileDiff.Type
+
+/**
+ * How full the conversation's context is: tokens in it, and how many fit.
+ *
+ * The protocol's own `usage_update`, projected to the two numbers a reader
+ * acts on. It is the other half of the sentence the header's model is there
+ * for — a turn's cost and character depend on which model it runs, and its
+ * ROOM depends on this — and the question it answers is the one nothing on
+ * screen used to: whether it is time to `/compact`.
+ *
+ * BOTH numbers travel, rather than the percentage they imply. A window is not
+ * a constant — 200k and 1M are both ordinary, and a session moves between them
+ * when the model does — so "80%" would be the one figure that reads the same
+ * either way while meaning quite different amounts of work left. The reader
+ * wants the denominator, and the wire is where it is known.
+ *
+ * `size` is the AGENT'S current best knowledge and is allowed to move under a
+ * conversation. The Claude Code adapter seeds it from what it last learned for
+ * the model and corrects it authoritatively when a turn ends, so the first turn
+ * after a `/model` can report the previous model's window mid-stream and the
+ * true one by the end. That is the agent revising a number it told us, not this
+ * panel guessing, and it is drawn as it arrives for exactly that reason.
+ *
+ * `cost` is deliberately NOT here. The protocol carries it on the turn-final
+ * frame and the header does not draw it: what a session has spent is a
+ * different question from whether it is about to run out of room, asked at a
+ * different moment, and a second number in that line buys nothing for the one
+ * this exists to answer.
+ */
+export const Usage = Schema.Struct({
+  /** Tokens currently in the context window. */
+  used: Schema.Int,
+  /** How many fit. Always positive — a report that said otherwise is dropped
+   *  where the payload is read ({@link ./usage.ts}), because a denominator of
+   *  zero is not a fact about a conversation. */
+  size: Schema.Int,
+})
+export type Usage = typeof Usage.Type

--- a/packages/chat/src/agent.ts
+++ b/packages/chat/src/agent.ts
@@ -88,6 +88,7 @@ import {
   permissionFormOf,
   Refused,
   relativeTo,
+  usageIn,
 } from "@olai/acp"
 import { UsageFailure } from "@olai/format"
 import { emitter, reasonOf } from "@olai/log"
@@ -444,8 +445,23 @@ export const make = (options: Options): Effect.Effect<Agent, never, never> =>
             emit({ _tag: "sessionTitled", title: update.title })
           }
           return
+        case "usage_update": {
+          // How full the context is, which is the one thing a person needs to
+          // decide whether to `/compact` and the one thing nothing on screen
+          // used to say. Several a turn: the agent revises `used` as it goes
+          // and may revise `size` too, so the panel holds the newest rather
+          // than the first.
+          //
+          // Read by `@olai/acp` rather than by `interpret.ts`, because this is
+          // ACP's own update kind and not one adapter's extension — any agent
+          // may send one, and one that never does simply leaves the header
+          // saying nothing about room.
+          const usage = usageIn(update)
+          if (usage !== null) emit({ _tag: "usage", usage })
+          return
+        }
         default:
-          // Thoughts, plans, usage. Real parts of the protocol that this panel
+          // Thoughts and plans. Real parts of the protocol that this panel
           // does not draw; ignored quietly rather than half-rendered.
           //
           // Quietly is right HERE and not two cases up, and the difference is

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -270,6 +270,13 @@ export const make = (options: Options): Effect.Effect<Chat, never, never> =>
         case "model":
           move({ model: event.name })
           return
+        case "usage":
+          // Beside the model, on the cell, for the model's own reason: it is a
+          // standing property of the conversation rather than something that
+          // HAPPENED in it. Several arrive per turn and the newest wins — the
+          // agent is revising a number it already told us, not adding a second.
+          move({ usage: event.usage })
+          return
         case "session":
           move({
             status: state.status === "thinking" ? "thinking" : "idle",
@@ -296,7 +303,18 @@ export const make = (options: Options): Effect.Effect<Chat, never, never> =>
           // the last one's answer up in between would be the panel reporting a
           // conversation that no longer exists — and, for a dead agent, one
           // nobody is in.
-          move({ session: null, commands: [], asking: asking(), missing: [] })
+          // The usage goes with the session it was usage OF. A fresh
+          // conversation has spent nothing and a loaded one has spent whatever
+          // it spent; either way the number from the last one is about a
+          // context that no longer exists, and leaving it up would be the
+          // panel answering "should I compact?" about somebody else.
+          move({
+            session: null,
+            commands: [],
+            asking: asking(),
+            missing: [],
+            usage: null,
+          })
           return
         case "replayStarted":
           publish(transcript.clear())

--- a/packages/chat/src/events.ts
+++ b/packages/chat/src/events.ts
@@ -14,7 +14,14 @@
  * the caller that asked is the one waiting.
  */
 
-import type { AskField, AskOutcome, FileDiff, MissingServer, Wrote } from "@olai/surface"
+import type {
+  AskField,
+  AskOutcome,
+  FileDiff,
+  MissingServer,
+  Usage,
+  Wrote,
+} from "@olai/surface"
 
 /** A slash command the agent offers. */
 export interface Command {
@@ -109,6 +116,10 @@ export type AgentEvent =
   | { readonly _tag: "servers"; readonly missing: ReadonlyArray<MissingServer> }
   /** The model this session runs, labelled the way the agent labels its own. */
   | { readonly _tag: "model"; readonly name: string | null }
+  /** How full this conversation's context is, as the agent last reported it.
+   *  Arrives several times a turn — the agent revises both halves as it goes —
+   *  and the panel holds the newest. */
+  | { readonly _tag: "usage"; readonly usage: Usage }
   /** Which stored conversation this now is. `title` is `null` until the agent
    *  has written one. */
   | { readonly _tag: "session"; readonly id: string; readonly title: string | null }

--- a/packages/surface/src/chat.ts
+++ b/packages/surface/src/chat.ts
@@ -41,7 +41,15 @@
  * was never sent.
  */
 
-import { AskAnswer, AskChoice, AskField, AskOutcome, FileDiff, YES_NO } from "@olai/acp/wire"
+import {
+  AskAnswer,
+  AskChoice,
+  AskField,
+  AskOutcome,
+  FileDiff,
+  Usage,
+  YES_NO,
+} from "@olai/acp/wire"
 import {
   BusyFailure,
   Found,
@@ -54,13 +62,13 @@ import {
 import { Schema } from "effect"
 
 /**
- * The ask vocabulary — and {@link FileDiff} below — re-exported rather than
- * declared.
+ * The ask vocabulary — and {@link FileDiff} and {@link Usage} below —
+ * re-exported rather than declared.
  *
- * `AskChoice`, `AskField`, `AskAnswer`, `AskOutcome`, `YES_NO` and `FileDiff`
- * belong to `@olai/acp` now — they are ACP's elicitation and diff shapes in
- * olai's spelling, and the package that speaks the protocol is the one that
- * owns its words. They are re-exported HERE because they TRAVEL: the
+ * `AskChoice`, `AskField`, `AskAnswer`, `AskOutcome`, `YES_NO`, `FileDiff` and
+ * `Usage` belong to `@olai/acp` now — they are ACP's elicitation, diff and
+ * usage shapes in olai's spelling, and the package that speaks the protocol is
+ * the one that owns its words. They are re-exported HERE because they TRAVEL: the
  * transcript entry below carries them, the browser draws them, and consumers
  * keep importing them from the spec they already import everything else from
  * — exactly the arrangement `RepoState` has, declared by `@olai/git` and
@@ -70,7 +78,7 @@ import { Schema } from "effect"
  * package with no protocol payload in it: the projections over ACP's own
  * payloads ride the main entry, and only `@olai/chat` reads those.
  */
-export { AskAnswer, AskChoice, AskField, AskOutcome, FileDiff, YES_NO }
+export { AskAnswer, AskChoice, AskField, AskOutcome, FileDiff, Usage, YES_NO }
 
 /**
  * A question the agent asked, and what became of it.
@@ -416,6 +424,21 @@ export const ChatState = Schema.Struct({
   /** The model a turn actually runs on, labelled the way the agent labels its
    *  own models. `null` until the agent has said. */
   model: Schema.NullOr(Schema.String),
+  /**
+   * How full this conversation's context is — see {@link Usage}.
+   *
+   * Beside the model rather than under it, and for the model's own reason: the
+   * header names what a turn RUNS ON because its cost and character depend on
+   * it, and this is the other half of that sentence — how much room is left to
+   * run it in, which is what "should I `/compact`?" is asking.
+   *
+   * `null` until the agent has reported some, which is not the same as a
+   * conversation that has spent nothing (that is `used: 0`): an agent that
+   * sends no `usage_update` at all leaves this empty for the life of the
+   * session, and the header simply says nothing about room. It goes with the
+   * conversation, like the model and the missing servers.
+   */
+  usage: Schema.NullOr(Usage),
   commands: Schema.Array(Command),
   /** How many messages are typed and waiting for the turn in flight to end.
    *
@@ -466,6 +489,7 @@ export const CHAT_OFF: ChatState = {
   status: "off",
   session: null,
   model: null,
+  usage: null,
   commands: [],
   queued: 0,
   asking: 0,

--- a/packages/surface/src/index.ts
+++ b/packages/surface/src/index.ts
@@ -513,6 +513,7 @@ export {
   NodeContext,
   OpFailure,
   SessionInfo,
+  Usage,
   UsageFailure,
   Wrote,
   YES_NO,

--- a/packages/tests/agent/fake-acp-agent.ts
+++ b/packages/tests/agent/fake-acp-agent.ts
@@ -515,21 +515,27 @@ const runTurn = async (id: unknown, text: string): Promise<void> => {
   const [verb, ...rest] = text.trim().split(/\s+/)
   const argument = rest.join(" ")
 
-  // The window the agent believes in, moving under the conversation — what the
-  // real adapter does on the first turn after a `/model`, where it seeds the
-  // previous model's window and corrects it when the turn ends. Read before the
-  // frames below so the change lands on the turn that asked for it.
+  // The window the agent believes in, moving under the conversation.
   //
   // `window`, NOT `context`: that verb is taken, by the scenarios that prove an
   // armed node reaches the prompt as an id the ops tools accept.
-  if (verb === "window") size = Number(argument)
+  const moving = verb === "window" ? Number(argument) : null
 
   // What a turn spends, reported the way a real turn reports it: MORE THAN ONE
-  // frame, with the number moving between them, and the cost riding the last.
+  // frame, with BOTH numbers moving between them, and the cost riding the last.
   // A panel that held the first report of a turn rather than the newest would
   // pass every scenario that only ever sent one.
+  //
+  // The window moves BETWEEN the two frames rather than before them, which is
+  // where the real adapter moves it: on the first turn after a `/model` it
+  // reports the previous model's window mid-stream and corrects it
+  // authoritatively when the turn ends. Assigning it before both frames — which
+  // is what this did first — sent the new denominator in both, so a panel that
+  // kept a turn's FIRST window would have passed. Newest-wins was pinned for
+  // `used` and not for `size`, which is half a claim.
   used += 12_000
   usageUpdate(false)
+  if (moving !== null) size = moving
   used += 900
   usageUpdate(true)
 

--- a/packages/tests/agent/fake-acp-agent.ts
+++ b/packages/tests/agent/fake-acp-agent.ts
@@ -36,8 +36,10 @@
  *                say silently, and not observably until the NEXT turn
  *   reconfig     re-announce the session's config options unchanged, the way
  *                the adapter does when anything else in that set moves
- *   window <n>   move the context WINDOW, the way the adapter does when it
- *                corrects a seeded guess at the end of a turn
+ *   window <n> [hold]   move the context WINDOW, the way the adapter does when
+ *                it corrects a seeded guess at the end of a turn. `hold` stops
+ *                between the turn's two usage frames, so a scenario can look at
+ *                the mid-stream window rather than infer it
  *   ask          ask a structured question and report the answer
  *   askstrict    ask one with a REQUIRED, typed field, the way an MCP server does
  *   plan         ask to leave plan mode, the way the adapter does
@@ -519,7 +521,14 @@ const runTurn = async (id: unknown, text: string): Promise<void> => {
   //
   // `window`, NOT `context`: that verb is taken, by the scenarios that prove an
   // armed node reaches the prompt as an id the ops tools accept.
-  const moving = verb === "window" ? Number(argument) : null
+  //
+  // `window <n> hold` stops BETWEEN the turn's two frames, which is the only
+  // way a scenario can look at the mid-stream state rather than infer it from
+  // where the turn ended — and inferring it is not enough here, because a
+  // version of this file that moved the window before both frames would end in
+  // the same place and pin nothing.
+  const moving = verb === "window" ? Number(rest[0]) : null
+  const holding = verb === "window" && rest[1] === "hold"
 
   // What a turn spends, reported the way a real turn reports it: MORE THAN ONE
   // frame, with BOTH numbers moving between them, and the cost riding the last.
@@ -535,6 +544,7 @@ const runTurn = async (id: unknown, text: string): Promise<void> => {
   // `used` and not for `size`, which is half a claim.
   used += 12_000
   usageUpdate(false)
+  if (holding) await released()
   if (moving !== null) size = moving
   used += 900
   usageUpdate(true)

--- a/packages/tests/agent/fake-acp-agent.ts
+++ b/packages/tests/agent/fake-acp-agent.ts
@@ -36,7 +36,7 @@
  *                say silently, and not observably until the NEXT turn
  *   reconfig     re-announce the session's config options unchanged, the way
  *                the adapter does when anything else in that set moves
- *   context <n>  move the context WINDOW, the way the adapter does when it
+ *   window <n>   move the context WINDOW, the way the adapter does when it
  *                corrects a seeded guess at the end of a turn
  *   ask          ask a structured question and report the answer
  *   askstrict    ask one with a REQUIRED, typed field, the way an MCP server does
@@ -519,7 +519,10 @@ const runTurn = async (id: unknown, text: string): Promise<void> => {
   // real adapter does on the first turn after a `/model`, where it seeds the
   // previous model's window and corrects it when the turn ends. Read before the
   // frames below so the change lands on the turn that asked for it.
-  if (verb === "context") size = Number(argument)
+  //
+  // `window`, NOT `context`: that verb is taken, by the scenarios that prove an
+  // armed node reaches the prompt as an id the ops tools accept.
+  if (verb === "window") size = Number(argument)
 
   // What a turn spends, reported the way a real turn reports it: MORE THAN ONE
   // frame, with the number moving between them, and the cost riding the last.
@@ -530,7 +533,7 @@ const runTurn = async (id: unknown, text: string): Promise<void> => {
   used += 900
   usageUpdate(true)
 
-  if (verb === "context") {
+  if (verb === "window") {
     say(`the context window is ${size} now.`)
     respond(id, { stopReason: "end_turn" })
     return

--- a/packages/tests/agent/fake-acp-agent.ts
+++ b/packages/tests/agent/fake-acp-agent.ts
@@ -36,6 +36,8 @@
  *                say silently, and not observably until the NEXT turn
  *   reconfig     re-announce the session's config options unchanged, the way
  *                the adapter does when anything else in that set moves
+ *   context <n>  move the context WINDOW, the way the adapter does when it
+ *                corrects a seeded guess at the end of a turn
  *   ask          ask a structured question and report the answer
  *   askstrict    ask one with a REQUIRED, typed field, the way an MCP server does
  *   plan         ask to leave plan mode, the way the adapter does
@@ -452,6 +454,38 @@ const sdkInit = (model: string): void => {
  */
 let liveModel = "fake-model-1"
 
+/**
+ * How full the context is, and how the real adapter reports it.
+ *
+ * `usage_update` is ACP's own update kind, sent SEVERAL TIMES A TURN: the agent
+ * revises `used` as the turn goes and the last frame of the turn adds the
+ * cumulative cost. Both halves may move — captured against 0.66.0, the first
+ * turn after a `/model` reports the PREVIOUS model's window mid-stream and the
+ * true one on that last frame, because the adapter seeds the window from what
+ * it last learned and corrects it authoritatively when the turn ends.
+ *
+ * Reproduced here rather than simplified, because a panel that held the FIRST
+ * report of a turn instead of the newest would look right in every scenario
+ * that only ever sent one.
+ */
+let used = 0
+let size = 200_000
+
+/** One report, as the protocol shapes it. `cost` rides the turn's last frame
+ *  alone, exactly as the real one's does — and nothing draws it, which is a
+ *  claim worth being able to make about a field that is actually there. */
+const usageUpdate = (final: boolean): void => {
+  notify("session/update", {
+    sessionId,
+    update: {
+      sessionUpdate: "usage_update",
+      used,
+      size,
+      ...(final ? { cost: { amount: 0.1234, currency: "USD" } } : {}),
+    },
+  })
+}
+
 /** A turn that was cancelled while it was waiting on the client ends as a
  *  cancelled turn. Answers whether it did, so the caller stops there. */
 const endedCancelled = (id: unknown): boolean => {
@@ -480,6 +514,27 @@ const runTurn = async (id: unknown, text: string): Promise<void> => {
 
   const [verb, ...rest] = text.trim().split(/\s+/)
   const argument = rest.join(" ")
+
+  // The window the agent believes in, moving under the conversation — what the
+  // real adapter does on the first turn after a `/model`, where it seeds the
+  // previous model's window and corrects it when the turn ends. Read before the
+  // frames below so the change lands on the turn that asked for it.
+  if (verb === "context") size = Number(argument)
+
+  // What a turn spends, reported the way a real turn reports it: MORE THAN ONE
+  // frame, with the number moving between them, and the cost riding the last.
+  // A panel that held the first report of a turn rather than the newest would
+  // pass every scenario that only ever sent one.
+  used += 12_000
+  usageUpdate(false)
+  used += 900
+  usageUpdate(true)
+
+  if (verb === "context") {
+    say(`the context window is ${size} now.`)
+    respond(id, { stopReason: "end_turn" })
+    return
+  }
 
   if (verb === "crash") {
     say("about to fall over")
@@ -1006,6 +1061,9 @@ const handle = async (message: Record<string, unknown>): Promise<void> => {
       sessionId = "fake-session-1"
       // A fresh conversation is on whatever the picker says it is picking.
       liveModel = "fake-model-1"
+      // ... and has spent nothing in a window of its own.
+      used = 0
+      size = 200_000
       respond(id, { sessionId, configOptions: CONFIG_OPTIONS })
       // NO `init` here, and that is the adapter's own shape: it forwards one
       // per PROMPT, so between opening a session and sending the first one the
@@ -1023,6 +1081,11 @@ const handle = async (message: Record<string, unknown>): Promise<void> => {
       sessionId = String(params["sessionId"] ?? sessionId)
       replay()
       liveModel = "fake-model-1"
+      // A different conversation is a different context. The client empties
+      // what it was showing when the session goes, so nothing is drawn about
+      // this one until its first turn reports.
+      used = 0
+      size = 200_000
       respond(id, { configOptions: CONFIG_OPTIONS })
       notify("session/update", {
         sessionId,

--- a/packages/tests/features/the_agent.feature
+++ b/packages/tests/features/the_agent.feature
@@ -440,6 +440,10 @@ Feature: Talking to the agent
     Then the panel header says the context is "13k/200k"
     When I ask the agent "window 1000000"
     Then the agent is idle
+    # The window moves BETWEEN that turn's two frames, where the adapter moves
+    # it — so this asserts both halves at once. A panel that kept the turn's
+    # first report would say "25k/200k": the old window, and the turn's own
+    # first count of what it had spent.
     And the panel header says the context is "26k/1M"
 
   @scratch:chat

--- a/packages/tests/features/the_agent.feature
+++ b/packages/tests/features/the_agent.feature
@@ -438,12 +438,20 @@ Feature: Talking to the agent
     # number and quite different amounts of work left.
     When I ask the agent "hello"
     Then the panel header says the context is "13k/200k"
-    When I ask the agent "window 1000000"
+    # HELD between the turn's two usage frames, so the mid-stream state is
+    # looked at rather than inferred from where the turn ended. Inferring it
+    # would pin nothing about the ORDER: an agent that moved the window before
+    # both frames ends in the same place.
+    When I ask the agent "window 1000000 hold"
+    Then the agent is working
+    # Mid-turn: the window the conversation began on, and this turn's first
+    # count of what it has spent.
+    And the panel header says the context is "25k/200k"
+    When the agent is released
     Then the agent is idle
-    # The window moves BETWEEN that turn's two frames, where the adapter moves
-    # it — so this asserts both halves at once. A panel that kept the turn's
-    # first report would say "25k/200k": the old window, and the turn's own
-    # first count of what it had spent.
+    # ... and the correction lands on the turn's last frame, which is where the
+    # adapter puts it. A panel that kept the turn's FIRST report would still be
+    # showing the line above.
     And the panel header says the context is "26k/1M"
 
   @scratch:chat

--- a/packages/tests/features/the_agent.feature
+++ b/packages/tests/features/the_agent.feature
@@ -438,7 +438,7 @@ Feature: Talking to the agent
     # number and quite different amounts of work left.
     When I ask the agent "hello"
     Then the panel header says the context is "13k/200k"
-    When I ask the agent "context 1000000"
+    When I ask the agent "window 1000000"
     Then the agent is idle
     And the panel header says the context is "26k/1M"
 

--- a/packages/tests/features/the_agent.feature
+++ b/packages/tests/features/the_agent.feature
@@ -413,6 +413,47 @@ Feature: Talking to the agent
     And the tool call's detail is shown
 
   @scratch:chat
+  Scenario: The header says how full the context is, and follows it across turns
+    # `chat-token-usage`. Nothing on screen used to say how much room was left,
+    # so the way a person found out it was time to `/compact` was by watching
+    # the agent start forgetting. The agent has been sending it all along —
+    # ACP's own `usage_update`, several frames a turn.
+    Then the panel header says nothing about the context
+    When I ask the agent "hello"
+    Then the agent is idle
+    # 12,900 after one turn, and NOT the 12,000 of that turn's first frame: the
+    # panel holds the newest report rather than the first.
+    And the panel header says the context is "13k/200k"
+    When I ask the agent "hello again"
+    Then the agent is idle
+    And the panel header says the context is "26k/200k"
+
+  @scratch:chat
+  Scenario: The context window itself can move, and the header follows that too
+    # Both halves of the fraction are the agent's to revise. The real adapter
+    # seeds the window from what it last learned for the model and corrects it
+    # authoritatively at the end of a turn, so the first turn after a `/model`
+    # can report the previous model's window and then the true one. A percentage
+    # would have hidden this entirely — 6% of 200k and 6% of 1M are the same
+    # number and quite different amounts of work left.
+    When I ask the agent "hello"
+    Then the panel header says the context is "13k/200k"
+    When I ask the agent "context 1000000"
+    Then the agent is idle
+    And the panel header says the context is "26k/1M"
+
+  @scratch:chat
+  Scenario: A new conversation is not asked how full the last one was
+    # The number goes with the context it was about. Leaving it up across a
+    # session change would be the panel answering "should I compact?" about a
+    # conversation that no longer exists.
+    When I ask the agent "hello"
+    Then the panel header says the context is "13k/200k"
+    When I start a new conversation
+    Then the agent is idle
+    And the panel header says nothing about the context
+
+  @scratch:chat
   Scenario: The header follows the model the agent is actually running
     # Two sources: the session's config option is what was PICKED, and the
     # CLI's own init message is what is RUNNING. A `/model` is handled inside

--- a/packages/tests/step_definitions/chat_steps.ts
+++ b/packages/tests/step_definitions/chat_steps.ts
@@ -67,6 +67,7 @@ import {
   CHAT_TOOL_PROGRESS,
   CHAT_TRANSCRIPT,
   CHAT_TROUBLE,
+  CHAT_USAGE,
   CHAT_WAITING,
   CHAT_WORKING,
   CHAT_WROTE,
@@ -1507,3 +1508,33 @@ Then(
 );
 
 const pictureChip = (name: string): string => `${CHAT_ATTACHMENT}[data-name="${name}"]`;
+
+/** How full the context is, as the header draws it. The whole string — `22k/1M`
+ *  rather than a substring — because the two halves are the claim: a scenario
+ *  matching only the numerator would pass on a build that lost the window. */
+Then(
+  "the panel header says the context is {string}",
+  async function (this: OlaiWorld, usage: string) {
+    await this.waitUntil(
+      async () => {
+        const line = this.page.locator(CHAT_USAGE);
+        return (await line.count()) > 0 && oneLine(await line.innerText()) === usage;
+      },
+      `the header to say the context is "${usage}"`,
+      HYDRATION_TIMEOUT,
+    );
+  },
+);
+
+/** ... and that it says nothing about it at all, which is a conversation the
+ *  agent has not reported on rather than one that has spent nothing. */
+Then(
+  "the panel header says nothing about the context",
+  async function (this: OlaiWorld) {
+    await this.waitUntil(
+      async () => (await this.page.locator(CHAT_USAGE).count()) === 0,
+      "the header to say nothing about the context",
+      HYDRATION_TIMEOUT,
+    );
+  },
+);

--- a/packages/tests/support/world.ts
+++ b/packages/tests/support/world.ts
@@ -580,6 +580,7 @@ export const CHAT_OUTLINE_CHANGE = selector(TESTID.chatOutlineChange);
 export const CHAT_WROTE = selector(TESTID.chatWrote);
 export const CHAT_NUDGE = selector(TESTID.chatNudge);
 export const CHAT_REFUSAL = selector(TESTID.chatRefusal);
+export const CHAT_USAGE = selector(TESTID.chatUsage);
 export const CHAT_TROUBLE = selector(TESTID.chatTrouble);
 export const CHAT_ASK = selector(TESTID.chatAsk);
 export const CHAT_ASK_CHOICE = selector(TESTID.chatAskChoice);

--- a/packages/web/src/client/chat/Header.tsx
+++ b/packages/web/src/client/chat/Header.tsx
@@ -3,9 +3,13 @@
  * session.
  *
  * The model is here because a turn's cost and character depend on it and
- * nothing else on screen says. The session title is here because the agent
- * writes one in the background, and a conversation with a name is one you can
- * come back to — which is what the picker beside it is for.
+ * nothing else on screen says. USAGE is the other half of that same sentence —
+ * how much room is left to run the turn in — and it is here because the
+ * question it answers, "is it time to `/compact`?", had no answer on screen at
+ * all: a person found out by watching the agent start forgetting. The session
+ * title is here because the agent writes one in the background, and a
+ * conversation with a name is one you can come back to — which is what the
+ * picker beside it is for.
  *
  * WORKING is drawn BESIDE the model, not instead of it. The status used to take
  * that line until a model arrived and then never appear again, so from the
@@ -30,6 +34,7 @@ import { QUIET_PILL } from "../pill.ts"
 import { TESTID } from "../testids.ts"
 import { Sessions } from "./Sessions.tsx"
 import type { Chat } from "./state.ts"
+import { usageOf } from "./usage.ts"
 
 export function Header(props: {
   readonly chat: Chat
@@ -50,6 +55,18 @@ export function Header(props: {
         <div class="flex items-center gap-2 truncate font-mono text-[0.6875rem] text-muted">
           <Show when={state().model} fallback={<span>{statusWord(state().status)}</span>}>
             {(model) => <span data-testid={TESTID.chatModel}>{model()}</span>}
+          </Show>
+          {/* The other half of the model's own sentence: what a turn runs on,
+              and how much room is left to run it in. Drawn only once the agent
+              has reported some — before the first turn there is nothing to
+              say, and a `0/?` invented for that gap would be a claim about a
+              window nobody named. */}
+          <Show when={usageOf(state().usage)}>
+            {(usage) => (
+              <span data-testid={TESTID.chatUsage} title="context used / context window">
+                {usage()}
+              </span>
+            )}
           </Show>
           {/* Always in the tree while a turn runs, whether or not a model is
               named — the two are independent, and a cue that only appears in

--- a/packages/web/src/client/chat/usage.test.ts
+++ b/packages/web/src/client/chat/usage.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The header's usage line, over values.
+ *
+ * The numbers here are the ones the pinned adapter (0.66.0) actually sent,
+ * captured across four turns and a `/model` — including the turn where the
+ * window itself moved, which is the case a fraction exists to make legible.
+ */
+
+import { describe, expect, test } from "bun:test"
+
+import { usageOf } from "./usage.ts"
+
+describe("how full the context is, as a header line", () => {
+  test("the numbers the agent actually sends", () => {
+    // Off the wire: a fresh session on a 1M model, then the same conversation
+    // after `/model claude-opus-4-5` — where the WINDOW is what changed, which
+    // a percentage would have hidden entirely (2% both times).
+    expect(usageOf({ used: 22102, size: 1000000 })).toBe("22k/1M")
+    expect(usageOf({ used: 22925, size: 200000 })).toBe("23k/200k")
+  })
+
+  test("a conversation that has spent nothing says so", () => {
+    // `0k` is not a number anybody writes, and the opening of every session is
+    // exactly where small counts are true.
+    expect(usageOf({ used: 0, size: 200000 })).toBe("0/200k")
+    expect(usageOf({ used: 847, size: 200000 })).toBe("847/200k")
+    expect(usageOf({ used: 999, size: 200000 })).toBe("999/200k")
+    expect(usageOf({ used: 1000, size: 200000 })).toBe("1k/200k")
+  })
+
+  test("nearly a million is not `1000k`", () => {
+    // The handover is done on the rounded thousands, so a fraction never has
+    // to be read twice to see that it is nearly full.
+    expect(usageOf({ used: 999_600, size: 1_000_000 })).toBe("1M/1M")
+    expect(usageOf({ used: 999_400, size: 1_000_000 })).toBe("999k/1M")
+  })
+
+  test("millions carry one decimal, and never a trailing zero", () => {
+    expect(usageOf({ used: 1_500_000, size: 2_000_000 })).toBe("1.5M/2M")
+    expect(usageOf({ used: 1_000_000, size: 1_000_000 })).toBe("1M/1M")
+  })
+
+  test("a context fuller than its window is drawn as it was reported", () => {
+    // The surprising state is the one a person most needs to see, so nothing
+    // here clamps it to a tidy 100%.
+    expect(usageOf({ used: 240000, size: 200000 })).toBe("240k/200k")
+  })
+
+  test("no report is no line, which is every session before its first turn", () => {
+    expect(usageOf(null)).toBeNull()
+  })
+})

--- a/packages/web/src/client/chat/usage.ts
+++ b/packages/web/src/client/chat/usage.ts
@@ -1,0 +1,45 @@
+/**
+ * How full the context is, as a line short enough to sit in a header.
+ *
+ * `22k/1M`. Two numbers and a slash, because the question it answers is "how
+ * much room is left" and neither half answers that alone: `22k` is meaningless
+ * without the window, and a window that never moved would not need saying —
+ * but it does move, since 200k and 1M are both ordinary and a session travels
+ * between them whenever the model does.
+ *
+ * A FRACTION rather than a percentage, and rather than a bar. A percentage is
+ * one number and reads the same at 80% of 200k as at 80% of 1M, which are
+ * quite different amounts of work left; a bar is a gauge, and this panel is
+ * Workflowy-quiet — the header's other facts are words, so this one is a
+ * number. The reader does the division, and gets the denominator for free.
+ *
+ * ROUNDED, hard. Nobody reads a header to learn they are at 22,102 tokens, and
+ * a figure that changes in its last three digits several times a turn is a
+ * flicker in the corner of the eye rather than information. Thousands to the
+ * nearest thousand, millions to one decimal — so the number moves when the
+ * answer moves and holds still when it does not.
+ */
+
+/** `used/size` for the header, e.g. `22k/1M` — or `null` when there is nothing
+ *  to say, which is every session before its first turn reports. */
+export const usageOf = (
+  usage: { readonly used: number; readonly size: number } | null,
+): string | null => (usage === null ? null : `${tokensOf(usage.used)}/${tokensOf(usage.size)}`)
+
+/**
+ * A token count, at the precision a header can use.
+ *
+ * Under a thousand is itself — the opening turns of a conversation, where `0`
+ * and `847` are both true and `0k` is neither. Thousands carry `k`, millions
+ * carry `M` with one decimal and no trailing `.0`, so a 1M window is `1M` and
+ * not `1.0M`. The k→M handover is done on the ROUNDED thousands rather than on
+ * the raw number, because 999,600 rounds to 1000k, and `1000k/1M` is a fraction
+ * that has to be read twice to see it is nearly full.
+ */
+const tokensOf = (tokens: number): string => {
+  if (tokens < 1_000) return String(tokens)
+  const thousands = Math.round(tokens / 1_000)
+  if (thousands < 1_000) return `${thousands}k`
+  const millions = Math.round(tokens / 100_000) / 10
+  return `${millions}M`
+}

--- a/packages/web/src/client/testids.ts
+++ b/packages/web/src/client/testids.ts
@@ -657,6 +657,10 @@ export const TESTID = {
   paletteSearchError: "palette-search-error",
   chatTitle: "chat-title",
   chatModel: "chat-model",
+  /** How full the context is (`22k/1M`), beside the model. Absent until the
+   *  agent has reported some — a conversation that has spent nothing says
+   *  `0/…`, so an absent line means nothing was said rather than nothing spent. */
+  chatUsage: "chat-usage",
   chatNew: "chat-new",
   /** Drawn beside the model while a turn is running. Beside, not instead:
    *  what it runs on and whether it is running are two facts. */


### PR DESCRIPTION
`chat-token-usage`: the panel had no answer to *is it time to `/compact`?*, so
the way you found out was by watching the agent start forgetting.

The agent had been saying it all along. `agent.ts`'s `default` arm named
"thoughts, plans, **usage**" as real parts of the protocol this panel drops, and
usage is the one of those three that answers a question somebody was asking.

## What it looks like

Beside the model, in the header's own quiet line:

![the header before any turn](https://github.com/user-attachments/assets/fe34f84a-06d9-49db-ab0e-33ea558637c7)

![the header after three turns](https://github.com/user-attachments/assets/5c86329b-2143-4dfa-8578-eb1e9e165e22)

And moving, which is the whole claim — real adapter, real turns, one fresh
conversation, nothing scripted:

https://github.com/user-attachments/assets/78820e71-c5b6-4c36-aede-c53fd29f7ed3

| | header |
|---|---|
| before any turn | `Fable` — nothing about room yet |
| after one turn | `Fable  24k/1M` |
| after a longer turn | `Fable  26k/1M` |
| after another | `Fable  28k/1M` |

## Where it is read, and why there

**`usage_update` is ACP's own update kind** — it sits in the `SessionUpdate`
union beside `tool_call` and `config_option_update`, and any agent may send one.
So it is read in **`@olai/acp`** (`usage.ts`, pure, unit-tested — the `diffs.ts`
pattern) rather than in `@olai/chat`'s `interpret.ts`, which exists for values
only the Claude Code adapter means anything by. That boundary is not which
payload a reader touches but *who has to have sent it*, and this one is the
protocol's.

`Usage` rides the `./wire` subpath and the surface re-exports it, exactly as
`FileDiff` does. The package's manifest test enumerates both export lists, so
the two new names are declared rather than assumed.

## The one design call worth arguing: a fraction, not a percentage

`22k/1M`, not `2%`. **The window is not a constant** — 200k and 1M are both
ordinary, and a session travels between them whenever the model does — so a
percentage reads identically in both while meaning quite different amounts of
work left. Both numbers are shown and the reader does the division, which also
puts the window on screen: a fact the header otherwise cannot state, since
[#176](https://github.com/juspay/olai/pull/176) established that the running
model's id never carries its context lane.

Not a gauge either. This panel is Workflowy-quiet and the header's other facts
are words, so this one is a number. Rounded hard (thousands to the thousand,
millions to one decimal): a figure that moves in its last three digits several
times a turn is a flicker in the corner of the eye rather than information.

## Both halves move, and the newest wins

Several frames arrive per turn and the panel holds the latest, not the first.
Captured off 0.66.0 across four turns with a `/model` in the middle:

| turn | `used` | `size` |
|---|---|---|
| 1 (on Fable) | 22102 → 22108 | 1000000 |
| 2 (`/model claude-opus-4-5`) | *no usage frames at all* | — |
| 3 (first turn on Opus 4.5) | 22903 → 22925 | 1000000 → **200000** |
| 4 | 22917 → 22939 | 200000 |

Turn 3 is the interesting one: the adapter seeds the window from what it last
knew and **corrects it authoritatively when the turn ends**, so the first turn
after a model switch reports the old window mid-stream and the true one on the
last frame. (This is the same correction @grok observed in #176's review, where
it was the reason a picker row must not lend a context lane; here it is data the
header simply follows.) That is the agent revising a number it told us — not
this panel guessing — so it is drawn as it arrives.

Turn 2 shows the other side: a `/model` turn spends nothing and sends no usage
frames, so the header holds what it had.

## What is deliberately not drawn

**`cost`.** The turn-final frame carries a cumulative session cost. What a
session has spent is a different question from whether it is about to run out of
room, asked at a different moment, and a second number in that line buys nothing
for the one this exists to answer. It is read *past* rather than not noticed —
`usage.test.ts` asserts a frame carrying it yields the two numbers and drops it.

## Tests

**Unit.** `@olai/acp`'s `usage.ts` (7 tests) over the payloads the real adapter
sent, plus the near misses that are the reason this is a function and not a
field access: a `size` of `0`/`NaN`/negative is not a window and yields nothing
(the adapter guards its own writes with `> 0` for the same reason — it has met
third-party backends answering that way), `used: 0` is a fact and survives,
`used` greater than `size` is reported rather than tidied to 100%. The header's
formatter (6 tests) covers the numbers actually captured, the `999k`→`1M`
handover on rounded thousands (so a nearly-full 1M window never reads
`1000k/1M`), and small counts staying whole.

**e2e**, 3 scenarios. The fake agent now sends frames the way a real one does —
more than one per turn with the number moving between them, cost on the last,
and a `window` verb that moves the window BETWEEN a turn's two frames, where the adapter moves it. So:

- the header says nothing before the first turn, then `13k/200k`, then
  `26k/200k` — and `13k` rather than `12k` is the assertion that the panel holds
  a turn's **newest** frame rather than its first;
- the window moving is followed (`13k/200k` → `26k/1M`), and because it moves
  between that turn's two frames this pins newest-wins for **both** halves: a
  panel keeping the turn's first report would read `25k/200k`;
- a new conversation is not asked how full the last one was.

## Docs

`docs/chat.md` gains "How full the context is": where the number comes from, why
a fraction, that the window can move under a conversation, that an agent
reporting nothing gets no line (distinct from `0/200k`), and that cost is on the
wire and not drawn. `packages/acp/README.md`'s module table gains `usage.ts` and
names `Usage` on the wire half.

## Review round

One review posted so far. Two findings, both real, both fixed in `0d0446f6`:
the `@olai/acp` README was garbled at line 1 by an edit of mine, and the fake
agent was not actually pinning the intra-turn `size` revision it claimed to
(newest-wins was pinned for `used` alone). Sabotage-checked: with `chat.ts`
holding a turn's first report instead of its newest, both usage scenarios fail
on the assertion they exist for. Per-finding reply in the thread.

## Left undone

- **no compaction cue.** The number is the fact; deciding *for* a person when to
  compact — a colour at 80%, a nudge — is a separate call about a panel that is
  deliberately quiet, and it wants the human's eye on a real session before
  anyone picks a threshold.
- **a loaded conversation shows nothing until its first turn.** `session/load`
  replays without a usage frame, so the header is blank about room until the
  next turn reports. Truthful, and fixable only by the agent sending one on
  load.

