### PR TITLE
The vault lock uses kolu's privacy predicate

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,12 +5,12 @@
     "": {
       "name": "olai",
       "dependencies": {
-        "@effect/platform-browser": "4.0.0-beta.106",
-        "@effect/platform-node": "4.0.0-beta.106",
+        "@effect/platform-browser": "4.0.0-rc.110",
+        "@effect/platform-node": "4.0.0-rc.110",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@solid-primitives/rootless": "^1.5.3",
         "@solid-primitives/scheduled": "^1.5.3",
-        "effect": "4.0.0-beta.106",
+        "effect": "4.0.0-rc.110",
         "solid-js": "^1.9.0",
         "ts-pattern": "^5.9.0",
         "ws": "^8.21.0",
@@ -26,7 +26,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",
-        "effect": "4.0.0-beta.106",
+        "effect": "4.0.0-rc.110",
       },
     },
     "packages/chat": {
@@ -38,7 +38,7 @@
         "@olai/format": "workspace:*",
         "@olai/log": "workspace:*",
         "@olai/surface": "workspace:*",
-        "effect": "4.0.0-beta.106",
+        "effect": "4.0.0-rc.110",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -54,7 +54,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@olai/git": "workspace:*",
-        "effect": "4.0.0-beta.106",
+        "effect": "4.0.0-rc.110",
         "fastest-levenshtein": "^1.0.16",
       },
     },
@@ -62,7 +62,7 @@
       "name": "@olai/git",
       "version": "0.1.0",
       "dependencies": {
-        "effect": "4.0.0-beta.106",
+        "effect": "4.0.0-rc.110",
       },
       "devDependencies": {
         "@olai/log": "workspace:*",
@@ -73,7 +73,7 @@
       "name": "@olai/log",
       "version": "0.1.0",
       "dependencies": {
-        "effect": "4.0.0-beta.106",
+        "effect": "4.0.0-rc.110",
       },
     },
     "packages/ops": {
@@ -83,10 +83,10 @@
         "@olai/format": "workspace:*",
         "@olai/git": "workspace:*",
         "@olai/store": "workspace:*",
-        "effect": "4.0.0-beta.106",
+        "effect": "4.0.0-rc.110",
       },
       "devDependencies": {
-        "@effect/platform-node": "4.0.0-beta.106",
+        "@effect/platform-node": "4.0.0-rc.110",
         "@olai/log": "workspace:*",
         "@types/node": "^22.0.0",
       },
@@ -95,14 +95,14 @@
       "name": "@olai/server",
       "version": "0.1.0",
       "dependencies": {
-        "@effect/platform-node": "4.0.0-beta.106",
+        "@effect/platform-node": "4.0.0-rc.110",
         "@olai/chat": "workspace:*",
         "@olai/format": "workspace:*",
         "@olai/log": "workspace:*",
         "@olai/ops": "workspace:*",
         "@olai/store": "workspace:*",
         "@olai/surface": "workspace:*",
-        "effect": "4.0.0-beta.106",
+        "effect": "4.0.0-rc.110",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -112,10 +112,10 @@
       "name": "@olai/store",
       "version": "0.1.0",
       "dependencies": {
-        "effect": "4.0.0-beta.106",
+        "effect": "4.0.0-rc.110",
       },
       "devDependencies": {
-        "@effect/platform-node": "4.0.0-beta.106",
+        "@effect/platform-node": "4.0.0-rc.110",
       },
     },
     "packages/surface": {
@@ -124,7 +124,7 @@
       "dependencies": {
         "@olai/acp": "workspace:*",
         "@olai/format": "workspace:*",
-        "effect": "4.0.0-beta.106",
+        "effect": "4.0.0-rc.110",
       },
     },
     "packages/tests": {
@@ -152,7 +152,7 @@
         "@olai/surface": "workspace:*",
         "@solid-primitives/keyed": "^1.5.3",
         "@solid-primitives/scheduled": "^1.5.3",
-        "effect": "4.0.0-beta.106",
+        "effect": "4.0.0-rc.110",
         "highlight.js": "^11.11.1",
         "lowlight": "^3.3.0",
         "rehype-autolink-headings": "^7.1.0",
@@ -178,9 +178,9 @@
     },
   },
   "overrides": {
-    "@effect/platform-browser": "4.0.0-beta.106",
-    "@effect/platform-node": "4.0.0-beta.106",
-    "effect": "4.0.0-beta.106",
+    "@effect/platform-browser": "4.0.0-rc.110",
+    "@effect/platform-node": "4.0.0-rc.110",
+    "effect": "4.0.0-rc.110",
   },
   "packages": {
     "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.3.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ=="],
@@ -271,11 +271,11 @@
 
     "@cucumber/tag-expressions": ["@cucumber/tag-expressions@9.1.0", "", {}, "sha512-bvHjcRFZ+J1TqIa9eFNO1wGHqwx4V9ZKV3hYgkuK/VahHx73uiP4rKV3JVrvWSMrwrFvJG6C8aEwnCWSvbyFdQ=="],
 
-    "@effect/platform-browser": ["@effect/platform-browser@4.0.0-beta.106", "", { "peerDependencies": { "effect": "^4.0.0-beta.106" } }, "sha512-3lPVbPDF9GppnnXHBmjFG8VlrLQSLxMsq0kPNt4y543tVQVsBuOPP6D+lDhYsuO3CY4XbDz6O4sDTebF7xvQoA=="],
+    "@effect/platform-browser": ["@effect/platform-browser@4.0.0-rc.110", "", { "peerDependencies": { "effect": "^4.0.0-rc.110" } }, "sha512-fwWN+6JH7GzW32MSFArPYymdXqLFHmUzV0lxcf6gHWktlA8gIg1YokDubC4gIVM2EOVOTxkVTZ7kmKl0/RwEqQ=="],
 
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.106", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.106", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.106", "ioredis": ">=5.7.0 <6.0.0" } }, "sha512-Me7uorWWroWp4OuWHbFg7EqyIex45QzZ3EPwh2p8y/t3VCWVy4KSFtL9AKOKpd7QK1krUWxRK/26J/hTsqvwZg=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-rc.110", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-rc.110", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-rc.110", "redis": ">=5.0.0 <7.0.0" } }, "sha512-poj6VxTc2kRDowUHgjGXAZL2nWHTyGi/18607jK+pV9A9CH/wqZ4NeYj38rij95j5SiZ3U7Y1iOsk2Vfnr4GEw=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.106", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.106" } }, "sha512-TRTzLmhCwVM8G7dXz16lI3wE2vZFSs1jNs/+3WhnuOZgOUeJz9vzBK/KKlGRbbi0QbtEqmW4rAy1y9Fj4MZfsw=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.110", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-rc.110" } }, "sha512-P8EZloxS7RtCOSL3VSBPyqSenUm93xLbXf9jkWoy67cibZ2wgZ9nAou9iN8f1i4vzgxUsWtDuy6BEmg67np6Zw=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.8.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
 
@@ -286,8 +286,6 @@
     "@hono/node-server": ["@hono/node-server@2.1.0", "", { "peerDependencies": { "hono": "^4" } }, "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg=="],
 
     "@internationalized/number": ["@internationalized/number@3.6.7", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg=="],
-
-    "@ioredis/commands": ["@ioredis/commands@1.10.0", "", {}, "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -368,6 +366,16 @@
     "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ=="],
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA=="],
+
+    "@redis/bloom": ["@redis/bloom@6.2.1", "", { "peerDependencies": { "@redis/client": "^6.2.1" } }, "sha512-huQgNLaCIZfQ9SeLn4q9124uOUd8HbZDYHwwUzNcRgHqCHiHKl2dDxMqJCeWh8cMqZAoWuHR8XnWbDMIf+o7ag=="],
+
+    "@redis/client": ["@redis/client@6.2.1", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-LzxBY7SIBvvJiyCgcaJZZakE3fJrZZ++i24+EDW9fKpCl68D35uJcKFpZZwCfOoG9WZTbyZlMzMeM0gtOAMU9Q=="],
+
+    "@redis/json": ["@redis/json@6.2.1", "", { "peerDependencies": { "@redis/client": "^6.2.1" } }, "sha512-AFIUJ8Gj0DaaSBHYuSt8+O0oYWM+50OK1c0OmodB7XERIA8+BbyV3O4v76f9iccWasd1/7qjfZTpuzexUaZtrQ=="],
+
+    "@redis/search": ["@redis/search@6.2.1", "", { "peerDependencies": { "@redis/client": "^6.2.1" } }, "sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ=="],
+
+    "@redis/time-series": ["@redis/time-series@6.2.1", "", { "peerDependencies": { "@redis/client": "^6.2.1" } }, "sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00WFzVSMRA/2Ijw=="],
 
     "@solid-primitives/event-listener": ["@solid-primitives/event-listener@2.4.6", "", { "dependencies": { "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-5I0YJcTVYIWoMmgBSROBZGcz+ymhew/pGTg2dHW74BUjFKsV8Li4bOZYl0YAGP4mHw5o4UBd9/BEesqBci3wxw=="],
 
@@ -517,7 +525,7 @@
 
     "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
 
-    "cluster-key-slot": ["cluster-key-slot@1.1.1", "", {}, "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw=="],
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -547,8 +555,6 @@
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
-    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
-
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
@@ -563,7 +569,7 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "effect": ["effect@4.0.0-beta.106", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "uuid": "^14.0.1" } }, "sha512-Sb1eNPYP8UdkE6xDOEEnrrOh/Vu2ocdRTPSeZTjZXukUrEYT2NtuQpbS90sEWaa7b6qLt8dfEYPpa6IVe5giHw=="],
+    "effect": ["effect@4.0.0-rc.110", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.4" } }, "sha512-ega6FTJ8CS2of7tHZiADvgyJyV999Q6tZ9juE56V81O0jw6flRwydaPNtyfvP2a5LL9PZrse8A1jnNUD5sWVHg=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.403", "", {}, "sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA=="],
 
@@ -685,8 +691,6 @@
 
     "ini": ["ini@2.0.0", "", {}, "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="],
 
-    "ioredis": ["ioredis@5.11.1", "", { "dependencies": { "@ioredis/commands": "1.10.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "redis-parser": "3.0.0", "standard-as-callback": "2.1.0" } }, "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A=="],
-
     "ip-address": ["ip-address@10.5.0", "", {}, "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
@@ -726,8 +730,6 @@
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "knuth-shuffle-seeded": ["knuth-shuffle-seeded@1.0.6", "", { "dependencies": { "seed-random": "~2.2.0" } }, "sha512-9pFH0SplrfyKyojCLxZfMcvkhf5hH0d+UwR9nTVJ/DDQJGuzcXjTwB7TP7sDfehSudlGGaOLblmEWqv04ERVWg=="],
-
-    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -947,9 +949,7 @@
 
     "read-pkg": ["read-pkg@10.1.0", "", { "dependencies": { "@types/normalize-package-data": "^2.4.4", "normalize-package-data": "^8.0.0", "parse-json": "^8.3.0", "type-fest": "^5.4.4", "unicorn-magic": "^0.4.0" } }, "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg=="],
 
-    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
-
-    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+    "redis": ["redis@6.2.1", "", { "dependencies": { "@redis/bloom": "6.2.1", "@redis/client": "6.2.1", "@redis/json": "6.2.1", "@redis/search": "6.2.1", "@redis/time-series": "6.2.1" } }, "sha512-Z9VHtgYs48PiQC77X9O2Er8Hj4T+5BtFjT91/vi5Is1D04N72cA946ZslM1ImJw8ZctFBZWAVjM7S5wJNeHMpg=="],
 
     "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
@@ -1033,8 +1033,6 @@
 
     "stackframe": ["stackframe@1.3.4", "", {}, "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="],
 
-    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
-
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string-argv": ["string-argv@0.3.1", "", {}, "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg=="],
@@ -1108,8 +1106,6 @@
     "upper-case-first": ["upper-case-first@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg=="],
 
     "util-arity": ["util-arity@1.1.0", "", {}, "sha512-kkyIsXKwemfSy8ZEoaIz06ApApnWsk5hQO0vLjZS6UkBiGiW++Jsyb8vSBoc0WKlffGoGs5yYy/j5pp8zckrFA=="],
-
-    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -375,7 +375,7 @@
 
     "@redis/search": ["@redis/search@6.2.1", "", { "peerDependencies": { "@redis/client": "^6.2.1" } }, "sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ=="],
 
-    "@redis/time-series": ["@redis/time-series@6.2.1", "", { "peerDependencies": { "@redis/client": "^6.2.1" } }, "sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00WFzVSMRA/2Ijw=="],
+    "@redis/time-series": ["@redis/time-series@6.2.1", "", { "peerDependencies": { "@redis/client": "^6.2.1" } }, "sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00QFZVSMRA/2Ijw=="],
 
     "@solid-primitives/event-listener": ["@solid-primitives/event-listener@2.4.6", "", { "dependencies": { "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-5I0YJcTVYIWoMmgBSROBZGcz+ymhew/pGTg2dHW74BUjFKsV8Li4bOZYl0YAGP4mHw5o4UBd9/BEesqBci3wxw=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -192,17 +192,17 @@
     url = "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-9.1.0.tgz";
     hash = "sha512-bvHjcRFZ+J1TqIa9eFNO1wGHqwx4V9ZKV3hYgkuK/VahHx73uiP4rKV3JVrvWSMrwrFvJG6C8aEwnCWSvbyFdQ==";
   };
-  "@effect/platform-browser@4.0.0-beta.106" = fetchurl {
-    url = "https://registry.npmjs.org/@effect/platform-browser/-/platform-browser-4.0.0-beta.106.tgz";
-    hash = "sha512-3lPVbPDF9GppnnXHBmjFG8VlrLQSLxMsq0kPNt4y543tVQVsBuOPP6D+lDhYsuO3CY4XbDz6O4sDTebF7xvQoA==";
+  "@effect/platform-browser@4.0.0-rc.110" = fetchurl {
+    url = "https://registry.npmjs.org/@effect/platform-browser/-/platform-browser-4.0.0-rc.110.tgz";
+    hash = "sha512-fwWN+6JH7GzW32MSFArPYymdXqLFHmUzV0lxcf6gHWktlA8gIg1YokDubC4gIVM2EOVOTxkVTZ7kmKl0/RwEqQ==";
   };
-  "@effect/platform-node-shared@4.0.0-beta.106" = fetchurl {
-    url = "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-4.0.0-beta.106.tgz";
-    hash = "sha512-TRTzLmhCwVM8G7dXz16lI3wE2vZFSs1jNs/+3WhnuOZgOUeJz9vzBK/KKlGRbbi0QbtEqmW4rAy1y9Fj4MZfsw==";
+  "@effect/platform-node-shared@4.0.0-rc.110" = fetchurl {
+    url = "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-4.0.0-rc.110.tgz";
+    hash = "sha512-P8EZloxS7RtCOSL3VSBPyqSenUm93xLbXf9jkWoy67cibZ2wgZ9nAou9iN8f1i4vzgxUsWtDuy6BEmg67np6Zw==";
   };
-  "@effect/platform-node@4.0.0-beta.106" = fetchurl {
-    url = "https://registry.npmjs.org/@effect/platform-node/-/platform-node-4.0.0-beta.106.tgz";
-    hash = "sha512-Me7uorWWroWp4OuWHbFg7EqyIex45QzZ3EPwh2p8y/t3VCWVy4KSFtL9AKOKpd7QK1krUWxRK/26J/hTsqvwZg==";
+  "@effect/platform-node@4.0.0-rc.110" = fetchurl {
+    url = "https://registry.npmjs.org/@effect/platform-node/-/platform-node-4.0.0-rc.110.tgz";
+    hash = "sha512-poj6VxTc2kRDowUHgjGXAZL2nWHTyGi/18607jK+pV9A9CH/wqZ4NeYj38rij95j5SiZ3U7Y1iOsk2Vfnr4GEw==";
   };
   "@emnapi/core@1.11.3" = fetchurl {
     url = "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz";
@@ -235,10 +235,6 @@
   "@internationalized/number@3.6.7" = fetchurl {
     url = "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz";
     hash = "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==";
-  };
-  "@ioredis/commands@1.10.0" = fetchurl {
-    url = "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz";
-    hash = "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==";
   };
   "@jridgewell/gen-mapping@0.3.13" = fetchurl {
     url = "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz";
@@ -367,6 +363,26 @@
   "@parcel/watcher@2.5.1" = fetchurl {
     url = "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz";
     hash = "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==";
+  };
+  "@redis/bloom@6.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/@redis/bloom/-/bloom-6.2.1.tgz";
+    hash = "sha512-huQgNLaCIZfQ9SeLn4q9124uOUd8HbZDYHwwUzNcRgHqCHiHKl2dDxMqJCeWh8cMqZAoWuHR8XnWbDMIf+o7ag==";
+  };
+  "@redis/client@6.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/@redis/client/-/client-6.2.1.tgz";
+    hash = "sha512-LzxBY7SIBvvJiyCgcaJZZakE3fJrZZ++i24+EDW9fKpCl68D35uJcKFpZZwCfOoG9WZTbyZlMzMeM0gtOAMU9Q==";
+  };
+  "@redis/json@6.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/@redis/json/-/json-6.2.1.tgz";
+    hash = "sha512-AFIUJ8Gj0DaaSBHYuSt8+O0oYWM+50OK1c0OmodB7XERIA8+BbyV3O4v76f9iccWasd1/7qjfZTpuzexUaZtrQ==";
+  };
+  "@redis/search@6.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/@redis/search/-/search-6.2.1.tgz";
+    hash = "sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ==";
+  };
+  "@redis/time-series@6.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/@redis/time-series/-/time-series-6.2.1.tgz";
+    hash = "sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00WFzVSMRA/2Ijw==";
   };
   "@solid-primitives/event-listener@2.4.6" = fetchurl {
     url = "https://registry.npmjs.org/@solid-primitives/event-listener/-/event-listener-2.4.6.tgz";
@@ -680,9 +696,9 @@
     url = "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz";
     hash = "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==";
   };
-  "cluster-key-slot@1.1.1" = fetchurl {
-    url = "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz";
-    hash = "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==";
+  "cluster-key-slot@1.1.2" = fetchurl {
+    url = "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz";
+    hash = "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==";
   };
   "color-convert@2.0.1" = fetchurl {
     url = "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz";
@@ -752,10 +768,6 @@
     url = "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz";
     hash = "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==";
   };
-  "denque@2.1.0" = fetchurl {
-    url = "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz";
-    hash = "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==";
-  };
   "depd@2.0.0" = fetchurl {
     url = "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz";
     hash = "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==";
@@ -788,9 +800,9 @@
     url = "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz";
     hash = "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==";
   };
-  "effect@4.0.0-beta.106" = fetchurl {
-    url = "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.106.tgz";
-    hash = "sha512-Sb1eNPYP8UdkE6xDOEEnrrOh/Vu2ocdRTPSeZTjZXukUrEYT2NtuQpbS90sEWaa7b6qLt8dfEYPpa6IVe5giHw==";
+  "effect@4.0.0-rc.110" = fetchurl {
+    url = "https://registry.npmjs.org/effect/-/effect-4.0.0-rc.110.tgz";
+    hash = "sha512-ega6FTJ8CS2of7tHZiADvgyJyV999Q6tZ9juE56V81O0jw6flRwydaPNtyfvP2a5LL9PZrse8A1jnNUD5sWVHg==";
   };
   "electron-to-chromium@1.5.403" = fetchurl {
     url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.403.tgz";
@@ -1036,10 +1048,6 @@
     url = "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz";
     hash = "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==";
   };
-  "ioredis@5.11.1" = fetchurl {
-    url = "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz";
-    hash = "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==";
-  };
   "ip-address@10.5.0" = fetchurl {
     url = "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz";
     hash = "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==";
@@ -1119,10 +1127,6 @@
   "knuth-shuffle-seeded@1.0.6" = fetchurl {
     url = "https://registry.npmjs.org/knuth-shuffle-seeded/-/knuth-shuffle-seeded-1.0.6.tgz";
     hash = "sha512-9pFH0SplrfyKyojCLxZfMcvkhf5hH0d+UwR9nTVJ/DDQJGuzcXjTwB7TP7sDfehSudlGGaOLblmEWqv04ERVWg==";
-  };
-  "kubernetes-types@1.30.0" = fetchurl {
-    url = "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz";
-    hash = "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==";
   };
   "lightningcss-android-arm64@1.32.0" = fetchurl {
     url = "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz";
@@ -1568,13 +1572,9 @@
     url = "https://registry.npmjs.org/read-pkg/-/read-pkg-10.1.0.tgz";
     hash = "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==";
   };
-  "redis-errors@1.2.0" = fetchurl {
-    url = "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz";
-    hash = "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==";
-  };
-  "redis-parser@3.0.0" = fetchurl {
-    url = "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz";
-    hash = "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==";
+  "redis@6.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/redis/-/redis-6.2.1.tgz";
+    hash = "sha512-Z9VHtgYs48PiQC77X9O2Er8Hj4T+5BtFjT91/vi5Is1D04N72cA946ZslM1ImJw8ZctFBZWAVjM7S5wJNeHMpg==";
   };
   "reflect-metadata@0.2.2" = fetchurl {
     url = "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz";
@@ -1744,10 +1744,6 @@
     url = "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz";
     hash = "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==";
   };
-  "standard-as-callback@2.1.0" = fetchurl {
-    url = "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz";
-    hash = "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==";
-  };
   "statuses@2.0.2" = fetchurl {
     url = "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz";
     hash = "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==";
@@ -1911,10 +1907,6 @@
   "util-arity@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/util-arity/-/util-arity-1.1.0.tgz";
     hash = "sha512-kkyIsXKwemfSy8ZEoaIz06ApApnWsk5hQO0vLjZS6UkBiGiW++Jsyb8vSBoc0WKlffGoGs5yYy/j5pp8zckrFA==";
-  };
-  "uuid@14.0.1" = fetchurl {
-    url = "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz";
-    hash = "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==";
   };
   "validate-npm-package-license@3.0.4" = fetchurl {
     url = "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz";

--- a/bun.nix
+++ b/bun.nix
@@ -382,7 +382,7 @@
   };
   "@redis/time-series@6.2.1" = fetchurl {
     url = "https://registry.npmjs.org/@redis/time-series/-/time-series-6.2.1.tgz";
-    hash = "sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00WFzVSMRA/2Ijw==";
+    hash = "sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00QFZVSMRA/2Ijw==";
   };
   "@solid-primitives/event-listener@2.4.6" = fetchurl {
     url = "https://registry.npmjs.org/@solid-primitives/event-listener/-/event-listener-2.4.6.tgz";

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "bfb4eb563cd08ab84b8b45387150203234b3f0a1",
-      "url": "https://github.com/juspay/kolu/archive/bfb4eb563cd08ab84b8b45387150203234b3f0a1.tar.gz",
-      "hash": "sha256-1c+kxWuzSlkI0nM7knQ2obTwxs5rwyt5uAXgxfxgsTU="
+      "revision": "1b3c20b5d39d8acdc79216d05ca577da6e66324f",
+      "url": "https://github.com/juspay/kolu/archive/1b3c20b5d39d8acdc79216d05ca577da6e66324f.tar.gz",
+      "hash": "sha256-mv7hlk7fa5kz3C1GwjDfKjQR42j2OMq9T2tkvSet9TQ="
     },
     "nixpkgs": {
       "type": "Git",

--- a/package.json
+++ b/package.json
@@ -12,21 +12,21 @@
   },
   "//dependencies": "The runtime dependencies of the hydrated @kolu/* sources, declared HERE at the root rather than in the member that imports them: the isolated linker (bunfig.toml) symlinks only the root package's direct dependencies into the root node_modules, and that is where node_modules/@kolu/<name>/src/*.ts resolves its own imports by walking up. Every entry is at the exact version the pinned kolu declares — PEER dependencies included, because a peer is a runtime import like any other and the arrangement it names (`the app supplies the runtime`) is exactly the one this list is. `ws` is here for that reason and not because any olai source imports it: @kolu/surface-app's serving half is a Node websocket server. `@modelcontextprotocol/sdk` and `ts-pattern` are the same case one package over — @kolu/surface-mcp is built on the SDK's low-level Server and matches on its connection state with ts-pattern; no olai source imports either. This is not maintained by memory — scripts/check-kolu-deps.sh reads the pinned kolu's own manifests and fails `just check` when this list drifts from them.",
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.106",
-    "@effect/platform-node": "4.0.0-beta.106",
+    "@effect/platform-browser": "4.0.0-rc.110",
+    "@effect/platform-node": "4.0.0-rc.110",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@solid-primitives/rootless": "^1.5.3",
     "@solid-primitives/scheduled": "^1.5.3",
-    "effect": "4.0.0-beta.106",
+    "effect": "4.0.0-rc.110",
     "solid-js": "^1.9.0",
     "ts-pattern": "^5.9.0",
     "ws": "^8.21.0"
   },
   "//overrides": "One effect instance, always. A transitive bump must not be able to smuggle in a second copy: Effect's error narrowing is `_tag`-structural precisely because two module instances would otherwise stop recognising each other's classes — and `instanceof`, Context keys and Schema identity do not even have that fallback. The @effect/platform-* packages carry tagged errors and Context tags of their own, so they are pinned beside it. Versions come from the pinned kolu and are checked by scripts/check-kolu-deps.sh; re-pinning kolu means re-running `just check` and moving whatever it names.",
   "overrides": {
-    "@effect/platform-browser": "4.0.0-beta.106",
-    "@effect/platform-node": "4.0.0-beta.106",
-    "effect": "4.0.0-beta.106"
+    "@effect/platform-browser": "4.0.0-rc.110",
+    "@effect/platform-node": "4.0.0-rc.110",
+    "effect": "4.0.0-rc.110"
   },
   "//devDependencies": "@types/ws is the other half of the `ws` entry above: the hydrated sources are raw TypeScript, so `tsc --noEmit` checks them, and it resolves their types from the same root node_modules their imports resolve from.",
   "devDependencies": {

--- a/packages/acp/package.json
+++ b/packages/acp/package.json
@@ -16,6 +16,6 @@
   "//dependencies": "A LEAF that speaks ACP: `effect` for the schemas the wire half is declared in, and the protocol SDK for the payload TYPES the projections read — type-only imports, so no zod and no runtime SDK code enters this package's closure (the subprocess that runs the protocol lives in @olai/chat, which is where the SDK's runtime and its zod peer stay declared). No @olai/* sibling, deliberately: the domain's words must not enter — this package refuses in its own `Refused`, and @olai/chat translates to `UsageFailure` at the seam. Machine-checked by src/manifest.test.ts, not remembered.",
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.3.0",
-    "effect": "4.0.0-beta.106"
+    "effect": "4.0.0-rc.110"
   }
 }

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -19,7 +19,7 @@
     "@olai/format": "workspace:*",
     "@olai/log": "workspace:*",
     "@olai/surface": "workspace:*",
-    "effect": "4.0.0-beta.106",
+    "effect": "4.0.0-rc.110",
     "zod": "^4.0.0"
   },
   "//devDependencies": "@types/node is for `node:child_process`, which is how an ACP agent is started.",

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -16,7 +16,7 @@
   "//dependencies": "The bottom of the layering (docs/architecture.md): nothing here can reach a disk, a server or a browser. @olai/git is the one workspace sibling, and it is not a layer violation but the other half of this floor — a LEAF beside this package, on `effect` alone, whose `./state` subpath is pure data (RepoState, Reason) that this package re-exports because it travels the wire. Only that subpath is imported: the main entry shells out to git, and this module is bundled into a browser. fastest-levenshtein is the did-you-mean distance — a focused, dependency-free library rather than eighteen lines of textbook matrix arithmetic we would then own.",
   "dependencies": {
     "@olai/git": "workspace:*",
-    "effect": "4.0.0-beta.106",
+    "effect": "4.0.0-rc.110",
     "fastest-levenshtein": "^1.0.16"
   }
 }

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -16,7 +16,7 @@
   },
   "//dependencies": "`effect` and nothing else, deliberately: this is a LEAF beside `format` and `log` (docs/architecture.md), and it is the whole point of the extraction — a package that shells out to git and knows nothing about outlines, writers or a wire. A workspace sibling appearing here would be that knowledge coming back.",
   "dependencies": {
-    "effect": "4.0.0-beta.106"
+    "effect": "4.0.0-rc.110"
   },
   "//devDependencies": "@types/node is for `node:child_process` and `node:fs`, which this package IS. @olai/log is here for its `./testlib` collector ONLY — a refusal is reported as a log line, so a test of what it reports has to hear one, and hearing one has exactly one spelling in this tree. Deliberately not a runtime dependency: the levels and the verbs are Effect's, so nothing in src/ imports it.",
   "devDependencies": {

--- a/packages/log/README.md
+++ b/packages/log/README.md
@@ -54,7 +54,7 @@ Colour follows the **destination** stream (stdout for `toStdout`, stderr for `to
 One line per event, `key=value`, quoted only where it has to be:
 
 ```
-timestamp=2026-08-10T17:45:36.770Z level=Info fiber=#5 message=serving serve=12ms root=/home/you/outlines url=http://127.0.0.1:7714
+timestamp=2026-08-10T17:45:36.770Z level=INFO fiber=#5 message=serving serve=12ms root=/home/you/outlines url=http://127.0.0.1:7714
 timestamp=2026-08-10T17:45:36.812Z level=Warn fiber=#8 message="the agent is running a model its picker does not offer" serve=54ms root=/home/you/outlines agent=claude-code-acp model=opus-5
 ```
 

--- a/packages/log/README.md
+++ b/packages/log/README.md
@@ -55,7 +55,7 @@ One line per event, `key=value`, quoted only where it has to be:
 
 ```
 timestamp=2026-08-10T17:45:36.770Z level=INFO fiber=#5 message=serving serve=12ms root=/home/you/outlines url=http://127.0.0.1:7714
-timestamp=2026-08-10T17:45:36.812Z level=Warn fiber=#8 message="the agent is running a model its picker does not offer" serve=54ms root=/home/you/outlines agent=claude-code-acp model=opus-5
+timestamp=2026-08-10T17:45:36.812Z level=WARN fiber=#8 message="the agent is running a model its picker does not offer" serve=54ms root=/home/you/outlines agent=claude-code-acp model=opus-5
 ```
 
 The message is a short, stable sentence; every value that varies is an annotation. That is what makes a line greppable by field rather than by substring — `url=` is the address, wherever the message went — and it is why a relayed multi-line agent message is still ONE line: the value is escaped, not wrapped.

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -15,6 +15,6 @@
   },
   "//dependencies": "`effect` and nothing else, deliberately: this is the bottom of the layering beside `format` and `store` (docs/architecture.md), and every package above logs. A workspace sibling appearing here would put a package between a caller and the ability to say what it is doing, which is the one thing everything needs. It is also why the LEVELS are Effect's own rather than a vocabulary of ours — an `Effect.logDebug` in `store` and one in `server` are already the same thing.",
   "dependencies": {
-    "effect": "4.0.0-beta.106"
+    "effect": "4.0.0-rc.110"
   }
 }

--- a/packages/log/src/lines.test.ts
+++ b/packages/log/src/lines.test.ts
@@ -38,7 +38,7 @@ test("a field the encoder left bare reads back as itself", async () => {
     ),
   )
 
-  expect(fields.level).toBe("Info")
+  expect(fields.level).toBe("INFO")
   expect(fields.message).toBe("serving")
   expect(fields.url).toBe("http://127.0.0.1:40429")
 })
@@ -81,7 +81,7 @@ test("a line found by message is that line, not a later one that shares a field"
 // in the middle of a quoted value, where there is no closing quote to find and
 // the fields read so far are all there is.
 test("a partial trailing line is not a match", () => {
-  expect(findLogfmt("timestamp=… level=Info fiber=#2 message=serv", "serving"))
+  expect(findLogfmt("timestamp=… level=INFO fiber=#2 message=serv", "serving"))
     .toBeUndefined()
 
   const cut = `timestamp=… level=Warn message="the agent could not`

--- a/packages/log/src/lines.test.ts
+++ b/packages/log/src/lines.test.ts
@@ -84,8 +84,8 @@ test("a partial trailing line is not a match", () => {
   expect(findLogfmt("timestamp=… level=INFO fiber=#2 message=serv", "serving"))
     .toBeUndefined()
 
-  const cut = `timestamp=… level=Warn message="the agent could not`
+  const cut = `timestamp=… level=WARN message="the agent could not`
   expect(findLogfmt(cut, "the agent could not open a session")).toBeUndefined()
-  expect(readLogfmt(cut).level).toBe("Warn")
+  expect(readLogfmt(cut).level).toBe("WARN")
   expect(readLogfmt(cut).message).toBeUndefined()
 })

--- a/packages/log/src/sinks.test.ts
+++ b/packages/log/src/sinks.test.ts
@@ -130,7 +130,7 @@ test("the stdout sink writes logfmt on stdout", async () => {
     // The shape the e2e suite reads the server's address out of: one line, the
     // level as a field, and every varying value its own `key=value`.
     const line = String(out[0])
-    expect(line).toContain("level=Info")
+    expect(line).toContain("level=INFO")
     expect(line).toContain("message=serving")
     expect(line).toContain("url=http://127.0.0.1:7714")
     expect(line).not.toContain("\n")
@@ -174,12 +174,12 @@ test("OLAI_LOG=pretty forces pretty even when the stream is not a TTY", async ()
 
     const { out } = await written(toStdout)
     // Pretty is message-first, local time in brackets — not logfmt's
-    // `timestamp=… level=Info message=…` field order. One line at least
+    // `timestamp=… level=INFO message=…` field order. One line at least
     // carries the message; none is a bare logfmt line.
     const joined = out.map(String).join("\n")
     expect(joined).toContain("serving")
-    expect(joined).not.toMatch(/^timestamp=\S+ level=Info /m)
-    // Coloured level is uppercased in pretty; logfmt uses Effect's title case.
+    expect(joined).not.toMatch(/^timestamp=\S+ level=INFO /m)
+    // Coloured level is uppercased in pretty; logfmt now is too (Effect rc).
     expect(joined).toMatch(/INFO/)
   })
 })
@@ -196,7 +196,7 @@ test("OLAI_LOG=pretty on toStderr keeps stdout empty (the protocol stream)", asy
     expect(err.length).toBeGreaterThan(0)
     const joined = err.map(String).join("\n")
     expect(joined).toContain("serving")
-    expect(joined).not.toMatch(/^timestamp=\S+ level=Info /m)
+    expect(joined).not.toMatch(/^timestamp=\S+ level=INFO /m)
     expect(joined).toMatch(/INFO/)
   })
 })

--- a/packages/ops/package.json
+++ b/packages/ops/package.json
@@ -18,11 +18,11 @@
     "@olai/format": "workspace:*",
     "@olai/git": "workspace:*",
     "@olai/store": "workspace:*",
-    "effect": "4.0.0-beta.106"
+    "effect": "4.0.0-rc.110"
   },
   "//devDependencies": "@effect/platform-node is the FileSystem the tests drive a real temp directory through, exactly as @olai/store's are. @types/node is for the node built-ins the tests reach for. @olai/log is here for its `./testlib` collector ONLY — hearing a log line has exactly one spelling in this tree. It is deliberately not a runtime dependency: the levels and the verbs are Effect's, so nothing in src/ imports it.",
   "devDependencies": {
-    "@effect/platform-node": "4.0.0-beta.106",
+    "@effect/platform-node": "4.0.0-rc.110",
     "@olai/log": "workspace:*",
     "@types/node": "^22.0.0"
   }

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -101,8 +101,8 @@ An agent does not have to READ that resource to learn a repository is busy, eith
 **A busy port is not a refusal.** If the port asked for is already listening, the listener binds once more on a port the OS picks and says so:
 
 ```
-timestamp=… level=Info fiber=#5 message="port in use — serving elsewhere" serve=24ms root=/home/you/outlines asked=7714 url=http://127.0.0.1:40429
-timestamp=… level=Info fiber=#5 message=serving serve=25ms root=/home/you/outlines url=http://127.0.0.1:40429
+timestamp=… level=INFO fiber=#5 message="port in use — serving elsewhere" serve=24ms root=/home/you/outlines asked=7714 url=http://127.0.0.1:40429
+timestamp=… level=INFO fiber=#5 message=serving serve=25ms root=/home/you/outlines url=http://127.0.0.1:40429
 ```
 
 The reader asked to read their outlines, not to own port 7714. Every other listen failure still is a refusal — a host that is not this machine's, a privileged port — which is why exactly one error code recovers rather than "listen failed". The address that gets reported is always the one **actually bound**, and it is its own `url=` field: the browser tests read it out of that line rather than assuming the port they passed, because the printed address is the only thing that knows. Everything about the shape of those lines — one format, the levels, what is a message and what is an annotation, and the `--log-level` that turns the quiet half on — is [`@olai/log`](../log/README.md).

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,14 +15,14 @@
   "//dependencies": "The composition root: it is the only package allowed to know about all of the others, and the direction is strictly downward (docs/architecture.md). @olai/web is deliberately absent — the server serves a built bundle it is handed, it does not import the client.",
   "//acp": "The ACP SDK is NOT here: talking to an agent is @olai/chat's, and this package composes it. What is left of the agent in this file is a workspace dependency and one call.",
   "dependencies": {
-    "@effect/platform-node": "4.0.0-beta.106",
+    "@effect/platform-node": "4.0.0-rc.110",
     "@olai/chat": "workspace:*",
     "@olai/format": "workspace:*",
     "@olai/log": "workspace:*",
     "@olai/ops": "workspace:*",
     "@olai/store": "workspace:*",
     "@olai/surface": "workspace:*",
-    "effect": "4.0.0-beta.106"
+    "effect": "4.0.0-rc.110"
   },
   "//ws": "Not here any more, and that is the point of serveSurfaceApp: no source in this package names a websocket implementation. `ws` is the hydrated @kolu/surface-app's own peer dependency, declared at the ROOT with the rest of them (bunfig.toml has the argument).",
   "devDependencies": {

--- a/packages/server/src/child.testlib.ts
+++ b/packages/server/src/child.testlib.ts
@@ -93,8 +93,12 @@ export interface WebChild {
 }
 
 /**
- * `olai web <root> --port 0 --no-commit`, spawned the way a person's shell
- * does — the packaged artefact's own entry point, not this package's modules.
+ * `olai web <root> --port 0 …`, spawned the way a person's shell does — the
+ * packaged artefact's own entry point, not this package's modules.
+ *
+ * `--no-commit` is the default extra because most callers are not about git.
+ * Pass `extra: []` to take the process default (`manual`), which is the one
+ * thing Effect 4 started refusing without a fallback on the boolean flag.
  */
 export const startWeb = (options: {
   readonly root: string
@@ -102,10 +106,13 @@ export const startWeb = (options: {
    *  meet somewhere the environment decides they do — said explicitly rather
    *  than left to what this process happens to have inherited. */
   readonly env?: NodeJS.ProcessEnv
+  /** Argv after `--port 0`. Unset includes `--no-commit`. */
+  readonly extra?: ReadonlyArray<string>
 }): WebChild => {
+  const extra = options.extra ?? ["--no-commit"]
   const child = spawn(
     process.execPath,
-    [MAIN, "web", options.root, "--port", "0", "--no-commit"],
+    [MAIN, "web", options.root, "--port", "0", ...extra],
     {
       env: {
         ...process.env,

--- a/packages/server/src/commits.test.ts
+++ b/packages/server/src/commits.test.ts
@@ -19,9 +19,14 @@
  */
 
 import { expect, test } from "bun:test"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
 
 import { COMMIT_BUTTON, COMMIT_MODES, commitDoors, COMMIT_TOOL } from "@olai/ops"
+import { BOOT_TIMEOUT, startWeb } from "./child.testlib.ts"
 import { commitMode, commitsSaid } from "./commits.ts"
+import { served } from "./serve.testlib.ts"
 
 // ── what the two flags come to between them ────────────────────────────
 
@@ -98,3 +103,28 @@ test("apart from the doors, both faces say the same thing", () => {
     commitsSaid(face).replace(commitDoors(face), "…")
   expect(withoutDoors("web")).toBe(withoutDoors("mcp"))
 })
+
+/**
+ * The parse-time half of "opt-out", which the truth table cannot see.
+ *
+ * Effect 4's `Flag.boolean` treats omission as a missing required flag unless
+ * it has a fallback. `--no-commit` is the opt-out: a person (and the e2e git
+ * scenarios) who want the default pass nothing. Spawning, not parsing in
+ * process, because that is the seam the CLI library owns and the unit tests
+ * of `commitMode` never touch.
+ */
+test("olai web without --no-commit still boots", async () => {
+  const runtime = fs.mkdtempSync(path.join(os.tmpdir(), "olai-commit-run-"))
+  const server = startWeb({
+    root: served(),
+    extra: [],
+    env: { XDG_RUNTIME_DIR: runtime },
+  })
+  try {
+    const url = await server.address()
+    expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/)
+    expect(server.said()).not.toContain("Missing required flag")
+  } finally {
+    server.kill()
+  }
+}, BOOT_TIMEOUT * 3)

--- a/packages/server/src/commits.ts
+++ b/packages/server/src/commits.ts
@@ -75,6 +75,12 @@ export const commitFlags = (face: CommitFace) => ({
   ),
   noCommit: Flag.boolean("no-commit").pipe(
     Flag.withDescription("the same as --commit=off"),
+    // Omission is false. Effect 4's boolean flags refuse to parse without a
+    // fallback ("Omission fails unless the flag is made optional or given a
+    // fallback"), and `--no-commit` is an opt-out: a person who wanted the
+    // default, and the e2e git scenarios that start a server so it WILL
+    // commit, pass nothing. `--no-commit` present is still `true`.
+    Flag.withDefault(false),
   ),
 })
 

--- a/packages/server/src/lock.test.ts
+++ b/packages/server/src/lock.test.ts
@@ -282,7 +282,7 @@ test("a runtime directory that is not a directory refuses the boot", async () =>
 }, BOUND_MS)
 
 test("a runtime directory other users can write refuses the boot", async () => {
-  // The threat `notPrivatelyOurs` is for: `/tmp/olai-$UID` is a fixed path, and
+  // The threat `isPrivateOwnedDir` is for: `/tmp/olai-$UID` is a fixed path, and
   // a directory somebody else prepared is one they can hold a lock in — olai
   // would then report a stranger's claim as another olai of the reader's own.
   // 0755 is OURS and still open, which is the case `mkdirSync`'s `mode:` cannot

--- a/packages/server/src/lock.ts
+++ b/packages/server/src/lock.ts
@@ -83,6 +83,7 @@
  * writes inside the thing it holds.
  */
 
+import { isPrivateOwnedDir } from "@kolu/surface/unix-socket"
 import { codeOf, reasonOf } from "@olai/log"
 import { Data, Effect } from "effect"
 import type { Scope } from "effect"
@@ -151,12 +152,12 @@ export const lockFor = (root: string): string =>
  * olai kept a user of until #184 and is one again here.
  *
  * Spelled out rather than called as `getRuntimeSocketPath`, which is the same
- * five lines and IS still importable: that function's value is that two
- * programs which must MEET compute one path, and the two processes here are
- * both olai computing it through this file. What it would cost is a module
- * about serving RPC over unix sockets pulled back into the binary's graph for a
- * string, one release after #184 took it out. If a second program ever has to
- * find olai's lock, that trade flips and the call is the right answer.
+ * five lines: that function's value is that two programs which must MEET
+ * compute one path, and the two processes here are both olai computing it
+ * through this file. If a second program ever has to find olai's lock, the
+ * call is the right answer. The unix-socket module is already in this file's
+ * graph for `isPrivateOwnedDir`; the reason this path is still local is the
+ * meeting-vs-computing distinction, not a desire to keep the module out.
  *
  * NOT `os.tmpdir()`, and that is the whole reason this is not one line: it
  * honours `$TMPDIR`, which differs by LAUNCH CONTEXT — a launchd- or
@@ -289,46 +290,20 @@ const openLock = (path: string): number | LockUnavailable => {
   const directory = dirname(path)
   try {
     fs.mkdirSync(directory, { recursive: true, mode: 0o700 })
-    const wrong = notPrivatelyOurs(directory)
-    if (wrong !== null) return new LockUnavailable({ path, reason: wrong })
+    // mkdirSync's mode applies only when the directory is CREATED. A
+    // pre-existing `/tmp/olai-$UID` is exactly the case it cannot speak for,
+    // so we ask the same predicate the unix-socket serve path uses. A failed
+    // lstat throws into this try and becomes LockUnavailable via reasonOf —
+    // the same fold mkdir and open already take. A false is "the directory
+    // exists and is not ours."
+    if (!isPrivateOwnedDir(directory)) {
+      return new LockUnavailable({
+        path,
+        reason: `${directory} is not a private owner-only directory`,
+      })
+    }
     return fs.openSync(path, fs.constants.O_RDWR | fs.constants.O_CREAT, 0o600)
   } catch (cause) {
     return new LockUnavailable({ path, reason: reasonOf(cause) })
   }
-}
-
-/**
- * Why the directory the lock sits in has to be interrogated rather than just
- * created: off systemd it is a FIXED path, `/tmp/olai-$UID`, and anybody on the
- * machine can get there first. A directory somebody else prepared is a
- * directory they can hold a lock in — and olai would then report a stranger's
- * claim as another olai of the reader's own, and refuse to serve their notes
- * until they worked out why.
- *
- * Three predicates, and `mkdirSync`'s `mode` is none of them: it applies only
- * when the directory is CREATED, so a pre-existing one is exactly the case it
- * cannot speak for.
- *
- *   - `lstat`, never `stat`: `stat` follows a symlink, so a link left at the
- *     path pointing somewhere owner-private would answer "yours" about a
- *     directory that is not the one at this path.
- *   - it must be a directory at all.
- *   - it must be ours, and closed to group and other.
- *
- * The list is `isPrivateOwnedDir` from `@kolu/surface`'s unix-socket module,
- * which guards the same fixed path against the same person, and whose docstring
- * argues each of the three. It is not exported, so this is the three predicates
- * rather than the call; if upstream ever exports it, this function is the thing
- * to delete.
- */
-const notPrivatelyOurs = (directory: string): string | null => {
-  const info = fs.lstatSync(directory)
-  if (!info.isDirectory()) return `${directory} is not a directory`
-  const us = process.getuid?.()
-  if (us !== undefined && info.uid !== us) {
-    return `${directory} belongs to uid ${info.uid}, not to you`
-  }
-  return (info.mode & 0o077) === 0
-    ? null
-    : `${directory} is open to other users (mode ${(info.mode & 0o777).toString(8)})`
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -13,10 +13,10 @@
   },
   "//dependencies": "No workspace sibling, deliberately: the store is generic over its content and must not know what an outline is (docs/brainstorming/architecture.live-store.md). If @olai/format ever appears here, the seam has leaked.",
   "dependencies": {
-    "effect": "4.0.0-beta.106"
+    "effect": "4.0.0-rc.110"
   },
   "//devDependencies": "@effect/platform-node is the FileSystem the unit tests probe a real temp directory through. It is a DEV dependency and stays one: the store asks for the `FileSystem` service and never names an implementation, which is what lets the same probe run under the server's Node layer, a test's, and whatever the browser or a worker would bring. Pinned with the rest of the fleet — see the root package.json overrides.",
   "devDependencies": {
-    "@effect/platform-node": "4.0.0-beta.106"
+    "@effect/platform-node": "4.0.0-rc.110"
   }
 }

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -17,6 +17,6 @@
   "dependencies": {
     "@olai/acp": "workspace:*",
     "@olai/format": "workspace:*",
-    "effect": "4.0.0-beta.106"
+    "effect": "4.0.0-rc.110"
   }
 }

--- a/packages/tests/step_definitions/fault_steps.ts
+++ b/packages/tests/step_definitions/fault_steps.ts
@@ -16,6 +16,12 @@
  * dependency's module initialisation, or the fault card itself, and the
  * scenario would be proving something else.
  *
+ * Effect rc.110 is that dependency: `Encoding.ts` fills a 256-entry hex table
+ * at import with `i.toString(16).padStart(2, "0")`. That runs before there is
+ * a tree to replace, so throwing on the first `(2, "0")` is a white tab for a
+ * reason this scenario is not about. Those 256 are skipped; what throws is the
+ * next `(2, "0")`, which is the client's own date pad, during a render.
+ *
  * The coupling that buys is real and is answered rather than hidden: if that
  * call ever stops happening, the app draws itself perfectly and the step below
  * fails saying exactly that, in a second, instead of timing out with nothing
@@ -45,13 +51,19 @@ Given(
   async function (this: OlaiWorld) {
     await this.page.addInitScript((message: string) => {
       const padStart = String.prototype.padStart;
+      // Effect's hex table at import: one pad per byte, before any render.
+      let hexTable = 256;
       String.prototype.padStart = function (
         this: string,
         length: number,
         fill?: string,
       ): string {
-        // `(2, "0")` is the client's own call and nobody else's plausible one.
-        if (length === 2 && fill === "0") throw new Error(message);
+        // `(2, "0")` is the client's date pad — after the hex table, not
+        // instead of it. See the file header.
+        if (length === 2 && fill === "0") {
+          if (hexTable > 0) hexTable -= 1;
+          else throw new Error(message);
+        }
         return padStart.call(this, length, fill);
       };
     }, THROWN);

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -16,7 +16,7 @@
     "@olai/surface": "workspace:*",
     "@solid-primitives/keyed": "^1.5.3",
     "@solid-primitives/scheduled": "^1.5.3",
-    "effect": "4.0.0-beta.106",
+    "effect": "4.0.0-rc.110",
     "highlight.js": "^11.11.1",
     "lowlight": "^3.3.0",
     "rehype-autolink-headings": "^7.1.0",


### PR DESCRIPTION
The copy in `lock.ts` already named its own death: [if upstream ever exports `isPrivateOwnedDir`, this function is the thing to delete](https://github.com/juspay/olai/blob/master/packages/server/src/lock.ts#L318-L334). **kolu [#2186](https://github.com/juspay/kolu/pull/2186) exported it** (`1b3c20b5`). The deletion is the installation — no wrapper.

`openLock` already folded `mkdir`/`open` failures into `LockUnavailable` via `reasonOf`. A thrown `lstat` takes that same catch; a `false` (the directory exists and is not ours) is the one new sentence. Verified against the two `LockUnavailable` boots, not assumed.

The pin is that squash, which also moves Effect to `4.0.0-rc.110`. `formatLogFmt` now writes `level=INFO`; the log tests and the example lines in the two READMEs follow.

### Try it locally

```sh
nix run github:juspay/olai/private-dir-export
```

_Generated by Grok (model `grok-4.6`)._