### PR TITLE
The highlight walks into a code span and a link

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -102,7 +102,9 @@ The note is **excerpted, never auto-expanded**. Notes here run to paragraphs; th
 
 None of this is stored, and none of it is a second matcher: the highlight comes from the same case fold `matching` searched with, so the page cannot light up a stretch of text the query never looked at — and a letter whose lower case is written with two characters (`İ`) lights whole, because there is no half a character to light.
 
-Two places a matched row lights nothing, named so they are not mistaken for bugs. A needle that lives **only inside a title's `code` span or link** selects the row and lights nothing: those are the one part of a title this app deliberately does not re-read (a `#` in a URL fragment is not a tag), and the highlight follows the same walk. And a phrase spanning two rendered pieces of a title — across a `**bold**`, say — lights neither, because the words are found per piece of rendered markup. A phrase across a `#tag` does light, since a tag is a split of one string rather than a second piece.
+A needle inside a title's **`code` span or link text** lights like any other, and that is worth saying because it did not used to. Those are the one part of a title this app deliberately does not re-read for `#tags` — a `#` in a URL fragment is not a tag — and the highlight, riding the same walk, used to stop at the same door: the row was selected on the strength of a word in its code span and drew nothing lit. The two rules are separate now. The tag rule is unchanged (no pills inside code or a link, however deeply nested); the highlight goes everywhere the text goes, and never into an attribute, so a link keeps its href.
+
+One place a matched row still lights nothing, named so it is not mistaken for a bug: a phrase spanning two rendered pieces of a title — across a `**bold**`, say — lights neither, because the words are found per piece of rendered markup. Lighting it means rendering that preserves the source's offsets, which is a different change. A phrase across a `#tag` does light, since a tag is a split of one string rather than a second piece.
 
 ### Which pages filter, and what it means on each
 

--- a/packages/format/src/backlinks.test.ts
+++ b/packages/format/src/backlinks.test.ts
@@ -146,7 +146,7 @@ test("the referrers come in corpus order, whichever index found them", () => {
 // parser, and deciding what a reference IS out of one would put a parser under
 // the write gate — so what the record SAYS is the answer. What that costs is a
 // disagreement with the browser, which DOES parse before it styles a tag
-// (`web/src/client/markdown/tags.ts`, whose `SKIP_TAGS` is `code` and `a`).
+// (`web/src/client/markdown/tags.ts`, which reads no tag inside `code` or `a`).
 //
 // THE DISAGREEMENT GOES BOTH WAYS, and these tests are the enumeration. Two
 // reviewers of #237 each found the prose one case short of the truth — it said
@@ -196,7 +196,7 @@ test("and the divergence runs the OTHER way too: emphasis is styled and is not a
   // The half that is easy to miss, and the reason "the bias is toward showing
   // more" is not a safe thing to say: `*` and `_` are not in the opening
   // alphabet, so this reading skips them — while the client's tag styling walks
-  // into `em` and `strong` (they are not in `SKIP_TAGS`) and draws the pill.
+  // into `em` and `strong` (they are not in `NO_TAGS_IN`) and draws the pill.
   // So a reader can see `@herbs` styled as a tag on a record's own page and not
   // find that record in the herb bed's referenced-by section.
   const view = viewOf({

--- a/packages/tests/features/title_markdown.feature
+++ b/packages/tests/features/title_markdown.feature
@@ -41,3 +41,36 @@ Feature: Inline markdown in titles
     And the node "kitchen" has the title "not a heading"
     And the node "demo" has the title "nor a list item"
     And there should be no page errors
+
+  Scenario: A filter lights its word inside a code span and inside a link
+    # The dark corner of `filter_in_place.feature`'s "every row says why it is
+    # drawn": these rows were already SELECTED — the matcher reads a title as
+    # the text somebody typed, backticks and brackets and all — and they drew
+    # nothing lit, because the highlight rode the walk that deliberately does
+    # not re-read code or a link for `#tags` and turned back at the same door.
+    # The tag rule is a rule about tags; the highlight goes everywhere.
+    When I rewrite "house.olai" as:
+      """
+      {"id":"kitchen","ord":"a0","title":"kitchen remodel #home"}
+      {"id":"demo","parent":"kitchen","ord":"a0","title":"run `just check` before pushing"}
+      {"id":"order","parent":"kitchen","ord":"a1","title":"see the [cabinet spec](https://example.com/spec#home) first"}
+      """
+    # 1. INSIDE THE CODE SPAN — and inside it, not merely somewhere in the row.
+    When I filter the page by "check"
+    Then the node "demo" is a match
+    And the node "demo" lights "check"
+    And the node "demo" lights "check" inside its code span
+    # 2. INSIDE THE LINK'S TEXT, which stays a link: a highlight is drawn in
+    #    text and never in an attribute.
+    When I filter the page by "spec"
+    Then the node "order" is a match
+    And the node "order" lights "spec"
+    And the node "order" lights "spec" inside its link
+    And the title of "order" links to "https://example.com/spec#home"
+    # 3. AND THE PROTECTION THE WALK WAS TURNING BACK FOR IS UNTOUCHED: the
+    #    `#home` in that URL fragment is not a tag, the `#home` in the row above
+    #    it is — one page, both readings, which is the whole point of the rule
+    #    being about tags rather than about where the walk may go.
+    And the title of "order" styles no tags
+    And the title of "kitchen" styles the tag "home"
+    And there should be no page errors

--- a/packages/tests/step_definitions/filter_steps.ts
+++ b/packages/tests/step_definitions/filter_steps.ts
@@ -160,6 +160,46 @@ Then(
   },
 );
 
+/**
+ * ...and WHERE IN THE TITLE'S MARKUP it landed, for the two rendered pieces
+ * the tag split deliberately leaves alone (`markdown/tags.ts`).
+ *
+ * The highlight used to leave them alone with it, so the step above is not
+ * enough here: a row that lit the same word somewhere else in its title would
+ * go green on a claim it is not making.
+ */
+const litInside = async (
+  world: OlaiWorld,
+  id: string,
+  piece: string,
+  said: string,
+): Promise<void> => {
+  const inside = world.nodeTitle(id).locator(`${piece} ${HIT}`);
+  await world.waitUntil(
+    async () => (await inside.allInnerTexts()).join(" ") === said,
+    `node \`${id}\` lights ${JSON.stringify(said)} inside its \`${piece}\``,
+  ).catch(() => undefined);
+  assert.strictEqual(
+    (await inside.allInnerTexts()).join(" "),
+    said,
+    `node \`${id}\` does not light ${JSON.stringify(said)} inside its \`${piece}\``,
+  );
+};
+
+Then(
+  "the node {string} lights {string} inside its code span",
+  async function (this: OlaiWorld, id: string, said: string) {
+    await litInside(this, id, "code", said);
+  },
+);
+
+Then(
+  "the node {string} lights {string} inside its link",
+  async function (this: OlaiWorld, id: string, said: string) {
+    await litInside(this, id, "a", said);
+  },
+);
+
 /** ...and the other half, which is the one that would go unnoticed: a row
  *  whose title holds nothing of the query lights nothing, whether it is the
  *  ancestry leading to a match or a match found behind its ¶. */

--- a/packages/tests/step_definitions/filter_steps.ts
+++ b/packages/tests/step_definitions/filter_steps.ts
@@ -135,68 +135,76 @@ Then(
 // waited for rather than read once: they follow a keystroke that re-renders
 // the whole tree.
 
-/** A node's OWN title, never a descendant's — nodes nest, and a parent's scope
- *  holds every title under it. `.first()` is its own because a title is
- *  rendered before the children (`world.nodeTitle`'s rule, one level down). */
-const lit = (world: OlaiWorld, id: string) =>
-  world.nodeTitle(id).locator(HIT);
-
-/** WHERE the query landed in this row's title — the highlight, read as the
- *  text it wraps. A page that draws the row and lights nothing in it is the
- *  page this whole feature is against: every number correct, and no row saying
- *  why it is in front of the reader. */
-Then(
-  "the node {string} lights {string}",
-  async function (this: OlaiWorld, id: string, said: string) {
-    await this.waitUntil(
-      async () => (await lit(this, id).allInnerTexts()).join(" ") === said,
-      `node \`${id}\` lights ${JSON.stringify(said)}`,
-    ).catch(() => undefined);
-    assert.strictEqual(
-      (await lit(this, id).allInnerTexts()).join(" "),
-      said,
-      `node \`${id}\` does not light ${JSON.stringify(said)}`,
-    );
-  },
-);
+/**
+ * A node's OWN title, never a descendant's — nodes nest, and a parent's scope
+ * holds every title under it. `.first()` is its own because a title is
+ * rendered before the children (`world.nodeTitle`'s rule, one level down).
+ *
+ * `piece` narrows to one rendered piece of the title's markdown — a `code`
+ * span, a link — for the steps that ask WHERE in the markup the query landed.
+ * Empty is the whole title, which is what most of them ask.
+ */
+const lit = (world: OlaiWorld, id: string, piece = "") =>
+  world.nodeTitle(id).locator(piece === "" ? HIT : `${piece} ${HIT}`);
 
 /**
- * ...and WHERE IN THE TITLE'S MARKUP it landed, for the two rendered pieces
- * the tag split deliberately leaves alone (`markdown/tags.ts`).
+ * WHERE the query landed in this row's title — the highlight, read as the text
+ * it wraps. A page that draws the row and lights nothing in it is the page this
+ * whole feature is against: every number correct, and no row saying why it is
+ * in front of the reader.
  *
- * The highlight used to leave them alone with it, so the step above is not
- * enough here: a row that lit the same word somewhere else in its title would
- * go green on a claim it is not making.
+ * ONE reading for every step below, narrowed or not. The wait and the assert
+ * read the same locator twice on purpose (the file's header says why), and two
+ * copies of that contract is exactly the drift it warns about.
  */
-const litInside = async (
+const expectLit = async (
   world: OlaiWorld,
   id: string,
-  piece: string,
   said: string,
+  piece = "",
 ): Promise<void> => {
-  const inside = world.nodeTitle(id).locator(`${piece} ${HIT}`);
+  const where = piece === "" ? "" : ` inside its \`${piece}\``;
+  const read = async () =>
+    (await lit(world, id, piece).allInnerTexts()).join(" ");
   await world.waitUntil(
-    async () => (await inside.allInnerTexts()).join(" ") === said,
-    `node \`${id}\` lights ${JSON.stringify(said)} inside its \`${piece}\``,
+    async () => (await read()) === said,
+    `node \`${id}\` lights ${JSON.stringify(said)}${where}`,
   ).catch(() => undefined);
   assert.strictEqual(
-    (await inside.allInnerTexts()).join(" "),
+    await read(),
     said,
-    `node \`${id}\` does not light ${JSON.stringify(said)} inside its \`${piece}\``,
+    `node \`${id}\` does not light ${JSON.stringify(said)}${where}`,
   );
 };
 
 Then(
+  "the node {string} lights {string}",
+  async function (this: OlaiWorld, id: string, said: string) {
+    await expectLit(this, id, said);
+  },
+);
+
+/**
+ * ...and the same reading narrowed to the two rendered pieces the tag split
+ * deliberately leaves alone (`markdown/tags.ts`).
+ *
+ * The highlight used to leave them alone with it, so the step above is not
+ * enough here: a row that lit the same word somewhere else in its title would
+ * go green on a claim it is not making. Two steps rather than one taking the
+ * piece as a `{string}`, so the Gherkin reads as a sentence instead of
+ * carrying quotes around a tag name.
+ */
+Then(
   "the node {string} lights {string} inside its code span",
   async function (this: OlaiWorld, id: string, said: string) {
-    await litInside(this, id, "code", said);
+    await expectLit(this, id, said, "code");
   },
 );
 
 Then(
   "the node {string} lights {string} inside its link",
   async function (this: OlaiWorld, id: string, said: string) {
-    await litInside(this, id, "a", said);
+    await expectLit(this, id, said, "a");
   },
 );
 

--- a/packages/tests/step_definitions/outline_tree_steps.ts
+++ b/packages/tests/step_definitions/outline_tree_steps.ts
@@ -612,6 +612,21 @@ Then(
   },
 );
 
+/** ...and the titles where a `#…` is written and is NOT a tag: inside code,
+ *  and inside a link (a URL fragment). A pill there would be pressable, and
+ *  would filter the page by a word nobody tagged anything with. */
+Then(
+  "the title of {string} styles no tags",
+  async function (this: OlaiWorld, id: string) {
+    const title = this.nodeTitle(id);
+    await title.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await this.waitUntil(
+      async () => (await title.locator(TAG).count()) === 0,
+      `the title of "${id}" to style no tags`,
+    );
+  },
+);
+
 /** Inline markdown in a title — the same promise a note's open body makes,
  *  scoped to the title span so a bold word in the note cannot answer for it. */
 Then(
@@ -625,6 +640,21 @@ Then(
           (value) => value.trim() === text,
         ),
       `the title of "${id}" to render ${JSON.stringify(text)} in bold`,
+    );
+  },
+);
+
+/** A link in a title, read by where it POINTS — the half of it a highlight
+ *  must never reach, since a mark inside an attribute is a broken link rather
+ *  than a loud one. */
+Then(
+  "the title of {string} links to {string}",
+  async function (this: OlaiWorld, id: string, href: string) {
+    const title = this.nodeTitle(id);
+    await title.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await this.waitUntil(
+      async () => (await title.locator("a").first().getAttribute("href")) === href,
+      `the title of "${id}" to link to ${JSON.stringify(href)}`,
     );
   },
 );

--- a/packages/tests/step_definitions/outline_tree_steps.ts
+++ b/packages/tests/step_definitions/outline_tree_steps.ts
@@ -25,6 +25,7 @@ import {
   NODE_GUTTER,
   NODE_MENU,
   NODE_REF,
+  NODE_TITLE,
   nodeSelector,
   NOTE_MARK,
   PROGRESS,
@@ -646,15 +647,16 @@ Then(
 
 /** A link in a title, read by where it POINTS — the half of it a highlight
  *  must never reach, since a mark inside an attribute is a broken link rather
- *  than a loud one. */
+ *  than a loud one. Through `expectAttribute`, so a failure says the href it
+ *  found and not only the one it wanted. */
 Then(
   "the title of {string} links to {string}",
   async function (this: OlaiWorld, id: string, href: string) {
-    const title = this.nodeTitle(id);
-    await title.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await this.waitUntil(
-      async () => (await title.locator("a").first().getAttribute("href")) === href,
-      `the title of "${id}" to link to ${JSON.stringify(href)}`,
+    await this.expectAttribute(
+      `${nodeSelector(id)} ${NODE_TITLE} a`,
+      "href",
+      href,
+      `the link in the title of "${id}"`,
     );
   },
 );

--- a/packages/web/src/client/markdown/tags.test.ts
+++ b/packages/web/src/client/markdown/tags.test.ts
@@ -78,8 +78,9 @@ test("a needle inside a code span nested in a link is lit too", () => {
 // ── the half that is protected, and stays protected ────────────────────
 
 test("a `#…` inside a code span is code, not a tag", () => {
+  // The whole HTML rather than a `not.toContain("data-tag")`: there is nowhere
+  // for a pill to hide in a string this short, and what is written is the claim.
   expect(lit("a `#home` in code")).toBe("a <code>#home</code> in code")
-  expect(lit("a `#home` in code")).not.toContain("data-tag")
 })
 
 test("a `#…` in a link is not a tag — a URL fragment is the sharpest case", () => {
@@ -93,7 +94,6 @@ test("...and lighting one does not turn it into a tag either", () => {
   expect(html).toBe(
     `a <code><mark class="olai-hit" data-testid="hit">#home</mark></code> in code`,
   )
-  expect(html).not.toContain("data-tag")
   expect(lit("the [#home](https://x.test/a#home) link", "#home"))
     .not.toContain("data-tag")
 })

--- a/packages/web/src/client/markdown/tags.test.ts
+++ b/packages/web/src/client/markdown/tags.test.ts
@@ -75,6 +75,36 @@ test("a needle inside a code span nested in a link is lit too", () => {
   )
 })
 
+test("a needle at a span's edges, and one that is the whole span", () => {
+  // The edges are `runsIn`'s and not this file's — a window is a pair of
+  // bounds on one search of the text — but a literal stretch reaches it
+  // through the guard added here, so this is where a change to that guard
+  // would show up. No empty runs, no mark that swallows a backtick.
+  const hit = (text: string) =>
+    `<mark class="olai-hit" data-testid="hit">${text}</mark>`
+  expect(lit(CODE, "just")).toContain(`<code>${hit("just")} check</code>`)
+  expect(lit(CODE, "check")).toContain(`<code>just ${hit("check")}</code>`)
+  expect(lit(CODE, "just check")).toContain(`<code>${hit("just check")}</code>`)
+})
+
+// ── and the half that is STILL deferred, pinned so it stays a decision ──
+
+test("a phrase spanning two rendered pieces still lights neither", () => {
+  // The other half of `filter-highlight-dark-corners`, deferred on this PR
+  // and named in docs/search.md: markdown has already cut the title into
+  // pieces, and one needle is looked for inside each piece rather than across
+  // them. Lighting it needs rendering that preserves the source's offsets.
+  //
+  // Here so that half cannot be un-deferred by accident: a change that starts
+  // lighting the fragment of the phrase that happens to sit inside the code
+  // span, or inside the link, would go red rather than shipping half an
+  // answer to a reader who typed a phrase.
+  expect(lit(CODE, "check before")).not.toContain("olai-hit")
+  expect(lit(LINK, "spec first")).not.toContain("olai-hit")
+  expect(lit("nested [`#home`](https://x.test) link", "#home link"))
+    .not.toContain("olai-hit")
+})
+
 // ── the half that is protected, and stays protected ────────────────────
 
 test("a `#…` inside a code span is code, not a tag", () => {

--- a/packages/web/src/client/markdown/tags.test.ts
+++ b/packages/web/src/client/markdown/tags.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The two jobs one walk does, held apart.
+ *
+ * `./tags.ts` walks a rendered title and does two things to the text it finds:
+ * it turns `#tags` into pills, and — where the page is filtered — it wraps the
+ * query's words in marks. For most of a title those two travel together, and
+ * they used to travel together everywhere: `code` and `a` were named as
+ * subtrees the walk did not enter, and BOTH stopped at that door.
+ *
+ * Only one of them was ever argued for. A `#` inside a URL fragment is not a
+ * tag and a `#` inside code is code — that is a rule about tags. The highlight
+ * inherited it by accident, and the result was a row the filter had selected
+ * on the strength of a word in its `code` span, drawn with nothing lit: the
+ * one page that cannot say why it is in front of you (grok, #240).
+ *
+ * So this file makes the two claims separately, and on the same titles: the
+ * words light everywhere, the pills do not. ./plain.test.ts is next door and
+ * is about something else — the fast path, which refuses every title here.
+ */
+
+import { expect, test } from "bun:test"
+
+import { installPipeline } from "./chunk.ts"
+import * as pipeline from "./pipeline.ts"
+import { plainTitle } from "./plain.ts"
+import { TAG_CLASS } from "./tags.ts"
+import { renderTitle } from "./title.ts"
+
+installPipeline(pipeline)
+
+const NOTE = "house.olai"
+
+/** A title as a filtered page draws it — the pipeline, since every title here
+ *  holds a backtick or a bracket and the fast path refuses those. */
+const lit = (title: string, ...needles: string[]): string =>
+  renderTitle(title, NOTE, { needles })
+
+const CODE = "run `just check` before pushing"
+const LINK = "see the [cabinet spec](https://example.com/spec#home) first"
+
+test("the fast path never answers these, so the pipeline is what is under test", () => {
+  for (const title of [CODE, LINK]) expect(plainTitle(title), title).toBeNull()
+})
+
+// ── the half that was missing ──────────────────────────────────────────
+
+test("a needle inside a code span is lit where it sits", () => {
+  expect(lit(CODE, "check")).toBe(
+    `run <code>just <mark class="olai-hit" data-testid="hit">check</mark></code>` +
+      ` before pushing`,
+  )
+})
+
+test("a needle inside a link's text is lit where it sits", () => {
+  expect(lit(LINK, "spec")).toBe(
+    `see the <a href="https://example.com/spec#home" target="_blank" ` +
+      `rel="noopener noreferrer">cabinet ` +
+      `<mark class="olai-hit" data-testid="hit">spec</mark></a> first`,
+  )
+})
+
+test("the link keeps its href — a highlight is drawn in TEXT, never in an attribute", () => {
+  // `spec` is in this link's destination as well as in its label, and the
+  // walk only ever sees text nodes. A mark that reached the URL would be a
+  // broken link rather than a loud one.
+  expect(lit(LINK, "spec")).toContain(`href="https://example.com/spec#home"`)
+  expect(lit(LINK, "example")).toBe(lit(LINK))
+})
+
+test("a needle inside a code span nested in a link is lit too", () => {
+  // The walk carries the tag rule down the whole subtree, and the highlight
+  // is carried down with nothing switched off at all.
+  expect(lit("nested [`#home`](https://x.test) link", "home")).toContain(
+    `<code>#<mark class="olai-hit" data-testid="hit">home</mark></code>`,
+  )
+})
+
+// ── the half that is protected, and stays protected ────────────────────
+
+test("a `#…` inside a code span is code, not a tag", () => {
+  expect(lit("a `#home` in code")).toBe("a <code>#home</code> in code")
+  expect(lit("a `#home` in code")).not.toContain("data-tag")
+})
+
+test("a `#…` in a link is not a tag — a URL fragment is the sharpest case", () => {
+  expect(lit(LINK)).not.toContain("data-tag")
+  expect(lit("the [#home](https://x.test/a#home) link")).not.toContain("data-tag")
+})
+
+test("...and lighting one does not turn it into a tag either", () => {
+  // The needle lands, the pill does not appear: the two claims on one string.
+  const html = lit("a `#home` in code", "#home")
+  expect(html).toBe(
+    `a <code><mark class="olai-hit" data-testid="hit">#home</mark></code> in code`,
+  )
+  expect(html).not.toContain("data-tag")
+  expect(lit("the [#home](https://x.test/a#home) link", "#home"))
+    .not.toContain("data-tag")
+})
+
+test("a tag OUTSIDE the code span in the same title is still a pill", () => {
+  // The rule is scoped to the subtree, not to the title that holds one.
+  const html = lit("`#home` is not, #home is #kitchen")
+  expect(html).toBe(
+    `<code>#home</code> is not, ` +
+      `<span class="${TAG_CLASS}" data-testid="tag" data-tag="#home">#home</span>` +
+      ` is <span class="${TAG_CLASS}" data-testid="tag" data-tag="#kitchen">#kitchen</span>`,
+  )
+})
+
+// ── and nothing moves on a page nobody is filtering ─────────────────────
+
+test("without a query these titles are written exactly as they were", () => {
+  for (const title of [CODE, LINK, "a `#home` in code", "nested [`x`](https://x.test)"]) {
+    expect(lit(title, "zzzz"), title).toBe(lit(title))
+    expect(lit(title), title).not.toContain("olai-hit")
+  }
+})

--- a/packages/web/src/client/markdown/tags.ts
+++ b/packages/web/src/client/markdown/tags.ts
@@ -25,6 +25,12 @@
  * markdown in them. So the needles ride through both walks and are wrapped by
  * one split (`../filter/lit.ts`) — text and tags alike, since a `#tag` typed
  * into the box is exactly the hit a reader most needs to see.
+ *
+ * ONLY ONE OF THE TWO CARRIES {@link NO_TAGS_IN}, and that is not an asymmetry
+ * to fix. A code span or a link is markdown, and ./plain.ts refuses every
+ * title holding a backtick or a bracket — so the HTML path cannot meet either
+ * and needs no rule about them. If that ever stops being true, the fast path
+ * has widened, and ./plain.test.ts's sweep is what says so.
  */
 
 import { litBy, type Lit, mayHoldTag, tagText, titleParts } from "@olai/format"
@@ -93,8 +99,15 @@ export const TAG_CLASS =
  */
 const NO_TAGS_IN = new Set(["code", "a"])
 
-/** Walk text nodes and turn `#tags` into styled spans — and, where the page
- *  is filtered, the query's words into marks (../filter/lit.ts). */
+/**
+ * Walk text nodes and turn `#tags` into styled spans — and, where the page is
+ * filtered, the query's words into marks (../filter/lit.ts).
+ *
+ * The seed is `true` and is not a parameter: a title's own text is prose, and
+ * literalness is something the markup UNDER it can only take away. A caller
+ * that could ask for a whole title to be read as code would be a second answer
+ * to a question the markdown has already answered.
+ */
 export const styleTags = (
   parent: Root | Element,
   needles: ReadonlyArray<string> = NO_NEEDLES,
@@ -138,17 +151,28 @@ const split = (
  * matched with nothing lit (grok, #240). `titleParts` tiles its input exactly,
  * so the running offset below is the part's place in this text.
  *
- * `tags` false is a stretch where a `#…` is not a tag ({@link NO_TAGS_IN}).
- * The words are still lit, and that is the whole of the difference — the same
- * one line a text with no sigil in it already took.
+ * TWO WAYS OUT WITH THE SAME ANSWER, and they are written as two because they
+ * are two different facts. One is about WHERE this text is — literal markup,
+ * where a `#…` is not a tag ({@link NO_TAGS_IN}) — and the other is about what
+ * is IN it. Folding them into one `||` would be this file making, one line
+ * further down, exactly the mistake it was rewritten to stop making: a claim
+ * about tags and a claim about the walk travelling as one condition, with only
+ * one of them argued for anywhere.
  */
 const splitTags = (
   text: string,
   needles: ReadonlyArray<string>,
-  tags = true,
+  tags: boolean,
 ): ElementContent[] => {
   const landed = litBy(text, needles)
-  if (!tags || !mayHoldTag(text)) return marked(text, landed, 0, text.length)
+
+  // Literal markup. The query's words are still lit — that is the whole of
+  // what this stretch gives up, and it gives up nothing else.
+  if (!tags) return marked(text, landed, 0, text.length)
+
+  // Prose with no sigil anywhere in it, which is most text nodes there are.
+  if (!mayHoldTag(text)) return marked(text, landed, 0, text.length)
+
   const out: ElementContent[] = []
   let at = 0
   for (const part of titleParts(text)) {

--- a/packages/web/src/client/markdown/tags.ts
+++ b/packages/web/src/client/markdown/tags.ts
@@ -75,17 +75,23 @@ export const TAG_CLASS =
   "olai-tag inline whitespace-nowrap text-[0.8125rem] font-normal leading-snug"
 
 /**
- * Subtrees where a `#…` sequence is not a tag: code is code, a link's text
- * and href are not re-parsed for tags (a URL fragment is the sharpest case).
+ * Subtrees where a `#…` sequence is not a tag: code is code, and a link's text
+ * is not re-parsed for tags (a URL fragment is the sharpest case).
  *
- * THE HIGHLIGHT SKIPS THEM TOO, and it follows from the walk rather than being
- * decided again: a needle that lives ONLY inside a title's `code` span or link
- * selects the row — the matcher reads the title as text — and lights nothing
- * (grok, #240). Named here so it is not rediscovered as a defect. Lighting
- * inside them would mean walking the one place this file exists to leave
- * alone, and a `#` inside a URL fragment is the reason it is left alone.
+ * THE WALK STILL GOES IN. It used to turn back at the door, and the highlight
+ * — which rides the same walk — turned back with it: a needle living ONLY
+ * inside a title's `code` span or link selected the row and lit nothing (grok,
+ * #240), because the one place nobody looks for tags was also the one place
+ * nobody lit. That was two claims traveling as one, and only the first was
+ * ever argued for. They are two things now: the walk descends everywhere and
+ * the query's words are marked wherever they sit, while this set turns THE TAG
+ * SPLIT off under it — a `#` in a URL fragment is still not a tag, and a `#`
+ * in code is still code.
+ *
+ * Off for the whole subtree rather than for one element of it: a `<code>`
+ * inside an `<a>` is as literal as either, which is the `&&` below.
  */
-const SKIP_TAGS = new Set(["code", "a"])
+const NO_TAGS_IN = new Set(["code", "a"])
 
 /** Walk text nodes and turn `#tags` into styled spans — and, where the page
  *  is filtered, the query's words into marks (../filter/lit.ts). */
@@ -93,14 +99,24 @@ export const styleTags = (
   parent: Root | Element,
   needles: ReadonlyArray<string> = NO_NEEDLES,
 ): void => {
+  split(parent, needles, true)
+}
+
+/** The walk, carrying down the one thing that varies along it: whether a `#…`
+ *  in here is a tag ({@link NO_TAGS_IN}). Lighting does not vary. */
+const split = (
+  parent: Root | Element,
+  needles: ReadonlyArray<string>,
+  tags: boolean,
+): void => {
   const next: ElementContent[] = []
   for (const child of parent.children) {
     if (child.type === "text") {
-      next.push(...splitTags(child.value, needles))
+      next.push(...splitTags(child.value, needles, tags))
       continue
     }
     if (child.type === "element") {
-      if (!SKIP_TAGS.has(child.tagName)) styleTags(child, needles)
+      split(child, needles, tags && !NO_TAGS_IN.has(child.tagName))
       next.push(child)
       continue
     }
@@ -121,13 +137,18 @@ export const styleTags = (
  * a tag part, so a search inside each piece finds it in neither and the row
  * matched with nothing lit (grok, #240). `titleParts` tiles its input exactly,
  * so the running offset below is the part's place in this text.
+ *
+ * `tags` false is a stretch where a `#…` is not a tag ({@link NO_TAGS_IN}).
+ * The words are still lit, and that is the whole of the difference — the same
+ * one line a text with no sigil in it already took.
  */
 const splitTags = (
   text: string,
   needles: ReadonlyArray<string>,
+  tags = true,
 ): ElementContent[] => {
   const landed = litBy(text, needles)
-  if (!mayHoldTag(text)) return marked(text, landed, 0, text.length)
+  if (!tags || !mayHoldTag(text)) return marked(text, landed, 0, text.length)
   const out: ElementContent[] = []
   let at = 0
   for (const part of titleParts(text)) {

--- a/packages/web/src/client/markdown/tags.ts
+++ b/packages/web/src/client/markdown/tags.ts
@@ -94,10 +94,25 @@ export const TAG_CLASS =
  * SPLIT off under it — a `#` in a URL fragment is still not a tag, and a `#`
  * in code is still code.
  *
- * Off for the whole subtree rather than for one element of it: a `<code>`
- * inside an `<a>` is as literal as either, which is the `&&` below.
+ * How that reaches a subtree rather than one element is {@link tagsIn}.
  */
 const NO_TAGS_IN = new Set(["code", "a"])
+
+/**
+ * Whether a `#…` written in this element's text is a tag.
+ *
+ * `outer` is the answer for the text AROUND it, and the `&&` is the whole of
+ * why {@link NO_TAGS_IN} covers a SUBTREE: literalness only ever accumulates
+ * on the way down, so a `<code>` inside an `<a>` is as literal as either and
+ * nothing below one can win its tags back.
+ *
+ * Its own function, and not the traversal's business: this is a question about
+ * markup — asked of one element and the answer it inherited — and the walk
+ * below is a question about a tree. Sharing a line was how the two got
+ * confused in the first place.
+ */
+const tagsIn = (element: Element, outer: boolean): boolean =>
+  outer && !NO_TAGS_IN.has(element.tagName)
 
 /**
  * Walk text nodes and turn `#tags` into styled spans — and, where the page is
@@ -112,12 +127,12 @@ export const styleTags = (
   parent: Root | Element,
   needles: ReadonlyArray<string> = NO_NEEDLES,
 ): void => {
-  split(parent, needles, true)
+  walk(parent, needles, true)
 }
 
-/** The walk, carrying down the one thing that varies along it: whether a `#…`
- *  in here is a tag ({@link NO_TAGS_IN}). Lighting does not vary. */
-const split = (
+/** The tree half: every text node, once, carrying down the one thing that
+ *  varies along the way ({@link tagsIn}). Lighting does not vary. */
+const walk = (
   parent: Root | Element,
   needles: ReadonlyArray<string>,
   tags: boolean,
@@ -129,7 +144,7 @@ const split = (
       continue
     }
     if (child.type === "element") {
-      split(child, needles, tags && !NO_TAGS_IN.has(child.tagName))
+      walk(child, needles, tagsIn(child, tags))
       next.push(child)
       continue
     }

--- a/packages/web/src/client/markdown/title.ts
+++ b/packages/web/src/client/markdown/title.ts
@@ -21,9 +21,11 @@
  *
  *   1. **inline markdown first** — same pipeline a note uses, forced to
  *      phrasing content (`renderToTree` + `toInline`).
- *   2. **then `#tags`** — walk the finished HAST and style tags in text nodes,
- *      skipping `code` and `a` so a tag inside code stays code and a URL
- *      fragment is not mistaken for a tag (./tags.ts).
+ *   2. **then `#tags`** — walk the finished HAST and style tags in text nodes.
+ *      The walk enters everything, including `code` and `a`; what is off under
+ *      those two is the TAG SPLIT alone, so a tag inside code stays code and a
+ *      URL fragment is not mistaken for a tag, while a filtered page still
+ *      lights the query's words wherever they sit (./tags.ts).
  *
  * Peeling tags *before* markdown would split constructs across two parser runs
  * (`**urgent #home**` loses its bold; `[spec](…#home)` shreds the link). Tags


### PR DESCRIPTION
A filtered page's whole promise is that **every row says why it is drawn**. Two titles could not keep it: a needle living only inside a title's `code` span, or inside a link's text, **selected** the row — the matcher reads a title as the text somebody typed, backticks and brackets and all — and **lit nothing**. Every number on the page correct, and the one row that most needs to explain itself explaining nothing.

This is half of the `filter-highlight-dark-corners` deferral from #240. The other half stays deferred — see the bottom.

## What was actually wrong

Two claims travelling as one. `markdown/tags.ts` named `code` and `a` as subtrees the **tag split** leaves alone, for a reason worth keeping: a `#` inside a URL fragment is not a tag, and a `#` inside code is code. The highlight rides that same walk, and the walk turned back at the door — so it inherited a rule about **tags** as a rule about where a **mark** may go. Only the first half was ever argued for; the second was written down beside it as a dark corner rather than a decision.

## The change

They are two things now. The walk descends everywhere and the query's words are marked wherever they sit; the set — renamed `NO_TAGS_IN` — switches off the **tag split** for the subtree under it, and nothing else. Off for the whole subtree rather than one element of it, so a `<code>` inside an `<a>` is as literal as either.

Two properties that fall out and are asserted rather than assumed:

- **Nothing lit reaches an attribute.** The walk only ever sees text nodes, so a link keeps its `href` — a mark in a URL would be a broken link rather than a loud one.
- **Nothing moves on an unfiltered page.** With no needles a text node is written exactly as it was; that is the first line of the run split and was true before this.

The tag protection is untouched in every reading of it: no pill inside code, none inside a link, none however deeply nested, and none even when the query lights the very `#home` that would otherwise have become one.

## Evidence

A filtered page with a needle inside a code span and inside a link, in both palettes.

One filtered page (`?q=cabinet`), three kinds of hit in the same query — plain title text, a **code span**, and a **link's text** — so the new behaviour is readable beside the behaviour that was already right. The `#home` on the ancestor stays a pill and stays unlit, which is the tag rule untouched.

**chalk** (light)

<img width="1000" alt="a filtered outline in the chalk palette, with cabinet lit in plain text, inside a code span, and inside a link" src="https://github.com/user-attachments/assets/436cc356-8d95-4f56-a7ce-b4fd749320a6" />

**pitch** (dark)

<img width="1000" alt="the same filtered outline in the pitch palette, with the same three highlights" src="https://github.com/user-attachments/assets/6cc0a039-eb31-4d48-8d5d-5c4d8b886127" />


## Held to it

`packages/web/src/client/markdown/tags.test.ts` (unit, beside the highlighter) makes the two claims separately and on the same titles — the words light inside code, inside a link, and inside a code span nested in a link; the pills appear in none of the three.

`title_markdown.feature` filters a page whose rows carry both, and reads the mark's **place** rather than its text (`lights "check" inside its code span`, `lights "spec" inside its link`) — a row lighting the same word elsewhere in its title would go green on a claim it is not making. Same scenario, same page: the `#home` in the link's fragment styles no tag, and the `#home` in the row above it still does.

Both were checked against the code reverted: the scenario fails with `node \`demo\` does not light "check"`, which is the defect exactly.


## Three refactor passes, as their own commits

`ff4f13e2` splits `splitTags`'s one `||` into two guards with a reason each — a claim about markup and a claim about content are exactly what this branch is about not folding together — and writes down two invariants the change leans on (the fast HTML path can never meet a code span, so it needs no rule about one; the walk's seed is not a parameter).

`021b3740` gives the `&&` its own name, `tagsIn`: a question about markup was being asked inside a walk whose subject is a tree, which is how the two got confused to begin with. `split` becomes `walk`, since `splitTags` sits three lines below it.

`4ebe0df4` is `/simplify`. Efficiency and altitude came back clean — the descent costs ~1% of a cache miss that has already paid for the parse, and the literal guard sits above `mayHoldTag`, so text inside a code span now pays *less* than before. Applied: one shared reading of a highlight in the step definitions (the new step had copied the old one's waiting contract), `expectAttribute` for the href step so a failure names what it found, a stale `SKIP_TAGS` reference in `format/backlinks.test.ts`, and two assertions standing behind an exact `toBe` that had already proved them.

## Deferrals

**The other half of `filter-highlight-dark-corners` stays deferred.** A phrase spanning two rendered pieces of a title — across a `**bold**`, say — still lights neither piece. The words are found per piece of rendered markup, and lighting across them needs offset-preserving rendering, which is a different change. `docs/search.md` now names it as the one remaining corner rather than as one of two.

Nothing else is left undone.
