### PR TITLE
Under load: the suite claims its ports, and stops reading the disk as this tab's receipt

### DIFF
--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -298,6 +298,15 @@ Both were measured under load, and both failed fifteen seconds later on a file t
 
 None of the four mistakes is fixed by a longer timeout, and a step that needed one was asking the wrong question. This one is the sharpest case: the gesture was *lost*, so the fifteen seconds are the budget and not the latency, and a minute would fail the same way.
 
+**What the four are worth, measured** (2026-08-16, 32-core box, five suites at once, six rounds each — thirty full runs both sides):
+
+| | drops | runs that dropped something |
+|---|---|---|
+| before | 27 | 20 of 30 |
+| after | 6 | 6 of 30 |
+
+The seventeen port drops went to zero, and so did the four faces of the disk-as-receipt mistake. What is left is **one** scenario this suite has not answered — `A rename staged by hand reads as a rename` waits thirty seconds for the commit pill to say `waiting`, and the diagnostic re-read after the timeout finds the value already correct, so the question is that step's budget against how fast a `.git` change can reach the page and not a lost event. Named here rather than guessed at.
+
 ## The scripted agent
 
 `agent/fake-acp-agent.ts` is a deterministic ACP agent: line-delimited JSON-RPC on stdio, just enough of the protocol to be indistinguishable from a real one as far as the server's client is concerned. Every server this suite spawns is pointed at it, for the same reason the Chromium flags are not branched on `CI` — a server configured differently for one feature than for another is a class of bug that only reproduces where it is hardest to see.

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -95,6 +95,20 @@ One section per run, against a directory the driver has just re-copied and a ser
 
 `SECTION=` on its own lists the sections; `SECTION=<name>` runs one against a server you are already running (`BASE` says where).
 
+## Making it flake on purpose
+
+```bash
+export OLAI_BIN="$(nix build .#olai --no-link --print-out-paths)/bin/olai"
+nix develop .#e2e -c bash
+cd packages/tests
+RUNS=20 BUSY=48 sh underload.sh     # one suite, the box pinned
+RUNS=6  SUITES=5 sh underload.sh    # five suites at once, as a shared box is
+```
+
+`underload.sh` / `underload.ts` are NOT part of the suite either. They exist because the failures this section is about are one scenario in six hundred, never the same one twice — so the fact worth having is a CENSUS over thirty runs and not a log of one, and `underload.ts` reads the cucumber message streams back into exactly that: which scenarios went, how often, on which step, and what each said.
+
+**The two knobs are two different questions, and mixing them answers neither.** `BUSY` pins the cores and leaves this the only suite on the box, so whatever fails under it failed on LOAD. `SUITES` starts several at once, which is what a box shared between worktrees actually looks like, and is the only way to reach the failures that need a STRANGER on the machine rather than a slow one — the port bands below were found that way and nothing else would have found them.
+
 ## Fixture corpora
 
 Scenarios do not build their own outlines: they name a directory. A feature (or a scenario) carries a `@corpus:<name>` tag naming a directory under `fixtures/`, and `hooks.ts` starts a server on a copy of it the first time some scenario asks — then keeps it for the rest of the run. Untagged scenarios get `@corpus:good`.
@@ -110,6 +124,10 @@ A COPY, and one per worker, because `--parallel` is one process per worker: four
 **`@git`** rides on top of `@scratch:`: the scratch copy is made a git repository with the fixtures already committed, and its server is started with `--commit=manual` rather than the harness's usual `--commit=off`. What is waiting to be committed is DERIVED from git rather than counted, so there is nothing to test without a repository — and the assertions at the end of those scenarios are lines out of its log, read through `world.git`. **`@no-git`** is the other half of the same knob: commits ON, and deliberately no repository, which is the only way to reach the Commit pill's "no git here" face. Every other scenario keeps `--commit=off`: committing into whatever repository happens to contain a temp directory is not this suite's business.
 
 A `@scratch:` scenario may also RESTART its server, which nothing else in the suite may do — a shared corpus server is running for every other scenario in the run, and `hooks.ts` refuses rather than trusting the tag. That is what lets a feature ask the one question no other scenario could: what does an open page do when the process behind it is replaced? The restart comes back on the SAME port, because the page is already pointed at it — `startOwnServer` binds the exact port and fails loudly if the address it got back is a different one, so a port stolen in between reads as itself instead of as a mysteriously dead page.
+
+**Which ports a worker may bind is CLAIMED, not computed** (`support/workers.ts`'s `heldBand`), and that is what makes the paragraph above hold on a box that is not only running this. Ports 20000 upward are cut into bands of two hundred; a worker takes a band by binding its FIRST port and keeping that socket for its whole life, so a second process wanting the same band is told `EADDRINUSE` by the kernel and walks on to the next. The search starts at the worker's own id, so one suite alone still gets bands 0, 1, 2, 3 exactly as it always did.
+
+It used to be arithmetic on that id, and the id is unique inside ONE run and says nothing about the run beside it: two worktrees each running the suite both numbered their workers from zero and both scanned from 20000. The restart is the one thing that could not survive it, because it has to come back on the same address and therefore has a window between letting the port go and the child's own `listen` — and the other run's port search walked into that window. Measured on a 32-core box, five suites at once, six rounds each: **thirty runs dropped twenty-seven scenarios, and seventeen of them were exactly this**, every one reported in `startOwnServer`'s own sentence. Nothing inside a single run ever collided — its bands were already disjoint and each worker asks for one port at a time — which is why an ordinary CI lane never saw it and a shared box saw it constantly.
 
 ## Git, which every other scenario is served without
 
@@ -244,7 +262,7 @@ The names are not written down twice. `support/world.ts` imports the client's ow
 
 ## Waiting, which is the whole of being honest under load
 
-This suite runs parallel, on machines that are also doing something else, so every assertion in it is a race unless it was written not to be. A run on a saturated box is the only way to find out, and there are exactly three ways to get it wrong. All three are green on an idle laptop.
+This suite runs parallel, on machines that are also doing something else, so every assertion in it is a race unless it was written not to be. A run on a saturated box is the only way to find out — `sh underload.sh` is that run, and it counts what it dropped rather than leaving five logs to read — and there are exactly four ways to get it wrong. All four are green on an idle laptop.
 
 **A value read on its way to its final one.** Most assertions here WAIT: they poll until the page or the file says the thing, and fail saying what they were waiting for. The ones that cannot are the NEGATIVES, and a negative is two different steps that read almost the same:
 
@@ -269,7 +287,16 @@ Asking the holding form of a write passes only when the round trip happens to la
 
 Every one of them will take "the page said why it did not" instead, which is the other way a key ends. `I press "…" without waiting` is how the two scenarios that MEAN the race say so.
 
-None of the three mistakes is fixed by a longer timeout, and a step that needed one was asking the wrong question.
+**A gesture aimed at the tab across a DISK assertion.** The newest one, and the one that reads most like a passing step. A write goes: the server writes the file, publishes the new set, and only then answers the tab that asked (`packages/store/src/store.ts` — *rename them all → re-probe and publish → the caller's post-publish hook*). So a step that polls the disk is reading a fact the server has, and the tab has not — and the tab has rules that turn on having been answered:
+
+| the rule | where | what it does to a gesture aimed too early |
+|---|---|---|
+| the inverse is filed when the answer comes back | `writes.ts` → `edit/undoing.ts`'s `record` | ⌘Z spends an empty stack: it draws `nothing to undo`, and the late `record` wipes even that, so the page keeps no trace |
+| one write at a time | `palette/Palette.tsx`, `edges/editing.tsx`, `date/DatePicker.tsx` — all `sending` | the second write is dropped where it stands: no op, no sentence, nothing on screen |
+
+Both were measured under load, and both failed fifteen seconds later on a file that never changed. So a scenario that makes a write and then aims something ELSE at the same tab needs the tab's own receipt in between, not the disk's: the palette's remark (`I capture …` now waits for it), the row the page redrew (`the node "…" comes after "…"`), the box re-primed. The disk assertion is still worth making — it is the claim about what LANDED — it just is not a gate.
+
+None of the four mistakes is fixed by a longer timeout, and a step that needed one was asking the wrong question. This one is the sharpest case: the gesture was *lost*, so the fifteen seconds are the budget and not the latency, and a minute would fail the same way.
 
 ## The scripted agent
 

--- a/packages/tests/features/palette_actions.feature
+++ b/packages/tests/features/palette_actions.feature
@@ -247,10 +247,16 @@ Feature: The ⌘K palette writes
     # So: one write at a time, the date picker's rule. The remark below is the
     # assertion that matters twice over — it proves the first landed AND that
     # no refusal overwrote it.
+    #
+    # BOTH keys out before either is answered, which is the premise and not a
+    # detail: two sequential presses are two round trips to the browser, and on
+    # a loaded box the first capture can land in between — the box is re-primed
+    # to `+ ` by then, so the second Enter captures a BLANK line and the
+    # refusal for it overwrites the remark below. That is a different scenario,
+    # and a true one, but it is not this one.
     When I press the palette shortcut
     And I type "+ buy the walnut stain" into the palette
-    And I press "Enter" without waiting
-    And I press "Enter" without waiting
+    And I press "Enter" twice without waiting
     Then the palette remarks "captured “buy the walnut stain” to Inbox.olai"
     And "Inbox.olai" holds exactly 1 node titled "buy the walnut stain"
     And there should be no page errors

--- a/packages/tests/step_definitions/edge_steps.ts
+++ b/packages/tests/step_definitions/edge_steps.ts
@@ -149,14 +149,65 @@ Then(
   },
 );
 
+/**
+ * THIS TAB'S OWN RECEIPT for a write these four steps make with the pointer —
+ * and why the disk is not one.
+ *
+ * A write goes: the server writes the file, publishes the new set, and only
+ * then answers the tab that asked (`packages/store/src/store.ts` — *rename
+ * them all → re-probe and publish → the caller's post-publish hook*). So a
+ * step that polls the FILE has read a fact the server has and this tab has
+ * not — and everything the client does next turns on having been answered: the
+ * inverse ⌘Z spends is filed on the answer (`client/writes.ts` →
+ * `client/edit/undoing.ts`'s `record`), and a second write is dropped where it
+ * stands while the first is out (`client/edges/editing.tsx`'s `sending`, the
+ * date picker's rule).
+ *
+ * What this surface CAN say is the refs it draws. Nothing is echoed here — a
+ * reference appears and goes when the file says so, off the same snapshot
+ * every other reader is drawn from (`client/edges/editing.tsx`'s header) — so
+ * the list having changed is this tab having been told, one message ahead of
+ * the answer on the same wire.
+ *
+ * OR THE PAGE SAID WHY IT DID NOT, which is the other way any of these ends: a
+ * loop refused, an id nothing declares. Same shape as `support/caret.ts`'s
+ * waits, and for its reason — a step that only knew the happy answer would
+ * hang for fifteen seconds on a scenario whose whole point is the refusal.
+ */
+const drawnOrSaid = async (
+  world: OlaiWorld,
+  changed: () => Promise<boolean>,
+  what: string,
+): Promise<void> => {
+  await world.waitUntil(
+    async () =>
+      (await changed()) || (await world.page.locator(EDGE_SAID).count()) > 0,
+    `${what}, or the page to say why it did not`,
+  );
+};
+
+/**
+ * Choose a hit, and wait for the panel to carry the write.
+ *
+ * A COUNT rather than the chip's own `data-ref`, because what this step is
+ * given is a TITLE and the chips are keyed by id. One more of them is the same
+ * claim, and it is the claim this panel can make about a write it just sent.
+ */
 When(
   "I choose {string} from the edge panel",
   async function (this: OlaiWorld, title: string) {
+    const held = (await panelOf(this)).locator(`${EDGE_HELD} ${EDGE_DROP}`);
+    const before = await held.count();
     const hit = (await panelOf(this))
       .locator(EDGE_HIT)
       .filter({ hasText: title })
       .first();
     await this.press(hit);
+    await drawnOrSaid(
+      this,
+      async () => (await held.count()) > before,
+      `the panel to draw ${JSON.stringify(title)} among what this node names`,
+    );
   },
 );
 
@@ -170,17 +221,35 @@ Then(
   },
 );
 
+/** The panel's own `×`. Waits for the chip to GO, for the reason the choose
+ *  above waits for one to arrive. */
 When(
   "I drop {string} in the edge panel",
   async function (this: OlaiWorld, target: string) {
-    await this.press(
-      (await panelOf(this)).locator(`${EDGE_DROP}[data-ref="${target}"]`).first(),
+    const chip = (await panelOf(this))
+      .locator(`${EDGE_DROP}[data-ref="${target}"]`)
+      .first();
+    await this.press(chip);
+    await drawnOrSaid(
+      this,
+      async () => (await chip.count()) === 0,
+      `the panel to stop drawing ${JSON.stringify(target)}`,
     );
   },
 );
 
-/** The `×` on a reference the PAGE draws, which is the other door onto the
- *  same op — and the one a person reading a node reaches for. */
+/**
+ * The `×` on a reference the PAGE draws, which is the other door onto the same
+ * op — and the one a person reading a node reaches for.
+ *
+ * This is the step that needed the receipt above. On a loaded box the suite
+ * dropped `⌘Z after a × puts the target back` three times in thirty runs
+ * (`../underload.sh`), because the scenario's next gate was the FILE and the
+ * chord after it reached a tab whose stack was still empty. ⌘Z then drew
+ * `nothing to undo` — and the write's own late answer wiped even that
+ * (`undoing.ts`'s `record` clears the said as it files the inverse), so the
+ * fifteen-second failure was over a page with nothing on it to say why.
+ */
 When(
   "I drop {string} from the drawn {string} of {string}",
   async function (
@@ -189,10 +258,14 @@ When(
     relation: string,
     id: string,
   ) {
-    await this.press(
-      this.node(id)
-        .locator(`${refsOf(relation)} ${REF_DROP}[data-ref="${target}"]`)
-        .first(),
+    const chip = this.node(id)
+      .locator(`${refsOf(relation)} ${REF_DROP}[data-ref="${target}"]`)
+      .first();
+    await this.press(chip);
+    await drawnOrSaid(
+      this,
+      async () => (await chip.count()) === 0,
+      `the row to stop drawing ${JSON.stringify(target)} among its \`${relation}\``,
     );
   },
 );

--- a/packages/tests/step_definitions/edge_steps.ts
+++ b/packages/tests/step_definitions/edge_steps.ts
@@ -150,8 +150,8 @@ Then(
 );
 
 /**
- * THIS TAB'S OWN RECEIPT for a write these four steps make with the pointer —
- * and why the disk is not one.
+ * THIS TAB'S OWN RECEIPT for a write the three steps below make with the
+ * pointer — and why the disk is not one.
  *
  * A write goes: the server writes the file, publishes the new set, and only
  * then answers the tab that asked (`packages/store/src/store.ts` — *rename
@@ -173,6 +173,12 @@ Then(
  * loop refused, an id nothing declares. Same shape as `support/caret.ts`'s
  * waits, and for its reason — a step that only knew the happy answer would
  * hang for fifteen seconds on a scenario whose whole point is the refusal.
+ *
+ * A sentence left over from the LAST write cannot end this wait: the surface
+ * clears its line before it sends (`editing.tsx`'s `write` — "cleared BEFORE
+ * the attempt … a write that takes a moment would otherwise sit under the last
+ * one's sentence"), and `world.press` has waited out a frame by the time any
+ * of these starts polling.
  */
 const drawnOrSaid = async (
   world: OlaiWorld,

--- a/packages/tests/step_definitions/editing_steps.ts
+++ b/packages/tests/step_definitions/editing_steps.ts
@@ -150,6 +150,37 @@ When(
   },
 );
 
+/**
+ * The same key TWICE, both keys out before either can be answered.
+ *
+ * Two of the step above is not the same thing, and that is the whole reason
+ * this exists: each `press` is a round trip to the browser, and the write the
+ * first key starts is a round trip to a server on this same machine — so on a
+ * loaded box the answer can land in the GAP between the two presses, and the
+ * scenario stops being about what it says it is about.
+ *
+ * `A second Enter on the first capture is not a second write` is where that
+ * showed: with the first capture already landed, the palette has re-primed its
+ * box to `+ ` (`palette/Palette.tsx`'s `sendCapture`), so the second Enter is a
+ * capture of a BLANK line — refused in the ops layer's own words, over the
+ * remark the scenario is asserting on. Measured at 2 in 15 loaded runs, and it
+ * got MORE likely rather than less when this suite's port bands stopped being
+ * shared, because an exclusive band is a faster `freePortIn` and so a faster
+ * round trip to beat.
+ *
+ * Issued together, the two keydowns reach the page with no round trip between
+ * them, which is the claim `without waiting` was always making.
+ */
+When(
+  "I press {string} twice without waiting",
+  async function (this: OlaiWorld, key: string) {
+    await Promise.all([
+      this.page.keyboard.press(key),
+      this.page.keyboard.press(key),
+    ]);
+  },
+);
+
 // ── where in the line the caret is ─────────────────────────────────────
 
 /** The open title editor, waited for. Two of the keys mean different things

--- a/packages/tests/step_definitions/outline_tree_steps.ts
+++ b/packages/tests/step_definitions/outline_tree_steps.ts
@@ -227,6 +227,19 @@ Then(
   },
 );
 
+/**
+ * WAITS, and that is the whole of what changed here. The badge is redrawn from
+ * the snapshot, and every scenario that asks this has just made a write — so
+ * the date on screen is a value on its way to its final one, and reading it
+ * once is the first mistake `../README.md` lists.
+ *
+ * It bit under load: `⌘Z takes a picked date back` failed in 27ms, saying the
+ * badge still read the date the chord had just taken back. The FILE already
+ * said otherwise (the step before this one polls it) — which is the same
+ * asymmetry the pointer's writes have, one step further along: the server
+ * writes and publishes before the tab is redrawn, so the disk is always the
+ * earlier reading.
+ */
 Then(
   "the node {string} shows the date {string}",
   async function (this: OlaiWorld, id: string, date: string) {
@@ -236,20 +249,29 @@ Then(
     // the ISO value is looked for in the places a formatted badge keeps it as
     // well as in the text. What is being asserted is that the badge is about
     // THIS date — not how it chooses to say so.
-    const shown = await badge.evaluate((node) =>
-      [
-        node.textContent,
-        node.getAttribute("datetime"),
-        node.getAttribute("data-date"),
-        node.getAttribute("title"),
-      ]
-        .filter((value): value is string => typeof value === "string")
-        .join(" | "),
-    );
-    assert.ok(
-      shown.includes(date),
-      `the date badge on "${id}" says ${JSON.stringify(shown)}, which does not mention ${date}`,
-    );
+    const shownOn = async (): Promise<string> =>
+      await badge.evaluate((node) =>
+        [
+          node.textContent,
+          node.getAttribute("datetime"),
+          node.getAttribute("data-date"),
+          node.getAttribute("title"),
+        ]
+          .filter((value): value is string => typeof value === "string")
+          .join(" | "),
+      );
+    // The re-assert on timeout is `has the title`'s rule, for its reason: it
+    // turns "waited 15s" into "says X, which does not mention Y".
+    await this.waitUntil(
+      async () => (await shownOn()).includes(date),
+      `the date badge on "${id}" to be about ${date}`,
+    ).catch(async () => {
+      const shown = await shownOn();
+      assert.ok(
+        shown.includes(date),
+        `the date badge on "${id}" says ${JSON.stringify(shown)}, which does not mention ${date}`,
+      );
+    });
   },
 );
 

--- a/packages/tests/step_definitions/palette_steps.ts
+++ b/packages/tests/step_definitions/palette_steps.ts
@@ -348,13 +348,40 @@ Then(
 
 // ── quick capture ──────────────────────────────────────────────────────
 
-/** The whole gesture, as a person makes it: the `+` prefix, the line, Enter. */
+/**
+ * The whole gesture, as a person makes it: the `+` prefix, the line, Enter —
+ * and then the palette's own answer, which is what makes a SECOND capture a
+ * gesture rather than a race.
+ *
+ * The palette takes ONE WRITE AT A TIME (`palette/Palette.tsx`'s `sending`,
+ * the date picker's rule), and a capture that arrives while the last one is
+ * still out is dropped where it stands: no write, no sentence, nothing on
+ * screen. The file having the first line does not close that window — the
+ * server writes, publishes and only then answers, so a scenario that reads the
+ * disk is reading a fact this TAB has not been told yet. Measured under load:
+ * `A second capture goes into the inbox that now exists` was one of the
+ * scenarios this suite dropped, on the second capture, as a fifteen-second
+ * wait for a line nobody had written.
+ *
+ * The answer is the slot, either mood — the remark a landed capture makes
+ * (`captured “…” to <file>`) or the ops layer's refusal — because both are set
+ * in the `.then` of the round trip and neither is there while it is out. The
+ * scenario next door already says this in words (`⌘Z takes back a capture`:
+ * *the palette's own line rather than the disk … it is said in the answer that
+ * files the inverse*); here it is the step's, so every caller gets it.
+ */
 When(
   "I capture {string} from the palette",
   async function (this: OlaiWorld, line: string) {
     const input = await fillPalette(this, `+ ${line}`);
     await input.press("Enter");
+    // The frame first: the send clears the slot synchronously, so a poll
+    // started before it would find the LAST capture's remark and stop there.
     await this.waitForFrame();
+    await this.waitUntil(
+      async () => (await this.page.locator(PALETTE_SAID).count()) > 0,
+      `the palette to say what came of capturing ${JSON.stringify(line)}`,
+    );
   },
 );
 

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -48,9 +48,9 @@ import type { GitMode } from "./world.ts";
 import type { OlaiWorld } from "./world.ts";
 import {
   freePortIn,
+  heldBand,
   holdPort,
   isolateEnv,
-  portRange,
   releasePort,
   workerId,
 } from "./workers.ts";
@@ -386,7 +386,7 @@ const startServerChild = async (
 
   for (let attempt = 1; attempt <= attempts; attempt++) {
     if (stopped) throw new Error(shuttingDown(label));
-    const port = fixedPort ?? (await freePortIn(portRange(workerId())));
+    const port = fixedPort ?? (await freePortIn(await heldBand()));
     // `--no-commit` unless the scenario is ABOUT git: a scratch directory is a
     // temp copy, and committing to whatever repository happens to contain the
     // temp dir is not the suite's business. A `@git:` scenario is the exception
@@ -537,9 +537,12 @@ export const stopOwnServer = async (world: OlaiWorld): Promise<void> => {
   });
   live.delete(child);
   world.ownServer = undefined;
-  // Bind the port ourselves until startOwnServer releases it. Without this,
-  // another worker's `freePortIn` (or a `listen(0)` elsewhere) can steal
-  // the address the page is still pointed at.
+  // Bind the port ourselves until startOwnServer releases it, so nothing on
+  // the box can take the address the page is still pointed at. The band is
+  // this process's alone (`workers.ts`'s `heldBand`), which is what closed the
+  // hole this hold could not: another RUN's `freePortIn` used to walk this
+  // band, and it walked it in the window between the release and the child's
+  // own listen, where a hold has already been given up.
   world.portHold = await holdPort(port);
 };
 

--- a/packages/tests/support/workers.ts
+++ b/packages/tests/support/workers.ts
@@ -12,6 +12,13 @@
  *     path (recall does this) or a padi on the laptop would be one thing
  *     every worker wrote. HOME is left alone (see `isolateEnv`).
  *
+ * AND THE BOX ITSELF, which is the third thing and the one this file learnt
+ * last. A worker id is unique inside ONE run and says nothing about the run
+ * beside it: two suites started from two worktrees both number their workers
+ * from zero, so a band COMPUTED from the id put both of them on the same two
+ * hundred ports. So a band is CLAIMED here rather than computed
+ * ({@link heldBand}), and the id is only where the search starts.
+ *
  * Ports and env live here. The count lives in `parallelism.js` — cucumber-js
  * loads `cucumber.js` with Node's ESM loader, which cannot import TypeScript,
  * so the profile imports the JS file and this module re-exports it. One
@@ -25,14 +32,24 @@ import type { EventEmitter } from "node:events";
 
 export { defaultWorkers, WORKER_CAP, workerCount } from "./parallelism.js";
 
-/** First port of worker 0's band. High enough to stay off well-known ports,
- *  low enough to stay out of the kernel's ephemeral range, so a `listen(0)`
- *  elsewhere on the box cannot land inside a worker's band. */
+/** First port of band 0. High enough to stay off well-known ports, low enough
+ *  to stay out of the kernel's ephemeral range, so a `listen(0)` elsewhere on
+ *  the box cannot land inside a worker's band. */
 export const PORT_BASE = 20_000;
 
 /** Ports reserved for one worker. A worker that has exhausted its band has
  *  leaked servers, not run out of a small number. */
 export const PORTS_PER_WORKER = 200;
+
+/** How many bands there are — and so how many e2e workers this BOX can carry
+ *  at once, across every run on it rather than inside one of them. Four
+ *  workers is one suite, and a box several worktrees share runs several.
+ *
+ *  Sixty bands of two hundred ends at 31999, which is the bound that decides
+ *  the number: Linux's `net.ipv4.ip_local_port_range` starts at 32768, and the
+ *  whole reason {@link PORT_BASE} is where it is would be given away by a band
+ *  that reached into the kernel's own pool. */
+export const BANDS = 60;
 
 /** Cucumber numbers workers from 0. Unset means this process is the only
  *  one — a serial run, or a unit test — and it takes band 0. */
@@ -48,8 +65,10 @@ export interface PortRange {
   readonly hi: number;
 }
 
-/** Half-open `[lo, hi)` this worker may bind. Disjoint from every other
- *  worker's, which is what makes a restart's re-bind unstealable. */
+/** Half-open `[lo, hi)` — the `id`th band, as arithmetic. WHICH band a worker
+ *  gets is {@link heldBand}'s answer and not this one's: the bands are
+ *  disjoint by construction, and the thing that has to be decided at run time
+ *  is which of them nobody else is already in. */
 export const portRange = (id: number): PortRange => {
   const lo = PORT_BASE + id * PORTS_PER_WORKER;
   return { lo, hi: lo + PORTS_PER_WORKER };
@@ -105,6 +124,65 @@ export const releasePort = (holder: net.Server): Promise<void> =>
   new Promise((resolve, reject) => {
     holder.close((cause) => (cause ? reject(cause) : resolve()));
   });
+
+/** The band this process holds, and the socket that says so — claimed on the
+ *  first ask, kept for the life of the process.
+ *
+ *  `marker` is written and never read, and it is not dead: the socket IS the
+ *  claim, so it is never closed, and a name at module scope is how a reader
+ *  finds the thing holding this band rather than an anonymous listener inside
+ *  a loop. Closing it would hand the band to somebody else mid-run, which is
+ *  the whole failure this file is about. */
+let held: Promise<PortRange> | undefined;
+let marker: net.Server | undefined;
+
+/**
+ * The ports this process may bind — CLAIMED, not computed.
+ *
+ * The claim is the band's FIRST port, bound and kept: a second process that
+ * wants the same band gets `EADDRINUSE` from the kernel and walks on to the
+ * next one. So the band a worker ends up in is a fact about the whole BOX
+ * rather than about this run's worker numbering, and the ports below the
+ * marker are its own however many suites are going at once.
+ *
+ * WHY, measured on a 32-core box (2026-08-16): five suites at once, six rounds
+ * each. A worker id is unique inside one run and nowhere else, so all five
+ * runs' worker 0 scanned the same band from 20000 — and the ONE thing that
+ * cannot survive a stranger in the band is a restart, which has to come back
+ * on the SAME port and therefore has a window between `releasePort` and the
+ * child's own `listen`. Those thirty runs dropped twenty-seven scenarios and
+ * SEVENTEEN of them were this, every one reported as `startOwnServer`'s own
+ * sentence ("the restarted server came up on …, not …"). Nothing inside a
+ * single run ever collided: its bands were already disjoint, and each worker
+ * asks for one port at a time.
+ *
+ * The search STARTS at the worker's own id, so a box running one suite gets
+ * band 0, 1, 2, 3 exactly as it did before this — the assignment a person
+ * reads off a port number is unchanged in the ordinary case, and only a box
+ * that really has two suites on it sees the higher bands.
+ */
+export const heldBand = (): Promise<PortRange> => (held ??= claimBand(workerId()));
+
+const claimBand = async (start: number): Promise<PortRange> => {
+  const refused: Array<string> = [];
+  for (let step = 0; step < BANDS; step++) {
+    const band = portRange((start + step) % BANDS);
+    try {
+      marker = await holdPort(band.lo);
+      // The marker is the band's own first port and is NOT handed out: a
+      // server on it would be a server on the claim.
+      return { lo: band.lo + 1, hi: band.hi };
+    } catch (cause) {
+      refused.push(`${band.lo}: ${cause instanceof Error ? cause.message : String(cause)}`);
+    }
+  }
+  throw new Error(
+    `every one of the ${BANDS} port bands from ${PORT_BASE} is claimed, so this ` +
+      "worker has nowhere to put its servers — either a great many e2e runs are " +
+      "going on this box at once, or an earlier one leaked its markers.\n  " +
+      refused.join("\n  "),
+  );
+};
 
 /**
  * The environment a spawned olai is allowed to see.

--- a/packages/tests/underload.sh
+++ b/packages/tests/underload.sh
@@ -41,14 +41,17 @@ mkdir -p "$out"
 
 # The busy loops go first and die with this script — a `trap` on EXIT rather
 # than a `kill` at the end, so an interrupted run does not leave the box
-# spinning for the next person.
+# spinning for the next person. BUSY=0 leaves nothing to kill and no trap,
+# which is not the same as a trap with no arguments.
 loops=""
 for _ in $(seq 1 "$busy"); do
   bash -c 'while :; do :; done' &
   loops="$loops $!"
 done
-# shellcheck disable=SC2064  # $loops is wanted as it is NOW, not at exit
-trap "kill $loops 2>/dev/null" EXIT INT TERM
+if [ -n "$loops" ]; then
+  # shellcheck disable=SC2064  # $loops is wanted as it is NOW, not at exit
+  trap "kill $loops 2>/dev/null" EXIT INT TERM
+fi
 
 # One suite's rounds, sequentially. Several of these run at once when SUITES>1.
 one_suite() {

--- a/packages/tests/underload.sh
+++ b/packages/tests/underload.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Run the suite over and over on a BUSY box, and say what it dropped.
+#
+#   RUNS=6 SUITES=5 sh underload.sh    # five suites at once, six rounds each
+#   RUNS=20 BUSY=48 sh underload.sh    # one suite, forty-eight busy loops
+#   RUNS=20 BUSY=48 FEATURES='features/undo.feature' sh underload.sh
+#
+# Expects to be run from packages/tests, inside `nix develop .#e2e`, with
+# OLAI_BIN pointing at a built binary — the same three things the README's
+# by-hand recipe asks for:
+#
+#   export OLAI_BIN="$(nix build .#olai --no-link --print-out-paths)/bin/olai"
+#
+# THE TWO KNOBS ARE TWO DIFFERENT QUESTIONS, and running them separately is
+# the whole reason both exist. BUSY pins the cores and leaves this the only
+# suite on the box: whatever fails under it failed on LOAD. SUITES starts
+# several suites at once, which is what a box shared by several worktrees
+# actually looks like, and is the only way to reach the failures that need a
+# STRANGER on the machine rather than a slow one. A run mixing them cannot say
+# which of the two it found.
+#
+# Every run leaves its own cucumber message stream, and `underload.ts` reads
+# them back into a census — a scenario dropped once in thirty runs is the shape
+# of this bug, so counting is the point and reading a log is not.
+set -uo pipefail
+
+runs=${RUNS:-5}
+suites=${SUITES:-1}
+busy=${BUSY:-0}
+out=${OUT:-reports/under-load}
+features=${FEATURES:-}
+
+if [ -z "${OLAI_BIN:-}" ]; then
+  echo "OLAI_BIN is unset — this loop spawns the binary a user runs, not a" >&2
+  echo "dev-shell server. Build one and point it here:" >&2
+  echo '  export OLAI_BIN="$(nix build .#olai --no-link --print-out-paths)/bin/olai"' >&2
+  exit 1
+fi
+
+mkdir -p "$out"
+
+# The busy loops go first and die with this script — a `trap` on EXIT rather
+# than a `kill` at the end, so an interrupted run does not leave the box
+# spinning for the next person.
+loops=""
+for _ in $(seq 1 "$busy"); do
+  bash -c 'while :; do :; done' &
+  loops="$loops $!"
+done
+# shellcheck disable=SC2064  # $loops is wanted as it is NOW, not at exit
+trap "kill $loops 2>/dev/null" EXIT INT TERM
+
+# One suite's rounds, sequentially. Several of these run at once when SUITES>1.
+one_suite() {
+  local suite=$1 i rc start
+  for i in $(seq 1 "$runs"); do
+    start=$(date +%s)
+    # shellcheck disable=SC2086  # $features is a LIST of paths, or nothing
+    bun run test --format "message:$out/s$suite-r$i.ndjson" $features \
+      > "$out/s$suite-r$i.out" 2> "$out/s$suite-r$i.err"
+    rc=$?
+    echo "suite=$suite round=$i rc=$rc secs=$(( $(date +%s) - start ))" \
+      >> "$out/index"
+  done
+}
+
+for suite in $(seq 1 "$suites"); do
+  one_suite "$suite" &
+done
+wait
+
+echo
+bun underload.ts "$out"

--- a/packages/tests/underload.ts
+++ b/packages/tests/underload.ts
@@ -1,0 +1,112 @@
+/**
+ * What a loaded run dropped, counted — the reading half of `underload.sh`.
+ *
+ * These failures are ONE scenario in a run of six hundred, never the same one
+ * twice, so the fact worth having is a census rather than a log: which
+ * scenarios went, how often, in how many runs, and what each said. A person
+ * reading five `.err` files by hand gets the first of those and none of the
+ * rest.
+ *
+ * It reads the cucumber MESSAGE stream rather than the pretty output, because
+ * the pretty output is for a human at the end of one run and this is arithmetic
+ * over thirty. Every non-passing step is a row: the scenario, the step, how
+ * long it took (which is what says whether a budget was reached or a key was
+ * lost), and the harness's own sentence.
+ *
+ *   bun underload.ts reports/under-load
+ */
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+interface Dropped {
+  readonly run: string
+  readonly scenario: string
+  readonly uri: string
+  readonly step: string
+  readonly ms: number
+  readonly message: string
+}
+
+/** Every non-passing step in one run's message stream.
+ *
+ *  Three lookups because the stream names things by id and not by name: a
+ *  finished step knows its test case, which knows its pickle, which is the
+ *  scenario a person wrote. */
+const droppedIn = (file: string): ReadonlyArray<Dropped> => {
+  const pickles = new Map<string, { name: string; uri: string }>()
+  const steps = new Map<string, string>()
+  const cases = new Map<string, { pickleId: string; steps: ReadonlyArray<{ id: string; pickleStepId?: string }> }>()
+  const started = new Map<string, string>()
+  const out: Array<Dropped> = []
+
+  for (const line of fs.readFileSync(file, "utf8").split("\n")) {
+    if (line.trim() === "") continue
+    let message: Record<string, any>
+    try {
+      message = JSON.parse(line)
+    } catch {
+      continue
+    }
+    if (message["pickle"] !== undefined) {
+      const pickle = message["pickle"]
+      pickles.set(pickle.id, { name: pickle.name, uri: pickle.uri })
+      for (const step of pickle.steps) steps.set(step.id, step.text)
+    }
+    if (message["testCase"] !== undefined) {
+      cases.set(message["testCase"].id, message["testCase"])
+    }
+    if (message["testCaseStarted"] !== undefined) {
+      started.set(message["testCaseStarted"].id, message["testCaseStarted"].testCaseId)
+    }
+    if (message["testStepFinished"] !== undefined) {
+      const finished = message["testStepFinished"]
+      const result = finished.testStepResult
+      if (result.status === "PASSED" || result.status === "SKIPPED") continue
+      const test = cases.get(started.get(finished.testCaseStartedId) ?? "")
+      const pickle = test === undefined ? undefined : pickles.get(test.pickleId)
+      const step = test?.steps.find((one) => one.id === finished.testStepId)
+      out.push({
+        run: path.basename(file, ".ndjson"),
+        scenario: pickle?.name ?? "(unknown scenario)",
+        uri: pickle?.uri ?? "(unknown feature)",
+        // A `Before`/`After` hook has no pickle step, and saying so beats an
+        // empty column: the server-per-scenario boots in one.
+        step: step?.pickleStepId === undefined ? "(hook)" : steps.get(step.pickleStepId) ?? "(step)",
+        ms: Math.round((result.duration.seconds * 1e9 + result.duration.nanos) / 1e6),
+        message: (result.message ?? "").split("\n")[0] ?? "",
+      })
+    }
+  }
+  return out
+}
+
+const dir = process.argv[2] ?? "reports/under-load"
+const runs = fs
+  .readdirSync(dir)
+  .filter((name) => name.endsWith(".ndjson"))
+  .sort()
+if (runs.length === 0) {
+  console.error(`no cucumber message streams under ${dir} — has underload.sh run?`)
+  process.exit(1)
+}
+
+const dropped = runs.flatMap((name) => droppedIn(path.join(dir, name)))
+const byRun = new Set(dropped.map((one) => one.run))
+
+console.log(`${runs.length} runs, ${byRun.size} with a drop, ${dropped.length} scenarios dropped\n`)
+if (dropped.length === 0) process.exit(0)
+
+/** Grouped by SCENARIO, because "never the same twice" is the claim being
+ *  measured and a count per scenario is what answers it. */
+const groups = new Map<string, Array<Dropped>>()
+for (const one of dropped) {
+  const key = `${one.uri} :: ${one.scenario}`
+  groups.set(key, [...(groups.get(key) ?? []), one])
+}
+for (const [key, all] of [...groups].sort((a, b) => b[1].length - a[1].length)) {
+  console.log(`${String(all.length).padStart(3)} × ${key}`)
+  for (const one of all) {
+    console.log(`      ${one.run}  ${String(one.ms).padStart(6)}ms  ${one.step}`)
+    console.log(`      ${" ".repeat(one.run.length)}  ${" ".repeat(6)}    ${one.message}`)
+  }
+}

--- a/packages/tests/underload.ts
+++ b/packages/tests/underload.ts
@@ -35,7 +35,10 @@ interface Dropped {
 const droppedIn = (file: string): ReadonlyArray<Dropped> => {
   const pickles = new Map<string, { name: string; uri: string }>()
   const steps = new Map<string, string>()
-  const cases = new Map<string, { pickleId: string; steps: ReadonlyArray<{ id: string; pickleStepId?: string }> }>()
+  const cases = new Map<
+    string,
+    { pickleId: string; testSteps: ReadonlyArray<{ id: string; pickleStepId?: string }> }
+  >()
   const started = new Map<string, string>()
   const out: Array<Dropped> = []
 
@@ -64,7 +67,7 @@ const droppedIn = (file: string): ReadonlyArray<Dropped> => {
       if (result.status === "PASSED" || result.status === "SKIPPED") continue
       const test = cases.get(started.get(finished.testCaseStartedId) ?? "")
       const pickle = test === undefined ? undefined : pickles.get(test.pickleId)
-      const step = test?.steps.find((one) => one.id === finished.testStepId)
+      const step = test?.testSteps.find((one) => one.id === finished.testStepId)
       out.push({
         run: path.basename(file, ".ndjson"),
         scenario: pickle?.name ?? "(unknown scenario)",

--- a/packages/tests/workers.test.ts
+++ b/packages/tests/workers.test.ts
@@ -11,8 +11,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import {
+  BANDS,
   defaultWorkers,
   freePortIn,
+  heldBand,
   holdPort,
   isolateEnv,
   PORT_BASE,
@@ -66,6 +68,36 @@ test("PIN (port bands): two workers' ranges do not overlap", () => {
   expect(a.lo).toBe(PORT_BASE);
   // A port in B cannot be in A.
   expect(b.lo >= a.hi).toBe(true);
+  // And the LAST band still ends below the kernel's ephemeral range, which is
+  // what keeps a `listen(0)` anywhere on the box out of every one of them.
+  // Raising BANDS past this is the mistake this line is here to catch.
+  expect(portRange(BANDS - 1).hi).toBeLessThanOrEqual(32_768);
+});
+
+test("PIN (a band is CLAIMED): the marker below it is bound, and asking again is the same band", async () => {
+  // The whole of what makes a band this process's rather than this run's: not
+  // arithmetic on a worker id — every run numbers its workers from zero — but
+  // a socket the kernel will not hand to a second asker. Deliberately makes no
+  // claim about WHICH band comes back: `just check` runs this leg beside the
+  // e2e one, and a test that pinned band 0 would be a test that failed
+  // whenever the thing it is about was working.
+  const band = await heldBand();
+  expect(band.lo).toBeGreaterThan(PORT_BASE - 1);
+  expect(band.hi).toBeLessThanOrEqual(PORT_BASE + BANDS * PORTS_PER_WORKER);
+  // The marker is the band's first port and is NOT served from, which is the
+  // one port of the two hundred this arithmetic can see.
+  expect(band.hi - band.lo).toBe(PORTS_PER_WORKER - 1);
+  let took = false;
+  try {
+    await releasePort(await holdPort(band.lo - 1));
+    took = true;
+  } catch {
+    // What is supposed to happen: we are holding it.
+  }
+  expect(took).toBe(false);
+  // Held for the life of the process: asking again is the same band, not a
+  // second claim walking on to the next one.
+  expect(await heldBand()).toEqual(band);
 });
 
 test("PIN (port hold): a held port is not handed out as free", async () => {


### PR DESCRIPTION
The roadmap's `suite-load-flakes`, taken at its word: *under load, the e2e suite
drops 1–3 unrelated scenarios — never the same twice*. It is not one bug and it
is not a timeout. It is **two mechanisms**, and one of them is a mistake this
suite already knew about and made in three more places.

**Thirty full runs before, thirty after, same box, same shape: 27 scenarios
dropped → 6.**

## How it was reproduced

A 32-core box, the nix-built binary, the suite at its own default four workers,
**five suites at once, six rounds each — thirty runs of 629 scenarios**. The loop
and the census that reads it are committed as `packages/tests/underload.sh` and
`underload.ts`, because the fact worth having about a bug like this is arithmetic
over thirty runs and not a log of one:

```bash
export OLAI_BIN="$(nix build .#olai --no-link --print-out-paths)/bin/olai"
nix develop .#e2e -c bash
cd packages/tests
RUNS=6 SUITES=5 sh underload.sh    # what a shared box is
RUNS=20 BUSY=48 sh underload.sh    # one suite, the cores pinned
```

**The two knobs are two different questions and mixing them answers neither.**
`BUSY` pins the cores and leaves this the only suite on the box, so what fails
under it failed on LOAD. `SUITES` puts several suites on at once, which is what
the roadmap's *"a box hosting other worktrees' servers"* actually is, and is the
only thing that reaches the first mechanism below.

### BEFORE — 27 drops, in 20 of 30 runs

| × | scenario | step | mechanism |
|---|---|---|---|
| 17 | five different `@scratch:` scenarios | `the server starts again on the same port` | **the box's ports** |
| 4 | `A restarted server retires the tab…` | `the server rejected the stale tab` | the same restart, one step later |
| 3 | `⌘Z after a × puts the target back` | `"house.olai" holds the node "hinges" after "order, handles"` | **the disk is not a receipt** |
| 1 | `A second capture goes into the inbox that now exists` | `"Inbox.olai" holds a node titled "and a tin of oil"` | **the disk is not a receipt** |
| 1 | `The transcript follows the newest line…` | `the transcript is scrolled to the newest line` | *one occurrence* |
| 1 | `A rename staged by hand reads as a rename…` | `the commit pill says "waiting"` | *named, not fixed* |

Every scenario the roadmap named by hand is in that table — inbox capture, server
restart, edge editing, the ⌘Z pair — which is the evidence that this is the item
it filed and not a neighbour of it.

## Mechanism one: a port band was arithmetic on a number only one run agrees about

`PORT_BASE + workerId × 200`. A worker id is unique inside ONE run and says
nothing about the run beside it, so five suites started from five checkouts all
numbered their workers from zero and all scanned the same two hundred ports from
20000.

Almost everything survives that, because `freePortIn` probes before it hands a
port out. The one thing that cannot is a **restart**: a `@scratch:` scenario that
replaces its server has to come back on the SAME address, because the page in
front of it is already pointed there — so `stopOwnServer` holds the port, and
`startOwnServer` must let it go a moment before the child's own `listen`. Another
run's port search walked into that window, and said so itself:

> the restarted server came up on http://127.0.0.1:40745, not
> http://127.0.0.1:20407 — something else took the port while it was free, so the
> open page would have been left pointing at nothing

**Nothing inside a single run ever collided** — its bands were already disjoint
and each worker asks for one port at a time — which is exactly why a lane running
one suite never saw this and a shared box saw it constantly.

**The fix**: a band is CLAIMED, not computed (`support/workers.ts`'s `heldBand`).
A worker takes a band by binding its first port and keeping that socket for its
whole life; a second process wanting the same band is told `EADDRINUSE` by the
kernel and walks on to the next. The search STARTS at the worker's own id, so one
suite alone still gets bands 0–3 and a port read off a log means what it always
did. Sixty bands of two hundred end at 31999, below the kernel's ephemeral range
— pinned in `workers.test.ts`, because raising `BANDS` past it is the one way to
give away the reason `PORT_BASE` is where it is.

Both faces of the restart went with it: the seventeen, and the four
`stale tab rejected` waits in the same scenario, which had a foreign process in
their band while the tab was redialling. **21 → 0 in thirty runs.**

## Mechanism two: the disk is not this tab's receipt

A write goes **server writes the file → publishes the new set → answers the tab
that asked** (`packages/store/src/store.ts`: *rename them all → re-probe and
publish → the caller's post-publish hook*). So a step that polls the FILE has
read a fact the server has and this tab has not.

That would be harmless if the client did not have rules that turn on having been
answered. It has two:

| the rule | where | what it does to a gesture aimed too early |
|---|---|---|
| the inverse is filed on the answer | `client/writes.ts` → `edit/undoing.ts`'s `record` | ⌘Z spends an empty stack |
| one write at a time | `palette/Palette.tsx`, `edges/editing.tsx`, `date/DatePicker.tsx` — all `sending` | the second write is dropped where it stands |

Both failures are **silent**, which is why they read as nothing at all:

- `⌘Z after a × puts the target back` — the chord found an empty stack, so it
  drew `nothing to undo`… and then the write's own late answer WIPED even that,
  because `record` clears the said line as it files the inverse. This is the
  failure screenshot fifteen seconds later: `handles` never came back, and there
  is nothing on the page to say why.

  ![the page after a ⌘Z that was lost](https://github.com/user-attachments/assets/00a864e6-a53d-4a07-81d1-d722d40a8d0d)

- `A second capture goes into the inbox that now exists` — the second capture
  arrived while the first was still out, so `sending` returned before sending
  anything. No op, no sentence, nothing on screen.

**This suite already knows the rule.** It is written down twice, in the very file
that flaked:

> *The CLOSE rather than the disk: the palette shuts in the same answer that
> files the inverse, so it is the signal that there is something on the stack.
> The file can be written a beat before that answer reaches the tab.*
> — `palette_actions.feature`

**The fix is the ritual, not the scenarios** — #164's lesson for the KEYS,
applied to the pointer:

- `I capture … from the palette` waits for the palette's own slot to carry an
  answer, either mood (a landed capture's remark, or the ops layer's refusal).
- `I choose … from the edge panel` waits for one more chip among what the node
  names; `I drop …` (both doors) waits for the chip to go — **or for the page to
  say why it did not**, which is the other way any of them ends and is what keeps
  the loop-refusal scenario honest.

No feature file was touched for those, no timeout was raised, no retry was added
and no claim was loosened. The disk assertions all stay — they are the claim about
what LANDED. They are just not a gate. **4 → 0 in thirty runs.**

**A longer timeout could never have fixed this**, and that is worth saying
because the roadmap offered it as the dull candidate: the gesture was *lost*, so
the fifteen seconds are the budget and not the latency. A minute would fail the
same way.

### The after-census found three more of the same mistake

Fixing the first two made the harness faster, and a faster harness moves races.
Three scenarios that had not fired in the before-census fired in the after one,
and all three are the same family — a step that does not wait for the answer:

- **`the node … shows the date …` read the badge ONCE**, which is the first
  mistake `packages/tests/README.md` lists. `⌘Z takes a picked date back` failed
  in **27ms**, saying the badge still read the date the chord had just taken
  back — while the file, polled one step earlier, already said otherwise. It
  polls now, with `has the title`'s re-assert-on-timeout so the message keeps
  saying what it found.
- **`A second Enter on the first capture` needs both keys out before either is
  answered**, and two sequential `I press … without waiting` are two round trips
  to the browser. On a loaded box the first capture lands in between; the palette
  re-primes its box to `+ `, so the second Enter captures a BLANK line and the
  refusal for it overwrites the remark the scenario asserts on. `I press …
  twice without waiting` issues them together. This one got MORE likely once the
  port bands stopped being shared — an exclusive band is a faster `freePortIn`,
  so a faster round trip to beat, which is worth recording as the shape of this
  kind of work.

Both were **2 in 30** before the fix and **0 in 30** loaded runs of their own
features after it — `RUNS=30 BUSY=48 FEATURES='features/setting_a_date.feature
features/palette_actions.feature features/committing.feature' sh underload.sh`,
which is this PR's own reproducer being used on this PR's own change.

Worth saying about that arm: the commit-pill residual below did **not** fire in
those 30 runs either, and it fired twice under the five-suites arm. The two
knobs are two different questions, and this is what that looks like in the data.

## Deferrals

**One residual, named and not fixed.** `A rename staged by hand reads as a rename,
and commits as one` waits thirty seconds for the commit pill to read `waiting`,
and fails — 1 of 27 before, 2 of 30 after. The useful detail is in the message
the harness prints: *expected the commit pill to have data-state="waiting", but
it is "waiting"* — `expectAttribute`'s diagnostic re-read, taken after the
deadline, finds the value already correct. So the event is not lost, it is late,
and the question is that step's budget against how fast a hand-staged `git mv`
reaches the page. That is a measurement, not a guess, and it is the next one to
make; it is written down in `packages/tests/README.md` rather than left as
folklore.

**And the general fix is still the human's.** Both faces of mechanism two are
this harness working around something the client does not publish: *this tab has
been answered*. #164 already named the honest fix — "publishing the client's own
quiescence (a counter bumped when a key is enqueued and cleared when the queue
drains) … is a product change made for tests and belongs to the human" — and this
PR does not make it. What it does is put the receipt where each surface already
has one, and say plainly where it does not.

No other deferrals.

## Checks

- `just check` (Linux) — green.
- 30 loaded runs before, 30 after, on `kolu-ci-1`.
