### PR TITLE
Escape after a completion no longer resurrects the draft

### DIFF
--- a/packages/tests/features/input_widgets.feature
+++ b/packages/tests/features/input_widgets.feature
@@ -210,6 +210,10 @@ Feature: The three input widgets
     # A pointer's write and a keystroke's file onto one stack, so the chord does
     # not mean two things depending on which hand made the edit. The inverse of
     # `add_mirror` is `remove_mirror`, named by the placement the write minted.
+    # Escape first: the draft must stay closed after the write lands. It used
+    # to bounce back when add_mirror was still in flight (`kept` in draft.ts).
+    # The chord after that spends the inverse `send` recorded — caret.ts waits
+    # for the placement to be drawn, which is this tab having the way back.
     When I click the title of "knobs"
     And I type " ((compost"
     And the mirror completions are open

--- a/packages/tests/support/caret.ts
+++ b/packages/tests/support/caret.ts
@@ -292,15 +292,25 @@ const answering = async (
     // the row appears is the reply). Without that wait, Escape+⌘Z after a
     // completion spent a stack that did not yet hold the placement.
     const kind = await world.page.locator(COMPLETIONS).getAttribute("data-kind");
-    const mirrors = await world.page.locator(`${NODE}[data-kind="mirror"]`).count();
+    // Two counts, not one poll: this is the floor, taken before the key.
+    const mirrorsBefore = await world.page
+      .locator(`${NODE}[data-kind="mirror"]`)
+      .count();
     return async () => {
       await theListIsGone(world);
       if (kind !== "mirror") return;
+      // …and this is the one `waitUntil` retries, until a new placement is
+      // on the page.
       await world.waitUntil(
         async () =>
-          (await world.page.locator(`${NODE}[data-kind="mirror"]`).count()) > mirrors,
+          (await world.page.locator(`${NODE}[data-kind="mirror"]`).count()) >
+          mirrorsBefore,
         "the placement to be drawn",
       );
+      // The frame after the row was drawn — the snapshot painted it; the
+      // apply reply is the next message on the same wire, and `undo.record`
+      // has run by then. Not the generic double-rAF flush `pressed` already
+      // waited for above the key.
       await world.waitForFrame();
     };
   }

--- a/packages/tests/support/caret.ts
+++ b/packages/tests/support/caret.ts
@@ -52,6 +52,12 @@
  *     when this returns, so "nothing is being typed" is not the same promise
  *     as "this tab has the way back".
  *
+ * `Enter` on a SHORTLIST is the other shape, not an omission: the list going
+ * is the widget's answer, but a `((` take is also a write, and the disk
+ * having the placement is not this tab having the inverse. Waiting for the
+ * new row to be drawn is what makes the ⌘Z after it spend the entry `send`
+ * just recorded.
+ *
  * Its own module for the reason `./said.ts` is one: this is a RITUAL rather
  * than a step, three step files could want it, and two of them waiting for the
  * client's answer two different ways is how one of them stops waiting properly.
@@ -277,9 +283,26 @@ const answering = async (
   // away; the arrows walk it and settle nothing. None of them moves the caret,
   // so none of the shapes below applies to any of them.
   if (await aListIsUp(world)) {
-    return key === "Enter" || key === "Escape"
-      ? async () => await theListIsGone(world)
-      : nothing;
+    if (key === "Escape") return async () => await theListIsGone(world);
+    if (key !== "Enter") return nothing;
+    // A take is two answers. The list going is the widget's. A `((` take is
+    // also a write, and the row that write draws is this tab saying the
+    // inverse is on the stack (`editing.tsx`'s `send` records it before it
+    // returns; the snapshot and the reply share the wire, and one frame after
+    // the row appears is the reply). Without that wait, Escape+⌘Z after a
+    // completion spent a stack that did not yet hold the placement.
+    const kind = await world.page.locator(COMPLETIONS).getAttribute("data-kind");
+    const mirrors = await world.page.locator(`${NODE}[data-kind="mirror"]`).count();
+    return async () => {
+      await theListIsGone(world);
+      if (kind !== "mirror") return;
+      await world.waitUntil(
+        async () =>
+          (await world.page.locator(`${NODE}[data-kind="mirror"]`).count()) > mirrors,
+        "the placement to be drawn",
+      );
+      await world.waitForFrame();
+    };
   }
   if (key === "Escape") {
     // Escape abandons the draft, always. With none open there is nothing to

--- a/packages/web/src/client/edit/draft.test.ts
+++ b/packages/web/src/client/edit/draft.test.ts
@@ -7,6 +7,7 @@ import {
   commitOf,
   type Draft,
   type Editing,
+  kept,
   landed,
   type Pending,
   refused,
@@ -100,6 +101,25 @@ test("a commit that landed is a draft with nothing left to say", () => {
 test("a landed commit carries the nudge the write came back with", () => {
   expect(landed(editing({ text: "x" }), "order", "every task under it is done now").nudge)
     .toBe("every task under it is done now")
+})
+
+test("a cancelled draft stays cancelled when the write lands", () => {
+  // Escape is not queued. A completion's add_mirror can still be in flight
+  // when the key lands, and putting `held` back is how the editor bounced
+  // open after the draft had already closed (input_widgets.feature:209).
+  const held = editing()
+  expect(kept(null, held, "placed")).toBeNull()
+})
+
+test("the same draft keeps the write's nudge", () => {
+  const held = editing()
+  expect(kept(held, held, "placed")).toEqual({ ...held, nudge: "placed" })
+})
+
+test("a different draft is left alone", () => {
+  const held = editing()
+  const other = editing({ row: "knobs", id: "knobs", text: "pick the knobs" })
+  expect(kept(other, held, "placed")).toBe(other)
 })
 
 test("a new row that landed becomes the row it created", () => {

--- a/packages/web/src/client/edit/draft.ts
+++ b/packages/web/src/client/edit/draft.ts
@@ -202,6 +202,25 @@ export const refused = (draft: Draft, failure: OpFailure): Draft => ({
   refused: failure,
 })
 
+/**
+ * After a write that keeps the caret: THIS draft, with what the write said —
+ * or nothing, if the reader already let go.
+ *
+ * Identity, the same check {@link landed}'s caller already makes. A cancel
+ * replaces the object with `null`, and `current ?? held` used to put the
+ * abandoned draft back. That is how Escape after a completion bounced the
+ * editor open (`input_widgets.feature:209`): the placement had landed on
+ * disk, Escape closed the line, and the in-flight `setDraft` resurrected it.
+ */
+export const kept = (
+  current: Draft | null,
+  held: Draft,
+  nudge?: string,
+): Draft | null => {
+  if (current !== held) return current
+  return nudge === undefined || held.kind !== "row" ? held : { ...held, nudge }
+}
+
 /** Where the NEXT row goes when this draft is followed by `Enter`: after the
  *  ROW, not after the node it shows. `Enter` on a mirror makes a sibling of
  *  the mirror — the line appears where the reader is looking — rather than a

--- a/packages/web/src/client/edit/draft.ts
+++ b/packages/web/src/client/edit/draft.ts
@@ -211,6 +211,13 @@ export const refused = (draft: Draft, failure: OpFailure): Draft => ({
  * abandoned draft back. That is how Escape after a completion bounced the
  * editor open (`input_widgets.feature:209`): the placement had landed on
  * disk, Escape closed the line, and the in-flight `setDraft` resurrected it.
+ *
+ * Three arguments because the question is about TWO drafts — the one the
+ * write left, and the one that is open now — plus what the write said.
+ * {@link typed} and {@link refused} rewrite one draft; this one decides
+ * whether to keep it. Slot forwarding (`was` / {@link stillAt}) is
+ * {@link landed}'s, and a caller that needs both composes them. There is
+ * no overload.
  */
 export const kept = (
   current: Draft | null,

--- a/packages/web/src/client/edit/editing.tsx
+++ b/packages/web/src/client/edit/editing.tsx
@@ -69,6 +69,7 @@ import {
   IDLE_COMMIT,
   type Draft,
   type Editing as RowDraft,
+  kept,
   landed,
   refused,
   sameSlot,
@@ -423,20 +424,17 @@ export const createEditor = (
     const moved = redraws(edit)
       ? await redrawing(edit, slot)
       : await send(edit, slot)
-    // The caret stays in the row that just moved: the draft is restored in
-    // case its editor was destroyed and blurred on the way out, and the caret
-    // is taken again because a row that merely moved among its siblings keeps
-    // its editor and loses the focus anyway — the document moved the element.
-    // Whatever the write had to say rides back with it — a `Ctrl+Enter` is the
-    // key most likely to earn a nudge, and it never goes through `commit`.
-    setDraft((current) => noted(current ?? held, moved?.nudge))
+    // The caret stays in the row that just moved: the same draft, with
+    // whatever the write had to say — a `Ctrl+Enter` is the key most likely
+    // to earn a nudge, and it never goes through `commit`. A cancel that
+    // landed while the write was in flight is left alone (`kept`); putting
+    // `held` back is how Escape after a completion bounced the editor open.
+    // The caret is taken again because a row that merely moved among its
+    // siblings keeps its editor and loses the focus anyway — the document
+    // moved the element.
+    setDraft((current) => kept(current, held, moved?.nudge))
     setCaret((n) => n + 1)
   }
-
-  /** A draft carrying what the write that just landed said, when it said
-   *  anything. */
-  const noted = (held: Draft, nudge: string | undefined): Draft =>
-    nudge === undefined || held.kind !== "row" ? held : { ...held, nudge }
 
   /** `Enter`: commit this row, and open an editor where the next one goes. The
    *  new row is not written until it has text — see {@link ./draft.ts}. */


### PR DESCRIPTION
## Verdict: (b) for Escape, (a) for the ⌘Z half

The flake still exists on master after #172.

Isolated on `naiveintent` (Linux x86_64, 16-way), `input_widgets.feature:209` failed on run 3 of 200:

```
When I press "Escape"
  timed out after 15000ms waiting until the draft to close
```

The dump is the receipt.

Capture-phase Escape hit the title-editor (`pick the knobs`, focused).

Bubble-phase: `defaultPrevented: true`, `active: body`, `editors: 0` — the draft closed.

57ms later the first poll saw `editors: 1`, focused, same text, and it stayed that way for 15s.

Escape worked.

The in-flight `add_mirror` put the draft back.

`structural` did `setDraft((current) => noted(current ?? held, nudge))`.

`cancel` is not queued, so Escape during `send`'s await left `current === null`, and `?? held` resurrected it.

A person who picks a completion and hits Escape while the placement is landing sees the editor bounce open.

`commit` already refuses that (`held === current`); `kept` is the same identity check.

Test-first: `kept(null, held)` against the old `??` was red; after the flip, green.

The neighboring ⌘Z step then failed on isolated run 150 (Escape now stayed closed): ⌘Z spent a stack that did not yet hold the placement.

The test waited for the disk, not this tab's inverse.

`Enter` on a `((` list now waits for the new row to be drawn — same wire as `undo.record`.

## Proof

300/300 consecutive `input_widgets.feature:209` on naiveintent after both fixes (the same isolated loop that went red on run 3, then on run 150 of the Escape-only fix).

100/100 of the neighboring Escape pair (`Escape puts the list away`, `With no list up`).

Full `input_widgets.feature` 19/19.

Full suite 604 scenarios / 4545 steps, all green, same machine, bun-served client.

Unit: `kept(null, held)` red against `current ?? held`, then green.

Does not touch `docs/roadmap.olai`.