### PR TITLE
`list_outlines` walks the set once, not once per file

### DIFF
--- a/packages/ops/src/query.test.ts
+++ b/packages/ops/src/query.test.ts
@@ -13,7 +13,7 @@ import { Found, type OutlineSet } from "@olai/format"
 import { describe, expect, test } from "bun:test"
 
 import { setOf } from "./fixtures.testlib.ts"
-import { detail, index, search, subtree } from "./query.ts"
+import { detail, index, outlines, search, subtree } from "./query.ts"
 
 /** A ledger: items in their sections, and a `Now` list made of placements —
  *  including one that CHAINS through another placement, which is the case
@@ -371,5 +371,65 @@ describe("a query is words and operators", () => {
     const answer = search(index(WORK()), { text: "is:done", limit: 1 })
     expect(answer.hits.map((hit) => hit.id)).toEqual(["book"])
     expect(answer.total).toBe(2)
+  })
+})
+
+/**
+ * What a listing says about a set of files — every arm of it in one fixture,
+ * because the walk that produces them is now one pass over the nodes and a
+ * lookup per file, and a lookup is a thing that can MISS.
+ *
+ * The three cases that miss differently are all here: a file whose nodes are
+ * in the walk, one that holds none at all (in `files`, absent from the tally),
+ * and one that did not parse (answered before the tally is consulted).
+ */
+describe("the directory", () => {
+  const DIRECTORY = (): OutlineSet =>
+    setOf({
+      "house.olai": [
+        // Written out of `ord` order on purpose: the roots a listing shows are
+        // the file's, in the order the file writes them.
+        `{"id":"garden","ord":"a1","title":"Garden"}`,
+        `{"id":"house","ord":"a0","title":"House"}`,
+        `{"id":"paint","parent":"house","ord":"a0","title":"paint the hall","todo":true}`,
+        // A mirror is a placement: it is neither counted nor a root, even
+        // sitting at the top level of the file.
+        `{"id":"shown","ord":"a2","mirror":"paint"}`,
+      ].join("\n"),
+      "empty.olai": "",
+      "shed.olai": `{"id":"shed","ord":"a0","title":"Shed"}`,
+    }, [], { "torn.olai": `{"id":` })
+
+  test("a row per file, in the order the directory lists them", () => {
+    expect(outlines(DIRECTORY(), index(DIRECTORY())).map((row) => row.file))
+      .toEqual(["house.olai", "empty.olai", "shed.olai", "torn.olai"])
+  })
+
+  test("a file's own regular nodes are counted, and its roots named in file order", () => {
+    const set = DIRECTORY()
+    expect(outlines(set, index(set))[0]).toEqual({
+      file: "house.olai",
+      nodes: 3,
+      roots: ["Garden", "House"],
+    })
+  })
+
+  test("an outline holding nothing says so, rather than saying nothing", () => {
+    const set = DIRECTORY()
+    expect(outlines(set, index(set))[1]).toEqual({
+      file: "empty.olai",
+      nodes: 0,
+      roots: [],
+    })
+  })
+
+  test("a file that did not parse carries its errors, and no count it could not take", () => {
+    const set = DIRECTORY()
+    expect(outlines(set, index(set))[3]).toEqual({
+      file: "torn.olai",
+      nodes: 0,
+      roots: [],
+      unreadable: [expect.any(String)],
+    })
   })
 })

--- a/packages/ops/src/query.test.ts
+++ b/packages/ops/src/query.test.ts
@@ -400,14 +400,23 @@ describe("the directory", () => {
       "shed.olai": `{"id":"shed","ord":"a0","title":"Shed"}`,
     }, [], { "torn.olai": `{"id":` })
 
+  /** The listing of ONE set — the set and the index it is asked through are
+   *  the same revision, which is the pairing {@link Derived} exists to keep:
+   *  two parameters would let a caller answer one revision out of another's
+   *  indexes, and the symptom would be a plausible answer rather than a
+   *  failure. Same shape as `at()` above, for the same reason. */
+  const listing = () => {
+    const set = DIRECTORY()
+    return outlines(set, index(set))
+  }
+
   test("a row per file, in the order the directory lists them", () => {
-    expect(outlines(DIRECTORY(), index(DIRECTORY())).map((row) => row.file))
+    expect(listing().map((row) => row.file))
       .toEqual(["house.olai", "empty.olai", "shed.olai", "torn.olai"])
   })
 
   test("a file's own regular nodes are counted, and its roots named in file order", () => {
-    const set = DIRECTORY()
-    expect(outlines(set, index(set))[0]).toEqual({
+    expect(listing()[0]).toEqual({
       file: "house.olai",
       nodes: 3,
       roots: ["Garden", "House"],
@@ -415,8 +424,7 @@ describe("the directory", () => {
   })
 
   test("an outline holding nothing says so, rather than saying nothing", () => {
-    const set = DIRECTORY()
-    expect(outlines(set, index(set))[1]).toEqual({
+    expect(listing()[1]).toEqual({
       file: "empty.olai",
       nodes: 0,
       roots: [],
@@ -424,8 +432,7 @@ describe("the directory", () => {
   })
 
   test("a file that did not parse carries its errors, and no count it could not take", () => {
-    const set = DIRECTORY()
-    expect(outlines(set, index(set))[3]).toEqual({
+    expect(listing()[3]).toEqual({
       file: "torn.olai",
       nodes: 0,
       roots: [],

--- a/packages/ops/src/query.test.ts
+++ b/packages/ops/src/query.test.ts
@@ -376,12 +376,12 @@ describe("a query is words and operators", () => {
 
 /**
  * What a listing says about a set of files — every arm of it in one fixture,
- * because the walk that produces them is now one pass over the nodes and a
- * lookup per file, and a lookup is a thing that can MISS.
+ * because a row is answered by a LOOKUP into the grouped nodes, and a lookup
+ * is a thing that can miss.
  *
- * The three cases that miss differently are all here: a file whose nodes are
- * in the walk, one that holds none at all (in `files`, absent from the tally),
- * and one that did not parse (answered before the tally is consulted).
+ * The three that miss differently are all here: a file whose nodes are in the
+ * grouping, one that holds none at all (in `files`, in no group), and one that
+ * did not parse (answered before the grouping is consulted).
  */
 describe("the directory", () => {
   const DIRECTORY = (): OutlineSet =>
@@ -400,43 +400,20 @@ describe("the directory", () => {
       "shed.olai": `{"id":"shed","ord":"a0","title":"Shed"}`,
     }, [], { "torn.olai": `{"id":` })
 
-  /** The listing of ONE set — the set and the index it is asked through are
-   *  the same revision, which is the pairing {@link Derived} exists to keep:
-   *  two parameters would let a caller answer one revision out of another's
-   *  indexes, and the symptom would be a plausible answer rather than a
-   *  failure. Same shape as `at()` above, for the same reason. */
-  const listing = () => {
+  /** The WHOLE listing in one assertion rather than four indexes into it: the
+   *  order is one of the claims, so a row pinned by position would be leaning
+   *  on a fact a sibling test owns. */
+  test("every file gets its row, in order, counted and titled by its own nodes", () => {
     const set = DIRECTORY()
-    return outlines(set, index(set))
-  }
-
-  test("a row per file, in the order the directory lists them", () => {
-    expect(listing().map((row) => row.file))
-      .toEqual(["house.olai", "empty.olai", "shed.olai", "torn.olai"])
-  })
-
-  test("a file's own regular nodes are counted, and its roots named in file order", () => {
-    expect(listing()[0]).toEqual({
-      file: "house.olai",
-      nodes: 3,
-      roots: ["Garden", "House"],
-    })
-  })
-
-  test("an outline holding nothing says so, rather than saying nothing", () => {
-    expect(listing()[1]).toEqual({
-      file: "empty.olai",
-      nodes: 0,
-      roots: [],
-    })
-  })
-
-  test("a file that did not parse carries its errors, and no count it could not take", () => {
-    expect(listing()[3]).toEqual({
-      file: "torn.olai",
-      nodes: 0,
-      roots: [],
-      unreadable: [expect.any(String)],
-    })
+    expect(outlines(set, index(set))).toEqual([
+      // Three regular nodes — the mirror is a placement, so it is neither
+      // counted nor a root — and the roots are in FILE order.
+      { file: "house.olai", nodes: 3, roots: ["Garden", "House"] },
+      { file: "empty.olai", nodes: 0, roots: [] },
+      { file: "shed.olai", nodes: 1, roots: ["Shed"] },
+      // The torn row carries `unreadable` BESIDE a zero and an empty list —
+      // the flat shape {@link OutlineSummary} holds knowingly.
+      { file: "torn.olai", nodes: 0, roots: [], unreadable: [expect.any(String)] },
+    ])
   })
 })

--- a/packages/ops/src/query.ts
+++ b/packages/ops/src/query.ts
@@ -367,11 +367,58 @@ export const subtree = (
 
 // ── the directory ──────────────────────────────────────────────────────
 
+/** What a listing has to say about one file, tallied as the nodes go past:
+ *  how many are its own, and the titles of the ones at its top level. */
+interface Tally {
+  nodes: number
+  readonly roots: Array<string>
+}
+
+/**
+ * The nodes counted into their files — ONE walk of the set, not one per file.
+ *
+ * The set is flat ({@link OutlineSet} says why), so "which nodes are this
+ * file's" is a scan, and asking it once per file makes listing a directory
+ * cost files × nodes with three scans per row: the file's own records, then
+ * the regular ones among them, then the roots among those. Four outlines never
+ * noticed; four hundred outlines over a few thousand nodes is the same answer
+ * arrived at a thousand times more slowly, and `list_outlines` is the FIRST
+ * call an agent makes on a directory it has not seen.
+ *
+ * The grouping is not kept on {@link Derived} beside the other indexes,
+ * because this is the only answer that wants it — every other walk here is
+ * keyed by id or by parent, both of which are already indexed, and a per-file
+ * map computed for every revision would be a fourth index carried for one
+ * caller.
+ *
+ * ORDER IS THE WALK'S, and that is what keeps the answer identical: roots come
+ * out in the order `derived.nodes` holds them — file order, as the old
+ * per-file filter also gave — rather than in sibling (`ord`) order, which is
+ * a different list whenever a root has been moved.
+ */
+const tallied = (derived: Derived): ReadonlyMap<string, Tally> => {
+  const byFile = new Map<string, Tally>()
+  for (const located of derived.nodes) {
+    // A mirror is a placement rather than a node, so it neither counts nor
+    // titles a row — the same rule {@link OutlineSummary}'s `nodes` states.
+    if (isMirror(located.node)) continue
+    let own = byFile.get(located.file)
+    if (own === undefined) {
+      own = { nodes: 0, roots: [] }
+      byFile.set(located.file, own)
+    }
+    own.nodes += 1
+    if (located.node.parent === undefined) own.roots.push(located.node.title)
+  }
+  return byFile
+}
+
 export const outlines = (
   set: OutlineSet,
   derived: Derived,
 ): ReadonlyArray<OutlineSummary> => {
   const broken = new Map(set.broken.map((entry) => [entry.file, entry.errors]))
+  const counted = tallied(derived)
   // ANNOTATED, so the row literals below are checked against the floor: a
   // field dropped from `OutlineSummary` fails HERE rather than only at the
   // table-driven decode. That is independent of what the rows hold, which is
@@ -388,13 +435,14 @@ export const outlines = (
         unreadable: errors.map(errorLine),
       }
     }
-    const own = derived.nodes.filter((located) => located.file === file)
+    // Absent for a file that holds no nodes at all — an outline can be empty,
+    // and `files` lists it either way, which is why the row is built from the
+    // list of FILES and only looked up here.
+    const own = counted.get(file)
     return {
       file,
-      nodes: own.filter((located) => !isMirror(located.node)).length,
-      roots: own
-        .filter((located) => located.node.parent === undefined && !isMirror(located.node))
-        .map((located) => (located as LocatedRegular).node.title),
+      nodes: own?.nodes ?? 0,
+      roots: own?.roots ?? [],
     }
   })
 }

--- a/packages/ops/src/query.ts
+++ b/packages/ops/src/query.ts
@@ -373,29 +373,31 @@ export const outlines = (
 ): ReadonlyArray<OutlineSummary> => {
   const broken = new Map(set.broken.map((entry) => [entry.file, entry.errors]))
   /**
-   * The nodes GROUPED BY FILE, once — not scanned once per file.
+   * Each file's own nodes, grouped once. The set is FLAT ({@link OutlineSet}
+   * says why), so "which nodes are this file's" is a scan of the whole list,
+   * and asking it per row cost files × nodes — on the first call an agent
+   * makes on a directory it has not seen.
    *
-   * The set is flat ({@link OutlineSet} says why), so "which nodes are this
-   * file's" is a scan of the whole list, and asking it per row made listing a
-   * directory cost files × nodes. Four outlines never noticed; four hundred
-   * over a few thousand nodes is the same answer arrived at far more slowly,
-   * on the FIRST call an agent makes on a directory it has not seen.
+   * `Map.groupBy` holds each group in ENCOUNTER order, which is what `roots`
+   * below stands on: a row's titles come out in file order, not the sibling
+   * (`ord`) order they would be in had anything sorted them.
    *
-   * `Map.groupBy` rather than a tally accumulated by hand: the grouping is the
-   * whole of what the walk decides, the runtime already ships it, and the row
-   * below is then the one this file has always written — which is what makes
-   * "the answer is unchanged" something a reader can see rather than trust.
-   * Each group holds its members in ENCOUNTER order, so a row's `roots` are
-   * still in file order, exactly as the per-file scan gave them.
+   * The mirrors drop HERE, once for the whole answer, as `countedChildren`
+   * drops them in the floor — a placement is neither counted nor a title, and
+   * that rule spelled once per use is a rule that can come to disagree with
+   * itself. Saying they are gone is also what lets the titles below be read
+   * without an assertion.
    *
-   * It is grouped HERE rather than kept on {@link Derived} beside the other
-   * indexes, and that is a recorded opportunity rather than a settled place:
-   * per-file access over a flat set is a real axis, `Derived` is where it
-   * would live, and `siblingsOf` in the floor asks the same question the same
-   * way — so the second consumer is somebody else's change, and building the
-   * index at population one would mean plumbing it twice.
+   * NOT a field on {@link Derived}, though this grouping is written three
+   * times in the tree: `siblingsOf` in the floor sorts what it groups,
+   * `publishedOf` and the pending walk ask it of an `OutlineSet` they never
+   * derive at all. Only the grouping itself is shared, and what shape a shared
+   * one should take is for the roadmap's `siblings-of-quadratic` to settle.
    */
-  const byFile = Map.groupBy(derived.nodes, (located) => located.file)
+  const byFile = Map.groupBy(
+    derived.nodes.filter((located): located is LocatedRegular => !isMirror(located.node)),
+    (located) => located.file,
+  )
   // ANNOTATED, so the row literals below are checked against the floor: a
   // field dropped from `OutlineSummary` fails HERE rather than only at the
   // table-driven decode. That is independent of what the rows hold, which is
@@ -412,19 +414,8 @@ export const outlines = (
         unreadable: errors.map(errorLine),
       }
     }
-    // No group at all is an outline holding no nodes: `files` lists it either
-    // way, which is why a row is built from the list of FILES and the group
-    // only looked up here.
-    //
-    // The mirrors drop ONCE, through a type guard, exactly as `countedChildren`
-    // drops them in the floor: a placement is neither counted nor a title, and
-    // that rule spelled twice — once for the count, once for the roots — is a
-    // rule that can come to disagree with itself. The guard is also what makes
-    // the titles below reachable without an assertion, which is the same trade
-    // the floor's comment names: saying the mirrors are gone is what deletes
-    // the cast.
-    const own = (byFile.get(file) ?? [])
-      .filter((located): located is LocatedRegular => !isMirror(located.node))
+    // No group at all is an outline holding no nodes of its own.
+    const own = byFile.get(file) ?? []
     return {
       file,
       nodes: own.length,

--- a/packages/ops/src/query.ts
+++ b/packages/ops/src/query.ts
@@ -387,6 +387,13 @@ export const outlines = (
    * "the answer is unchanged" something a reader can see rather than trust.
    * Each group holds its members in ENCOUNTER order, so a row's `roots` are
    * still in file order, exactly as the per-file scan gave them.
+   *
+   * It is grouped HERE rather than kept on {@link Derived} beside the other
+   * indexes, and that is a recorded opportunity rather than a settled place:
+   * per-file access over a flat set is a real axis, `Derived` is where it
+   * would live, and `siblingsOf` in the floor asks the same question the same
+   * way — so the second consumer is somebody else's change, and building the
+   * index at population one would mean plumbing it twice.
    */
   const byFile = Map.groupBy(derived.nodes, (located) => located.file)
   // ANNOTATED, so the row literals below are checked against the floor: a
@@ -408,13 +415,22 @@ export const outlines = (
     // No group at all is an outline holding no nodes: `files` lists it either
     // way, which is why a row is built from the list of FILES and the group
     // only looked up here.
-    const own = byFile.get(file) ?? []
+    //
+    // The mirrors drop ONCE, through a type guard, exactly as `countedChildren`
+    // drops them in the floor: a placement is neither counted nor a title, and
+    // that rule spelled twice — once for the count, once for the roots — is a
+    // rule that can come to disagree with itself. The guard is also what makes
+    // the titles below reachable without an assertion, which is the same trade
+    // the floor's comment names: saying the mirrors are gone is what deletes
+    // the cast.
+    const own = (byFile.get(file) ?? [])
+      .filter((located): located is LocatedRegular => !isMirror(located.node))
     return {
       file,
-      nodes: own.filter((located) => !isMirror(located.node)).length,
+      nodes: own.length,
       roots: own
-        .filter((located) => located.node.parent === undefined && !isMirror(located.node))
-        .map((located) => (located as LocatedRegular).node.title),
+        .filter((located) => located.node.parent === undefined)
+        .map((located) => located.node.title),
     }
   })
 }

--- a/packages/ops/src/query.ts
+++ b/packages/ops/src/query.ts
@@ -367,58 +367,28 @@ export const subtree = (
 
 // ── the directory ──────────────────────────────────────────────────────
 
-/** What a listing has to say about one file, tallied as the nodes go past:
- *  how many are its own, and the titles of the ones at its top level. */
-interface Tally {
-  nodes: number
-  readonly roots: Array<string>
-}
-
-/**
- * The nodes counted into their files — ONE walk of the set, not one per file.
- *
- * The set is flat ({@link OutlineSet} says why), so "which nodes are this
- * file's" is a scan, and asking it once per file makes listing a directory
- * cost files × nodes with three scans per row: the file's own records, then
- * the regular ones among them, then the roots among those. Four outlines never
- * noticed; four hundred outlines over a few thousand nodes is the same answer
- * arrived at a thousand times more slowly, and `list_outlines` is the FIRST
- * call an agent makes on a directory it has not seen.
- *
- * The grouping is not kept on {@link Derived} beside the other indexes,
- * because this is the only answer that wants it — every other walk here is
- * keyed by id or by parent, both of which are already indexed, and a per-file
- * map computed for every revision would be a fourth index carried for one
- * caller.
- *
- * ORDER IS THE WALK'S, and that is what keeps the answer identical: roots come
- * out in the order `derived.nodes` holds them — file order, as the old
- * per-file filter also gave — rather than in sibling (`ord`) order, which is
- * a different list whenever a root has been moved.
- */
-const tallied = (derived: Derived): ReadonlyMap<string, Tally> => {
-  const byFile = new Map<string, Tally>()
-  for (const located of derived.nodes) {
-    // A mirror is a placement rather than a node, so it neither counts nor
-    // titles a row — the same rule {@link OutlineSummary}'s `nodes` states.
-    if (isMirror(located.node)) continue
-    let own = byFile.get(located.file)
-    if (own === undefined) {
-      own = { nodes: 0, roots: [] }
-      byFile.set(located.file, own)
-    }
-    own.nodes += 1
-    if (located.node.parent === undefined) own.roots.push(located.node.title)
-  }
-  return byFile
-}
-
 export const outlines = (
   set: OutlineSet,
   derived: Derived,
 ): ReadonlyArray<OutlineSummary> => {
   const broken = new Map(set.broken.map((entry) => [entry.file, entry.errors]))
-  const counted = tallied(derived)
+  /**
+   * The nodes GROUPED BY FILE, once — not scanned once per file.
+   *
+   * The set is flat ({@link OutlineSet} says why), so "which nodes are this
+   * file's" is a scan of the whole list, and asking it per row made listing a
+   * directory cost files × nodes. Four outlines never noticed; four hundred
+   * over a few thousand nodes is the same answer arrived at far more slowly,
+   * on the FIRST call an agent makes on a directory it has not seen.
+   *
+   * `Map.groupBy` rather than a tally accumulated by hand: the grouping is the
+   * whole of what the walk decides, the runtime already ships it, and the row
+   * below is then the one this file has always written — which is what makes
+   * "the answer is unchanged" something a reader can see rather than trust.
+   * Each group holds its members in ENCOUNTER order, so a row's `roots` are
+   * still in file order, exactly as the per-file scan gave them.
+   */
+  const byFile = Map.groupBy(derived.nodes, (located) => located.file)
   // ANNOTATED, so the row literals below are checked against the floor: a
   // field dropped from `OutlineSummary` fails HERE rather than only at the
   // table-driven decode. That is independent of what the rows hold, which is
@@ -435,14 +405,16 @@ export const outlines = (
         unreadable: errors.map(errorLine),
       }
     }
-    // Absent for a file that holds no nodes at all — an outline can be empty,
-    // and `files` lists it either way, which is why the row is built from the
-    // list of FILES and only looked up here.
-    const own = counted.get(file)
+    // No group at all is an outline holding no nodes: `files` lists it either
+    // way, which is why a row is built from the list of FILES and the group
+    // only looked up here.
+    const own = byFile.get(file) ?? []
     return {
       file,
-      nodes: own?.nodes ?? 0,
-      roots: own?.roots ?? [],
+      nodes: own.filter((located) => !isMirror(located.node)).length,
+      roots: own
+        .filter((located) => located.node.parent === undefined && !isMirror(located.node))
+        .map((located) => (located as LocatedRegular).node.title),
     }
   })
 }


### PR DESCRIPTION
`list_outlines` asked "which nodes are this file's" once per file, over the flat node list the set keeps — and asked it three times per row: the file's own records, then the regular ones among them, then the roots among those. That is files × nodes, three passes each. Four outlines never noticed; four hundred do, and this is the FIRST call an agent makes on a directory it has not seen.

Now the nodes are grouped by file once, with `Map.groupBy`, and each row is a lookup.

**The answer is identical**, field for field. Roots included: `Map.groupBy` promises each group holds its members in *encounter* order, so a row's titles come out in the file order the per-file scan also gave (not `ord` order, which is a different list whenever a root has been moved). The torn-file row is still answered before the grouping is consulted, and a file that holds no nodes at all still gets `nodes: 0, roots: []` — it is in `files` and in no group, which is why a row is still built from the list of FILES.

The mirrors drop once, before the grouping, rather than being re-excluded in each row — so "a placement is neither counted nor a title" is stated once for the whole answer, and the titles are readable without a cast.

## Evidence: before/after on a generated directory

Generated set: `files` outlines each holding 20 regular nodes (three roots, the rest children of them) plus a mirror, alongside one empty outline and one file that did not parse. Both implementations run against the *same* `Derived` — deriving is not part of what is timed — and the benchmark **asserts the two answers are identical (`JSON.stringify`) before it times anything**, so a faster walk that answered differently aborts rather than posting a number.

Per-run median of 25 rounds (15 at 400+ files) after 3 warm-up rounds; the table is the median of five such runs. `bun` 1.3.13, x86_64-linux.

| files | nodes | before (ms) | after (ms) | speedup |
| ---: | ---: | ---: | ---: | ---: |
| 100 | 2,100 | 1.40 | 0.17 | 8× |
| 200 | 4,200 | 2.37 | 0.22 | 11× |
| 400 | 8,400 | 10.02 | 0.60 | 17× |
| 800 | 16,800 | 45.51 | 0.68 | 67× |

The shape matters more than any single row: doubling the directory multiplies `before` by ~4.5 at the top end (10.02 → 45.51) and `after` by ~1.1 (0.60 → 0.68) — quadratic against linear. Spread across the five runs was 1.38–1.43 / 45.46–46.82 on the `before` column and 0.15–0.21 / 0.65–0.82 on the `after` column.

<details>
<summary>The benchmark (drop in <code>packages/ops/bench-outlines.ts</code>, <code>nix develop -c bun packages/ops/bench-outlines.ts</code>)</summary>

It is not committed: this repo has no bench harness to add a leg to, and the measurement is a one-off about a walk that is now linear. It carries `before` verbatim so it can be re-run against any later revision.

```ts
import {
  type Derived,
  errorLine,
  isMirror,
  type LocatedRegular,
  type OutlineSet,
  type OutlineSummary,
} from "@olai/format"
import { setOf } from "./src/fixtures.testlib.ts"
import * as Query from "./src/query.ts"

const after = Query.outlines

/** The implementation as it stood on master, verbatim. */
const before = (set: OutlineSet, derived: Derived): ReadonlyArray<OutlineSummary> => {
  const broken = new Map(set.broken.map((entry) => [entry.file, entry.errors]))
  return set.files.map((file): OutlineSummary => {
    const errors = broken.get(file)
    if (errors !== undefined) {
      return { file, nodes: 0, roots: [], unreadable: errors.map(errorLine) }
    }
    const own = derived.nodes.filter((located) => located.file === file)
    return {
      file,
      nodes: own.filter((located) => !isMirror(located.node)).length,
      roots: own
        .filter((located) => located.node.parent === undefined && !isMirror(located.node))
        .map((located) => (located as LocatedRegular).node.title),
    }
  })
}

/** A directory of `files` outlines, each holding `per` nodes: three roots, the
 *  rest children of them, and a mirror so the count and the roots both have
 *  placements to ignore. Plus one file that did not parse, and one empty one. */
const directory = (files: number, per: number): OutlineSet => {
  const outlinesText: Record<string, string> = {}
  for (let f = 0; f < files; f += 1) {
    const lines: Array<string> = []
    const roots: Array<string> = []
    for (let n = 0; n < per; n += 1) {
      const id = `f${f}-n${n}`
      const ord = `a${n.toString(36).padStart(4, "0")}`
      if (n < 3) {
        roots.push(id)
        lines.push(JSON.stringify({ id, ord, title: `Root ${n} of file ${f}` }))
      } else {
        const parent = roots[n % 3]
        lines.push(JSON.stringify({ id, parent, ord, title: `Node ${n} of file ${f}` }))
      }
    }
    lines.push(JSON.stringify({
      id: `f${f}-mirror`,
      parent: roots[0],
      ord: "z0",
      mirror: `f${f}-n3`,
    }))
    outlinesText[`file-${f.toString().padStart(4, "0")}.olai`] = lines.join("\n")
  }
  outlinesText["empty.olai"] = ""
  return setOf(outlinesText, [], { "torn.olai": `{"id":` })
}

const median = (samples: ReadonlyArray<number>): number =>
  [...samples].sort((a, b) => a - b)[Math.floor(samples.length / 2)] ?? 0

const time = (
  run: (set: OutlineSet, derived: Derived) => ReadonlyArray<OutlineSummary>,
  set: OutlineSet,
  derived: Derived,
  rounds: number,
): number => {
  for (let i = 0; i < 3; i += 1) run(set, derived) // warm
  const samples: Array<number> = []
  for (let i = 0; i < rounds; i += 1) {
    const started = performance.now()
    run(set, derived)
    samples.push(performance.now() - started)
  }
  return median(samples)
}

const SHAPES = [
  { files: 100, per: 20 },
  { files: 200, per: 20 },
  { files: 400, per: 20 },
  { files: 800, per: 20 },
]

console.log("files\tnodes\tbefore\tafter")
for (const shape of SHAPES) {
  const set = directory(shape.files, shape.per)
  const derived = Query.index(set)
  const rounds = shape.files >= 400 ? 15 : 25

  // Same answer, field for field, before anything is timed: a faster walk that
  // answered differently would be the wrong measurement entirely.
  if (JSON.stringify(before(set, derived)) !== JSON.stringify(after(set, derived))) {
    console.error("ANSWERS DIFFER — benchmark is meaningless")
    process.exit(1)
  }

  const took = {
    before: time(before, set, derived, rounds),
    after: time(after, set, derived, rounds),
  }
  console.log(
    `${shape.files}\t${derived.nodes.length}\t${took.before.toFixed(2)}\t${took.after.toFixed(2)}`,
  )
}
```

</details>

## Tests

The listing had no test of its own — it was pinned only through `tools.test.ts`'s decode fixture, which is about the SHAPE the MCP table answers in. So `query.test.ts` grows a `the directory` block over one fixture holding every arm a lookup can miss: a file whose nodes are in the grouping, an empty outline (in `files`, in no group), and a torn one (answered before the grouping is consulted). It asserts the whole listing in one `toEqual` rather than indexing into it, so no row leans on an ordering another test owns.

Everything else is unchanged and green.

## Review passes

The implementation was accepted first and then refactored, one commit per pass, each pushed on its own:

- **`architecture-first-principles`** — C1 (ecosystem-duplicate) caught the first version hand-rolling group-by-key with a mutable tally cell when `Map.groupBy` is a language built-in, present in the pinned Bun and typed by `lib: ESNext`. Adopting it also settled C6/P1 (the mutable place read back as truth) and deleted a `Tally` interface that was `OutlineSummary` minus its `file`.
- **`hickey` + `lowy`** — the row literal spelled "a mirror is not a node" twice, once for the count and once for the roots, with the `as LocatedRegular` cast as the fingerprint (a boolean filter narrows nothing). Dropped once now through a type guard, the floor's own spelling in `countedChildren`. The tests lost four repetitions of "make a set, index it, list it" — and with them a slip where the first test indexed a *second* set and answered the first out of it, exactly the pairing `Derived`'s doc exists to prevent.
- **`/simplify`** — four cleanup agents. The code came back clean; the comments did not. About a dozen lines were arguing the change was safe against a parent commit that stops existing once this merges, and one sentence was **false**: it claimed this grouping had no second consumer. `Map.groupBy(nodes, file)` is written three times in the tree — here, `publishedOf` in `@olai/server`, and the pending walk in `@olai/ops`, which already memoises it per set. The note now says that, and says why a shared one still is not obvious (two of the three have no `Derived` to hang it on; the third sorts what it groups), citing `siblings-of-quadratic` rather than describing whose turn it is.

The timing table above was re-measured after the last of these — the walk changed in every pass.
