### PR TITLE
Opening a chat lands on the newest line

### DIFF
--- a/docs/chat.md
+++ b/docs/chat.md
@@ -23,6 +23,8 @@ The note lives with this machine's other state (`~/.local/state/olai/`, or where
 
 **chats** lists the stored conversations for this directory, and each row says when it was last touched, to the minute. That is deliberate rather than decorative: `/clear` leaves two sessions sharing one name, and the protocol carries no fact that says which of them replaced the other, so the time is what tells you the row you mean. Picking one loads it — and makes it the conversation you come back to.
 
+**A conversation opens on its newest line.** The panel jumps there at once, so a long transcript is not something you have to scroll down. While you read, new text only follows if you were already at the bottom; scroll up and it stays put.
+
 ## Which model the header names
 
 Under the conversation's title, the header names the model — because a turn's cost and character depend on it and nothing else on screen says.

--- a/packages/tests/agent/fake-acp-agent.ts
+++ b/packages/tests/agent/fake-acp-agent.ts
@@ -1583,6 +1583,15 @@ const replay = (): void => {
       content: { type: "text", text: "we decided to order the cabinets." },
     },
   })
+  // `an older conversation` is the one a scenario picks, so it has to overflow
+  // the pane — otherwise "scrolled to the newest line" is true of a short
+  // transcript by construction and says nothing. The two lines above stay so
+  // every other stored-session claim still has the words it already asserts.
+  if (sessionId === "fake-stored-old") {
+    for (let line = 0; line < 40; line++) {
+      say(`line ${line} — ${"the quick brown fox jumps over the lazy dog. ".repeat(3)}\n\n`)
+    }
+  }
 }
 
 /** The steering extension's method name, as the real adapter spells it. */

--- a/packages/tests/agent/fake-acp-agent.ts
+++ b/packages/tests/agent/fake-acp-agent.ts
@@ -1591,6 +1591,17 @@ const replay = (): void => {
     for (let line = 0; line < 40; line++) {
       say(`line ${line} — ${"the quick brown fox jumps over the lazy dog. ".repeat(3)}\n\n`)
     }
+    // AFTER the open-jump has landed, and only when a scenario asked: a
+    // restored transcript's markdown (and any later row) grows the pane
+    // once the reader is already looking at it. Armed by `.agent-want-late`,
+    // released by the same `.agent-release` a held turn uses, so the late
+    // line is a step rather than a race against the first assertion.
+    if (existsSync(`${cwd}/.agent-want-late`)) {
+      rmSync(`${cwd}/.agent-want-late`, { force: true })
+      void released().then(() => {
+        say(`late line — ${"the quick brown fox jumps over the lazy dog. ".repeat(3)}\n\n`)
+      })
+    }
   }
 }
 

--- a/packages/tests/features/the_agent.feature
+++ b/packages/tests/features/the_agent.feature
@@ -919,6 +919,38 @@ Feature: Talking to the agent
     And the transcript has stayed where I left it
 
   @scratch:chat
+  Scenario: Opening a conversation with a transcript lands on the newest line
+    # A different question from the one above. Following is a decision the
+    # reader makes by scrolling WHILE they are in a conversation. Opening one
+    # — the panel coming back, a stored chat picked from the list — is always
+    # a jump to the newest line, even if they had scrolled away before they
+    # left. The jump is instant: an open is a place, not a motion.
+    When I ask the agent "flood"
+    Then the agent is idle
+    And the transcript is scrolled to the newest line
+    When I scroll the transcript to the top
+    And I close the agent panel
+    And I open the agent panel again
+    Then the chat eventually shows "line 39"
+    And the transcript is scrolled to the newest line
+
+  @agent-stored @scratch:chat
+  Scenario: Picking a stored conversation lands on the newest line
+    # Same claim, other door: the panel stays mounted and the conversation
+    # identity changes. A scroll-away in this one must not leave the next one
+    # stuck at the top. `an older conversation` replays enough lines that the
+    # pane has a bottom to be at.
+    When I ask the agent "flood"
+    Then the agent is idle
+    And the transcript is scrolled to the newest line
+    When I scroll the transcript to the top
+    And I open the session picker
+    And I pick the conversation "an older conversation"
+    Then the conversation is titled "an older conversation"
+    And the chat eventually shows "line 39"
+    And the transcript is scrolled to the newest line
+
+  @scratch:chat
   Scenario: The agent's question is a form in the conversation, and the answer goes back
     # The panel advertises `elicitation.form`, so the agent may ask a
     # structured question at all — without it the adapter puts AskUserQuestion

--- a/packages/tests/features/the_agent.feature
+++ b/packages/tests/features/the_agent.feature
@@ -950,6 +950,26 @@ Feature: Talking to the agent
     And the chat eventually shows "line 39"
     And the transcript is scrolled to the newest line
 
+  @agent-stored @scratch:chat
+  Scenario: Growth after opening still lands on the newest line
+    # The open-jump can pass while the pane is still growing — a restored
+    # conversation's markdown lands after the first paint, and a late row is
+    # the same shape. The first assertion is the open; the second is growth
+    # that arrives after that assertion has already passed. If following
+    # were stamped false by the jump's own late `scroll` event, the late
+    # line would leave the reader short of the newest. Armed and released
+    # rather than slept, so the two moments are steps, not a race.
+    When I arm late growth on the next stored conversation
+    And I open the session picker
+    And I pick the conversation "an older conversation"
+    Then the conversation is titled "an older conversation"
+    And the chat eventually shows "line 39"
+    And the transcript is scrolled to the newest line
+    And the chat does not yet show "late line"
+    When the agent is released
+    Then the chat eventually shows "late line"
+    And the transcript is scrolled to the newest line
+
   @scratch:chat
   Scenario: The agent's question is a form in the conversation, and the answer goes back
     # The panel advertises `elicitation.form`, so the agent may ask a

--- a/packages/tests/step_definitions/chat_steps.ts
+++ b/packages/tests/step_definitions/chat_steps.ts
@@ -18,6 +18,7 @@ import * as path from "node:path";
 import { Given, Then, When } from "@cucumber/cucumber";
 import type { Locator } from "playwright";
 
+import { NEAR } from "@olai/web/src/client/chat/Transcript.tsx";
 import { selector, TESTID, type TestId } from "@olai/web/src/client/testids.ts";
 
 import {
@@ -160,6 +161,13 @@ When("the agent is released", async function (this: OlaiWorld) {
   fs.writeFileSync(path.join(this.scratch(), ".agent-release"), "");
 });
 
+/** Ask the next `session/load` of `an older conversation` to hold a last
+ *  line until `the agent is released`. The open-jump can then be observed
+ *  before that growth, which is the claim the late-line scenario makes. */
+When("I arm late growth on the next stored conversation", function (this: OlaiWorld) {
+  fs.writeFileSync(path.join(this.scratch(), ".agent-want-late"), "");
+});
+
 /** Take a stored conversation out of the agent's store, the way a deleted
  *  session or a cleaned-out store would. The next boot's `session/list` no
  *  longer offers it, so a panel that remembers being in it has to fall back.
@@ -206,6 +214,21 @@ Then(
       async () => (await transcriptText(this)).includes(text),
       `the chat to say "${text}"`,
       HYDRATION_TIMEOUT,
+    );
+  },
+);
+
+/** A read, not a wait: the step before it has already waited for something
+ *  that arrives BEFORE the late growth this is about, so if the late line
+ *  were already here the open-jump would have nothing left to follow. */
+Then(
+  "the chat does not yet show {string}",
+  async function (this: OlaiWorld, text: string) {
+    assert.ok(
+      !(await transcriptText(this)).includes(text),
+      `the chat already says "${text}" — the late growth this scenario is ` +
+        "about landed before the open-jump was observed, so the second " +
+        "assertion would not be testing growth after open",
     );
   },
 );
@@ -495,7 +518,7 @@ Then(
     await this.waitUntil(
       async () => {
         const at = await scrollOf(this);
-        return at.overflow > 0 && at.fromBottom < 64;
+        return at.overflow > 0 && at.fromBottom < NEAR;
       },
       "the transcript to be following the newest line",
       HYDRATION_TIMEOUT,
@@ -510,7 +533,7 @@ When("I scroll the transcript to the top", async function (this: OlaiWorld) {
       pane.scrollTop = 0;
     });
   await this.waitUntil(
-    async () => (await scrollOf(this)).fromBottom > 64,
+    async () => (await scrollOf(this)).fromBottom > NEAR,
     "the transcript to be scrolled away from the bottom",
   );
 });
@@ -520,7 +543,7 @@ Then(
   async function (this: OlaiWorld) {
     const at = await scrollOf(this);
     assert.ok(
-      at.fromBottom > 64,
+      at.fromBottom > NEAR,
       "the panel scrolled a reader who had deliberately scrolled away back to " +
         "the newest token. Being yanked out of what the agent did two turns " +
         "ago is worse than a panel that never scrolled at all.",

--- a/packages/web/src/client/chat/Transcript.tsx
+++ b/packages/web/src/client/chat/Transcript.tsx
@@ -44,9 +44,22 @@
  * Leaving a reader alone when they have scrolled away is the part worth
  * keeping: being yanked to the newest token while reading what the agent did
  * two turns ago is worse than a panel that never scrolled at all.
+ *
+ * OPENING A CONVERSATION is not that question. The session id is the
+ * conversation's identity; when it changes (or first appears) the reader has
+ * just opened this chat, and the newest line is where they start. following is
+ * reset so a scroll-away in the previous conversation cannot leave this one
+ * stuck at the top. The jump is instant — assigning `scrollTop`, no animation
+ * — because an open is a place, not a motion.
+ *
+ * The jump itself is not a reader scroll. Assigning `scrollTop` fires the same
+ * event a wheel does, and if anything has grown between the assignment and the
+ * handler — the markdown chunk landing on a restored transcript is the usual
+ * case — `atBottom()` would come back false and following would drop at the
+ * moment there is something to follow. A flag keeps that event from counting.
  */
 
-import { createMemo, For, onCleanup, onMount, Show } from "solid-js"
+import { createEffect, createMemo, For, on, onCleanup, onMount, Show } from "solid-js"
 
 import { useShowNode } from "../focus.ts"
 import { TESTID } from "../testids.ts"
@@ -70,23 +83,51 @@ export function Transcript(props: { readonly chat: Chat }) {
   /** Should new text pull the view down with it? True until the reader scrolls
    *  away from the bottom, and true again the moment they come back. */
   let following = true
+  /** True while we are assigning `scrollTop` ourselves, so the scroll event
+   *  that assignment fires is not read as the reader leaving the bottom. */
+  let jumping = false
 
   const atBottom = (): boolean =>
     pane !== undefined &&
     pane.scrollHeight - pane.scrollTop - pane.clientHeight < NEAR
+
+  const jump = (): void => {
+    if (pane === undefined) return
+    // The assignment fires `scroll` synchronously. Hold the flag only
+    // across that event — a frame later would also swallow a reader who
+    // left the bottom in the same turn, and the follow-observer would
+    // pull them back.
+    jumping = true
+    pane.scrollTop = pane.scrollHeight
+    jumping = false
+  }
 
   onMount(() => {
     if (content === undefined) return
     // Content growing does NOT move `scrollTop`, so the browser fires no scroll
     // event for it — which is what makes this safe: every scroll event this
     // component sees is one the reader caused, or the one our own jump below
-    // causes, and that one lands at the bottom and agrees.
+    // causes (and that one is ignored, see `jumping`).
     const grown = new ResizeObserver(() => {
-      if (following && pane !== undefined) pane.scrollTop = pane.scrollHeight
+      if (following) jump()
     })
     grown.observe(content)
     onCleanup(() => grown.disconnect())
   })
+
+  // Opening a conversation is not "new text arrived while reading". The
+  // session id is the conversation's identity; when it changes, the newest
+  // line is where the reader starts — even if they had scrolled away in the
+  // conversation they just left.
+  createEffect(
+    on(
+      () => props.chat.state().session?.id,
+      () => {
+        following = true
+        jump()
+      },
+    ),
+  )
 
   /** An id the agent named, pressed — shown, or nothing when the press landed
    *  on the words around one.
@@ -154,6 +195,7 @@ export function Transcript(props: { readonly chat: Chat }) {
       data-testid={TESTID.chatTranscript}
       ref={pane}
       onScroll={() => {
+        if (jumping) return
         following = atBottom()
       }}
       onClick={(event) => {

--- a/packages/web/src/client/chat/Transcript.tsx
+++ b/packages/web/src/client/chat/Transcript.tsx
@@ -52,11 +52,15 @@
  * stuck at the top. The jump is instant — assigning `scrollTop`, no animation
  * — because an open is a place, not a motion.
  *
- * The jump itself is not a reader scroll. Assigning `scrollTop` fires the same
- * event a wheel does, and if anything has grown between the assignment and the
- * handler — the markdown chunk landing on a restored transcript is the usual
- * case — `atBottom()` would come back false and following would drop at the
- * moment there is something to follow. A flag keeps that event from counting.
+ * The jump is not a reader scroll, but the event it schedules cannot be
+ * ignored with a flag around the assignment: Chromium (149, and the suite's
+ * Playwright) dispatches `scroll` asynchronously, at a rendering update, so
+ * a boolean held across the write is already false when the handler runs.
+ * What we remember instead is the `scrollTop` we assigned. An event that
+ * lands on that value is our jump — or growth that did not move the top —
+ * and if a follow is still owed and we are no longer at the bottom, the
+ * handler re-jumps rather than stamping following false. An event that
+ * lands somewhere else is the reader.
  */
 
 import { createEffect, createMemo, For, on, onCleanup, onMount, Show } from "solid-js"
@@ -73,8 +77,9 @@ import type { Chat } from "./state.ts"
 
 /** How close to the bottom still counts as "at the bottom". Anything under a
  *  line or two of slack and a smooth scroll mid-flight reads as "the reader
- *  scrolled away". */
-const NEAR = 64
+ *  scrolled away". Exported so the scenarios that measure the same slack
+ *  (`chat_steps.ts`) cannot drift from the pane that defined it. */
+export const NEAR = 64
 
 export function Transcript(props: { readonly chat: Chat }) {
   const show = useShowNode()
@@ -83,9 +88,10 @@ export function Transcript(props: { readonly chat: Chat }) {
   /** Should new text pull the view down with it? True until the reader scrolls
    *  away from the bottom, and true again the moment they come back. */
   let following = true
-  /** True while we are assigning `scrollTop` ourselves, so the scroll event
-   *  that assignment fires is not read as the reader leaving the bottom. */
-  let jumping = false
+  /** The `scrollTop` we last assigned. A later `scroll` event that still sits
+   *  here is our jump, not the reader — the event is dispatched after the
+   *  assignment returns, so a boolean around the write cannot see it. */
+  let assignedTop = Number.NaN
 
   const atBottom = (): boolean =>
     pane !== undefined &&
@@ -93,21 +99,15 @@ export function Transcript(props: { readonly chat: Chat }) {
 
   const jump = (): void => {
     if (pane === undefined) return
-    // The assignment fires `scroll` synchronously. Hold the flag only
-    // across that event — a frame later would also swallow a reader who
-    // left the bottom in the same turn, and the follow-observer would
-    // pull them back.
-    jumping = true
     pane.scrollTop = pane.scrollHeight
-    jumping = false
+    assignedTop = pane.scrollTop
   }
 
   onMount(() => {
     if (content === undefined) return
     // Content growing does NOT move `scrollTop`, so the browser fires no scroll
-    // event for it — which is what makes this safe: every scroll event this
-    // component sees is one the reader caused, or the one our own jump below
-    // causes (and that one is ignored, see `jumping`).
+    // event for it. New text is followed from here. The jump's own `scroll`
+    // arrives later and is recognised by `assignedTop`, not by a flag.
     const grown = new ResizeObserver(() => {
       if (following) jump()
     })
@@ -195,7 +195,15 @@ export function Transcript(props: { readonly chat: Chat }) {
       data-testid={TESTID.chatTranscript}
       ref={pane}
       onScroll={() => {
-        if (jumping) return
+        if (pane === undefined) return
+        // Same top we assigned: our jump's late event, or growth that left
+        // the top alone. If a follow is still owed and we are no longer at
+        // the bottom, more content landed after the assignment — re-jump
+        // rather than decide the reader left.
+        if (Number.isFinite(assignedTop) && Math.abs(pane.scrollTop - assignedTop) < 1) {
+          if (following && !atBottom()) jump()
+          return
+        }
         following = atBottom()
       }}
       onClick={(event) => {


### PR DESCRIPTION
## What was wrong

Opening an existing conversation did not put the reader on the newest message. The panel landed somewhere above, and they had to scroll down themselves.

Following new text *while already reading* was already implemented and tested (`the transcript follows the newest line, unless I have scrolled away`). Opening a chat is a different question.

## The distinction

- **Opening a chat** (panel remounts on an existing transcript, or a stored conversation is picked): always jump to the newest line, instantly — no animation. The session id is the conversation's identity; when it changes, `following` is reset so a scroll-away in the previous conversation cannot leave this one stuck at the top.
- **New messages arriving** while the reader has scrolled up: unchanged. Stick to the bottom only if they were already there.

A programmatic `scrollTop` assignment fires the same `scroll` event a wheel does. If anything has grown between the assignment and the handler — the markdown chunk landing on a restored transcript is the usual case — `atBottom()` would come back false and following would drop. The jump is flagged so that event does not count. The flag is only held across the synchronous assignment, so a reader who then leaves the bottom is still heard.

## Tests

The e2e harness already asserts scroll position (`the transcript is scrolled to the newest line`, overflow required so a short pane cannot pass by construction).

- **Opening a conversation with a transcript lands on the newest line** — flood, scroll away, close the panel, reopen: at the newest line.
- **Picking a stored conversation lands on the newest line** — flood, scroll away, pick `an older conversation` (replayed long enough to overflow): at the newest line.
- The existing follow-unless-scrolled-away scenario still passes.

## Docs

`docs/chat.md` — a conversation opens on its newest line; new text only follows if you were already at the bottom.

## Refactor

Skipped. Small, local fix in the file that already owned following.

## Out of scope (own item, not this PR)

The follow-while-scrolled-up rule already existed and is not being grown. Nothing else about live following was changed.

## Evidence

A long existing transcript, panel closed and reopened: the view is on `line 39` (the newest), with the composer under it. Instant jump, no animation.

![long existing chat opening at the newest line](https://github.com/user-attachments/assets/8b80dd34-92d3-4aad-905e-92f8366f9dbe)