### PR TITLE
The user unit comes back after a stray SIGTERM — the ledger stays up (olai-service-sigterm)

### DIFF
--- a/docs/RCA/2026-08-20-olai-service-sigterm.md
+++ b/docs/RCA/2026-08-20-olai-service-sigterm.md
@@ -1,0 +1,83 @@
+# RCA: olai.service died by outside SIGTERM, twice in one night, and stayed down (2026-08-20)
+
+**Status**: unit fixed (`Restart=always` + `RestartSec=1s`, `SuccessExitStatus=130` kept); sender of the SIGTERM unknown after ruling out every kill path in this repo (and the odu/kolu tooling the overnight lanes were running).
+
+## Timeline (host journal, 2026-08-19 evening → 2026-08-20 morning)
+
+Live unit (`systemctl --user cat olai.service`, home-manager generated from `nix/home/module.nix`):
+
+```
+ExecStart=/nix/store/…-olai/bin/olai web /home/srid/code/olai/docs --port 7714 --host 127.0.0.1
+Restart=on-failure
+SuccessExitStatus=130
+```
+
+`journalctl --user -u olai --since "2026-08-19 20:00"`, lifecycle lines only:
+
+| time | what |
+|---|---|
+| 20:49:45 | `olai web: received SIGTERM` + systemd `Stopped` + `Started` — a deliberate `systemctl` restart |
+| 23:06:33 | `olai web: received SIGTERM`; systemd `Consumed 2min 6s CPU time over 2h 16min wall clock…`. **No** `Stopping`/`Stopped`, **no** restart. Unit went inactive. |
+| 00:52:15 | systemd `Started` — orchestrator restarted it by hand, 105 min later |
+| 06:01:09 | `olai web: received SIGTERM`; systemd `Consumed 4min 23s CPU time over 5h 8min wall clock…`. Again: no Stopping/Stopped, no restart. |
+| 06:51:32 | systemd `Started` — restarted by hand, 50 min later |
+| 08:12:02 | `received SIGTERM` / `Stopped` / `Started` — deliberate restart (new store path) |
+
+`systemctl --user show olai` after the last hand-start: `ActiveState=active`, `NRestarts=0`, `Result=success`.
+
+The two deaths that went dark (23:06, 06:01) both fell inside windows of heavy `nix-daemon` activity by this user — overnight agent lanes running e2e/CI in `.worktrees/*`.
+
+## Mechanism
+
+The roadmap note's "the service has no `Restart=`" was stale. The unit already had `Restart=on-failure`. Effect's `runMain` handles SIGTERM, writes `olai web: received SIGTERM` to stderr, and **exits 130**. `SuccessExitStatus=130` declares that a clean success, so `systemctl stop` does not land the unit in failed — which is the right call for a deliberate stop.
+
+The two lines together are exactly the configuration that makes a stray SIGTERM take the ledger down for hours: `on-failure` does not restart a successful exit. systemd's table (`man systemd.service`, `Restart=`) is unambiguous — a clean exit (exit 0, or a status listed in `SuccessExitStatus=`) restarts only under `always` / `on-success`, not under `on-failure`.
+
+`Restart=always` is the fix that keeps the two properties we want:
+
+- A SIGTERM that did **not** come from systemd comes back after `RestartSec=1s`.
+- A death that **was** a systemd operation is never restarted: "When the death of the process is a result of systemd operation (e.g. service stop or restart), the service will not be restarted" (`man systemd.service`, `Restart=`). `systemctl stop` / `restart` stay deliberate.
+
+`SuccessExitStatus=130` stays. Dropping it would make every clean stop a failed unit.
+
+## Launchd (parity check, not a Darwin incident)
+
+The Darwin agent is `KeepAlive.SuccessfulExit=false` + `Crashed=true`. `launchd.plist(5)`: `SuccessfulExit=false` restarts on the inverse of a zero exit, so a 130 **already restarts there** — 130 is non-zero, and Effect exits rather than dying of an uncaught signal, so the `Crashed=` arm is not the one that fires. `KeepAlive=true` would also restart a clean 0, which `olai web` never does (it waits until interrupted). `launchctl bootout` stays a deliberate stop either way. Linux was the gap; Darwin already survived the incident's exit.
+
+## Sender
+
+Something sent SIGTERM **straight to the process**. systemd did not stop the unit: the 20:49 and 08:12 restarts have `Stopped`/`Started` pairs; the 23:06 and 06:01 deaths have neither. A `systemctl kill` or a raw `kill -TERM <mainpid>` would look like this; a `systemctl stop` would not.
+
+**Not found in this repo.** Every kill path was read. None of them can hit the 7714 user unit:
+
+| suspect | what it actually kills | signal | why it cannot be 7714 |
+|---|---|---|---|
+| e2e harness (`packages/tests/support/hooks.ts` `killChild`, `stopOwnServer`) | the `ChildProcess` it spawned | **SIGKILL**, not SIGTERM | no `--port` unless a `@scratch:` scenario is restarting *its own* already-bound OS-assigned port; the harness's own comment: "two worktrees cannot pick the same number and cannot squat production" |
+| `underload.sh` | the busy-wait `bash -c 'while :'` loops it spawned | SIGTERM of those pids | never names olai |
+| `wire.sh` / `evidence.sh` / `support/serve.sh` | `$OLAI_SERVER`, which is `$!` of the bun they just spawned | SIGTERM of that child | port 0 unless `PORT=` is set, and `olai_port_free` **refuses** an explicit port something else is already serving. Pid is not read from `.olai-dev/url` |
+| `just serve` | `trap 'kill 0'` — this recipe's process group | SIGTERM of the group | a systemd user unit is its own cgroup; it is not in the recipe's group |
+| `just run` | nothing; writes `.olai-dev/url` (`url` + `pid=`) | — | nothing in this repo reads that pid and kills it. Docs say `curl` the URL to check staleness |
+| packaged `olai web` (`packages/server`) | `process.kill(pid, 0)` is a liveness probe (signal 0) in `lock.ts`; tests `child.kill()` their own children | 0 / test-only | no process-group or parent signal on shutdown |
+| ACP child (`packages/chat/src/agent.ts` `stop`) | `at.child.kill()` — the agent subprocess this server spawned | default SIGTERM of **the child** | the parent is the server; killing the child does not signal the parent |
+| `packages/acp` | — | — | no `kill` at all |
+| `scripts/` | hydrate / kolu-deps / bun-test-preload | — | no process control |
+
+**Read, not changed, outside this repo:**
+
+- `~/.config/odu` is `hosts.json`. No kill scripts. odu's own `cancel`/`supersede` tears down a CI coordinator in a checkout, not `olai.service`.
+- `~/code/kolu/.worktrees/master`: `justfile` `dev-clean` `kill -TERM`s padi/kaval pids from *their* runtime dir, with a state-root manifest check so it will not touch a foreign pid. No `pkill -f olai`, no `lsof -ti:7714`.
+
+No `pkill -f "olai web"`, no `lsof -ti:7714 | xargs kill`, no stale-`.olai-dev/url`-pid kill exists in this tree. A guess that "nix-daemon did it" because the deaths sat in busy-build windows is not a finding — nix sandboxing is a PID namespace; a build's teardown cannot signal the host's user unit. The sender is **unknown**. Next time: the unit comes back in a second, and the `received SIGTERM` line plus the absence of systemd `Stopped` still names an outside signal.
+
+## Fix
+
+`nix/home/module.nix` (asserted by `nix/home/check.nix`, described by `docs/running.md`):
+
+- Linux: `Restart=always`, `RestartSec=1s`, `SuccessExitStatus=130` kept.
+- Darwin: KeepAlive dict unchanged (already restarts 130); comment now says so.
+
+## How we'd know next time
+
+- Journal still prints `olai web: received SIGTERM`.
+- A systemd-initiated stop has `Stopping`/`Stopped`. An outside SIGTERM does not — and, with this unit, is followed by a start ~1s later (`NRestarts` increments, `ActiveState=active`).
+- If it does **not** come back, the start limiter fired (`StartLimitBurst=` / `StartLimitIntervalSec=`, systemd defaults) or the unit was actually stopped. `systemctl --user status olai` says which.

--- a/docs/RCA/2026-08-20-olai-service-sigterm.md
+++ b/docs/RCA/2026-08-20-olai-service-sigterm.md
@@ -1,6 +1,6 @@
 # RCA: olai.service died by outside SIGTERM, twice in one night, and stayed down (2026-08-20)
 
-**Status**: unit fixed (`Restart=always` + `RestartSec=1s`, `SuccessExitStatus=130` kept); sender of the SIGTERM unknown after ruling out every kill path in this repo (and the odu/kolu tooling the overnight lanes were running).
+**Status**: module fixed (`Restart=always` + `RestartSec=1s`, `SuccessExitStatus=130` kept) — the live unit gains `Restart=always` at the host's next home-manager switch; sender of the SIGTERM unknown after ruling out every kill path in this repo (and the odu/kolu tooling the overnight lanes were running).
 
 ## Timeline (host journal, 2026-08-19 evening → 2026-08-20 morning)
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -54,7 +54,7 @@ Put it behind a reverse proxy or `tailscale serve` and the browser's origin will
 
 It says what it is doing on stdout, one line per event, quietly: the address it bound, the agent it started, and anything that went wrong. `--log-level debug` turns on the rest, including everything the agent itself writes.
 
-A SIGINT or SIGTERM writes `olai web: received SIGTERM` (or `SIGINT`) to stderr before the process unwinds. Effect still treats the interrupt as a successful stop and exits 130 — the shipped user unit counts 130 as success so `systemctl stop` is not a failed unit. On Linux the unit is `Restart=always` with `RestartSec=1s`, so a SIGTERM that did not come from systemd comes back in a second; systemd never restarts a unit it stopped itself (`man systemd.service`, `Restart=` — `systemctl stop` / `restart` stay deliberate). That one line on stderr is still what lets a journal tell a signaled death from a deliberate stop. On macOS, launchd's `KeepAlive.SuccessfulExit=false` already restarts a 130 exit (it is non-zero); `launchctl bootout` is the deliberate stop.
+A SIGINT or SIGTERM writes `olai web: received SIGTERM` (or `SIGINT`) to stderr before the process unwinds. Effect still treats the interrupt as a successful stop and exits 130 — the shipped user unit counts 130 as success so `systemctl stop` is not a failed unit, and on Linux `Restart=always` still brings a stray SIGTERM back (see [As a user service](#as-a-user-service-home-manager)). That one line is what lets a journal tell a signaled death from a deliberate stop.
 
 ## As a user service (home-manager)
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -54,7 +54,7 @@ Put it behind a reverse proxy or `tailscale serve` and the browser's origin will
 
 It says what it is doing on stdout, one line per event, quietly: the address it bound, the agent it started, and anything that went wrong. `--log-level debug` turns on the rest, including everything the agent itself writes.
 
-A SIGINT or SIGTERM writes `olai web: received SIGTERM` (or `SIGINT`) to stderr before the process unwinds. Effect still treats the interrupt as a successful stop and exits 130 — the shipped user unit counts 130 as success so `systemctl stop` is not a failed unit — and that one line is what lets a journal tell a signaled death from a deliberate stop.
+A SIGINT or SIGTERM writes `olai web: received SIGTERM` (or `SIGINT`) to stderr before the process unwinds. Effect still treats the interrupt as a successful stop and exits 130 — the shipped user unit counts 130 as success so `systemctl stop` is not a failed unit. On Linux the unit is `Restart=always` with `RestartSec=1s`, so a SIGTERM that did not come from systemd comes back in a second; systemd never restarts a unit it stopped itself (`man systemd.service`, `Restart=` — `systemctl stop` / `restart` stay deliberate). That one line on stderr is still what lets a journal tell a signaled death from a deliberate stop. On macOS, launchd's `KeepAlive.SuccessfulExit=false` already restarts a 130 exit (it is non-zero); `launchctl bootout` is the deliberate stop.
 
 ## As a user service (home-manager)
 
@@ -79,6 +79,8 @@ inputs.olai.url = "github:juspay/olai";
 ```
 
 The module fills `package` from the flake for the host platform. The packaged binary already bakes the browser bundle (`OLAI_DIST_DIR`), so the service needs no ambient environment.
+
+On Linux the unit is `Restart=always` / `RestartSec=1s` / `SuccessExitStatus=130`. A stray `kill -TERM` of the main pid is a successful exit that systemd still brings back; a `systemctl --user stop olai` is a systemd stop, which `Restart=` never overrides. On macOS the agent is `KeepAlive.SuccessfulExit=false` and `Crashed=true` — a 130 exit already restarts there, because launchd treats non-zero as unsuccessful. The 2026-08-20 incident (an outside SIGTERM, `on-failure` + `SuccessExitStatus=130`, hours of dark ledger) is [the RCA](RCA/2026-08-20-olai-service-sigterm.md).
 
 ## Agents, over HTTP
 

--- a/nix/home/check.nix
+++ b/nix/home/check.nix
@@ -77,8 +77,11 @@ let
   execPlain = builtins.unsafeDiscardStringContext execStart;
   _linux =
     assert linuxService.Unit.Description == "olai web view";
-    assert linuxService.Service.Restart == "on-failure";
+    assert linuxService.Service.Restart == "always";
+    assert linuxService.Service.RestartSec == "1s";
     # Effect runMain exits 130 on SIGTERM; without this, clean stops are failed.
+    # Kept with Restart=always: a stray SIGTERM must come back, and a
+    # systemctl stop must not land the unit in failed.
     assert linuxService.Service.SuccessExitStatus == 130;
     assert linuxService.Install.WantedBy == [ "default.target" ];
     assert lib.hasInfix exePlain execPlain;
@@ -96,6 +99,10 @@ let
   _darwin =
     assert darwinAgent.enable == true;
     assert darwinAgent.config.RunAtLoad == true;
+    # launchd.plist(5): SuccessfulExit=false restarts on a non-zero exit,
+    # so a 130 (Effect's SIGTERM) already comes back — unlike systemd's
+    # on-failure + SuccessExitStatus=130, which treated 130 as success
+    # and did not restart. Crashed=true is the signal-death arm.
     assert darwinAgent.config.KeepAlive.SuccessfulExit == false;
     assert darwinAgent.config.KeepAlive.Crashed == true;
     assert darwinAgent.config.StandardOutPath == "/home/alice/Library/Logs/olai.out.log";

--- a/nix/home/check.nix
+++ b/nix/home/check.nix
@@ -100,9 +100,8 @@ let
     assert darwinAgent.enable == true;
     assert darwinAgent.config.RunAtLoad == true;
     # launchd.plist(5): SuccessfulExit=false restarts on a non-zero exit,
-    # so a 130 (Effect's SIGTERM) already comes back — unlike systemd's
-    # on-failure + SuccessExitStatus=130, which treated 130 as success
-    # and did not restart. Crashed=true is the signal-death arm.
+    # so a 130 (Effect's SIGTERM) already comes back. Crashed=true is the
+    # signal-death arm.
     assert darwinAgent.config.KeepAlive.SuccessfulExit == false;
     assert darwinAgent.config.KeepAlive.Crashed == true;
     assert darwinAgent.config.StandardOutPath == "/home/alice/Library/Logs/olai.out.log";

--- a/nix/home/module.nix
+++ b/nix/home/module.nix
@@ -67,12 +67,21 @@ in
         };
         Service = {
           ExecStart = lib.escapeShellArgs webArgs;
-          Restart = "on-failure";
+          # always, not on-failure: Effect's runMain exits 130 on SIGTERM,
+          # SuccessExitStatus below declares that a success, and on-failure
+          # does not restart a successful exit. A stray kill -TERM then
+          # left the ledger dark for hours (docs/RCA/2026-08-20-olai-service-sigterm.md).
+          # systemd never restarts a unit whose death was a systemd stop or
+          # restart (man systemd.service, Restart=), so systemctl stop stays
+          # a stop.
+          Restart = "always";
+          RestartSec = "1s";
           # Effect's runMain exits 130 when the main fiber is interrupted
-          # (SIGTERM from systemctl stop / session teardown). Without this,
-          # every clean stop lands the unit in failed. The process writes
-          # `olai web: received SIGTERM` to stderr first, so a non-systemctl
-          # SIGTERM is still a successful unit but is not a silent one.
+          # (SIGTERM from systemctl stop / session teardown / an outside
+          # signal). Without this, every clean stop lands the unit in failed.
+          # The process writes `olai web: received SIGTERM` to stderr first,
+          # so a non-systemctl SIGTERM is still a successful unit but is not
+          # a silent one.
           SuccessExitStatus = 130;
         };
         Install = {
@@ -87,8 +96,12 @@ in
         config = {
           ProgramArguments = webArgs;
           RunAtLoad = true;
-          # Match systemd's on-failure: restart on a non-zero exit OR a crash
-          # signal, not only a successful one.
+          # A 130 exit is non-zero, so SuccessfulExit=false already restarts
+          # it — the Linux incident's case, without needing KeepAlive=true
+          # (which would also restart a clean 0 that `olai web` never does;
+          # it waits until interrupted). Crashed=true covers a signal death
+          # that never became an exit status. launchctl bootout stays a
+          # deliberate stop either way.
           KeepAlive = {
             SuccessfulExit = false;
             Crashed = true;

--- a/nix/home/module.nix
+++ b/nix/home/module.nix
@@ -67,21 +67,16 @@ in
         };
         Service = {
           ExecStart = lib.escapeShellArgs webArgs;
-          # always, not on-failure: Effect's runMain exits 130 on SIGTERM,
-          # SuccessExitStatus below declares that a success, and on-failure
-          # does not restart a successful exit. A stray kill -TERM then
-          # left the ledger dark for hours (docs/RCA/2026-08-20-olai-service-sigterm.md).
-          # systemd never restarts a unit whose death was a systemd stop or
-          # restart (man systemd.service, Restart=), so systemctl stop stays
-          # a stop.
+          # One policy, three knobs. Effect's runMain exits 130 on SIGTERM.
+          # SuccessExitStatus=130 keeps systemctl stop out of failed.
+          # Restart=always (not on-failure) still brings a stray kill -TERM
+          # back: on-failure does not restart a successful exit, which is
+          # how two outside SIGTERMs left the ledger dark for hours
+          # (docs/RCA/2026-08-20-olai-service-sigterm.md). systemd never
+          # restarts a unit whose death was a systemd stop or restart
+          # (man systemd.service, Restart=).
           Restart = "always";
           RestartSec = "1s";
-          # Effect's runMain exits 130 when the main fiber is interrupted
-          # (SIGTERM from systemctl stop / session teardown / an outside
-          # signal). Without this, every clean stop lands the unit in failed.
-          # The process writes `olai web: received SIGTERM` to stderr first,
-          # so a non-systemctl SIGTERM is still a successful unit but is not
-          # a silent one.
           SuccessExitStatus = 130;
         };
         Install = {


### PR DESCRIPTION
## What changed and why

Twice in one night (23:06 and 06:01, 2026-08-19→20) `olai.service` received SIGTERM, exited 130, and stayed down — 105 min and 50 min of dark ledger — until the orchestrator started it by hand. systemd logged no `Stopping`/`Stopped`; this was not a `systemctl stop`.

The roadmap note's "the service has no `Restart=`" was stale. The unit already had `Restart=on-failure`. Effect's `runMain` exits 130 on interrupt, and `SuccessExitStatus=130` declares that a success so a clean `systemctl stop` is not a failed unit. `on-failure` does not restart a successful exit. Those two lines together are the configuration that makes a stray SIGTERM take the ledger down for hours.

**Linux** (`nix/home/module.nix`): `Restart=always` + `RestartSec=1s`. `SuccessExitStatus=130` stays — clean stops must not land the unit in failed. systemd never restarts a unit whose death was a systemd stop or restart (`man systemd.service`, `Restart=`), so `systemctl stop` / `restart` stay deliberate while an outside signal costs a second.

**Darwin:** `KeepAlive.SuccessfulExit=false` / `Crashed=true` already restarts a 130 exit (`launchd.plist(5)`: `SuccessfulExit=false` restarts on a non-zero exit; 130 is non-zero; Effect exits rather than dying of an uncaught signal). `KeepAlive=true` would also restart a clean 0, which `olai web` never does. No launchd change; the comment now says this. Linux was the gap.

**Sender:** not found in this repo. Every kill path was read — e2e harness (`SIGKILL` of the child it spawned, OS-assigned ports), `underload.sh` / `wire.sh` / `evidence.sh` / `serve.sh` (their own `$!`), `just serve`'s `kill 0` (the recipe's process group), `just run`'s `.olai-dev/url` `pid=` (nothing here kills it), `packages/server` (signal 0 liveness probe), ACP `child.kill()` (the agent subprocess, not the parent), `packages/acp` (no kill). `~/.config/odu` is `hosts.json`; kolu `dev-clean` SIGTERMs padi/kaval from *their* runtime dir. No `pkill -f "olai web"`, no `lsof -ti:7714`. A guess that nix-daemon did it because the deaths sat in busy-build windows is not a finding. Full ruled-out list: `docs/RCA/2026-08-20-olai-service-sigterm.md`.

`docs/running.md` describes the unit that ships (the SIGTERM paragraph points at the user-service knobs). `nix/home/check.nix` asserts `Restart=always`, `RestartSec=1s`, and the unchanged 130 / launchd KeepAlive keys.

## Verification

Production `olai.service` (pid 131029, port 7714) was not stopped, restarted, or signaled. Read-only `is-active` / `show` / `ss` before and after: still `active`, same pid, still `127.0.0.1:7714`.

### hm-module check

```
$ nix eval --impure --raw --expr builtins.currentSystem
x86_64-linux
$ nix build .#checks.x86_64-linux.hm-module --no-link --print-out-paths --accept-flake-config
/nix/store/xbgzblr8yirawmna999nklicbi4f7y8z-olai-hm-module-check
```

### Transient user units against the built binary

Binary: `/nix/store/6whc2shshps24wl1r4va268c0inhfhnb-olai` (`nix build .#olai`). Two throwaway units, OS-assigned ports (41401 / 46643 / 45289), never 7714. Both `SuccessExitStatus=130`; `OLAI_ACP_AGENT=` empty so no chat agent.

**`Restart=always` `RestartSec=1s` — comes back:**

```
$ systemd-run --user --unit=olai-probe-always --service-type=simple \
    --setenv=OLAI_ACP_AGENT= \
    --property=Restart=always --property=RestartSec=1s \
    --property=SuccessExitStatus=130 --no-block \
    -- $BIN web $vault --port 0 --host 127.0.0.1
Running as unit: olai-probe-always.service

$ systemctl --user show olai-probe-always -p ActiveState,NRestarts,MainPID,Result
ActiveState=active
NRestarts=0
MainPID=249005
Result=success

$ kill -TERM 249005
$ sleep 3
$ systemctl --user show olai-probe-always -p ActiveState,NRestarts,MainPID,Result
ActiveState=active
NRestarts=1
MainPID=249066
Result=success
```

Journal (same shape as the incident's `Consumed … wall clock` line, then a restart the incident never got):

```
olai[249005]: olai web: received SIGTERM
systemd: olai-probe-always.service: Consumed 857ms CPU time over 1.085s wall clock time, 179.4M memory peak.
systemd: olai-probe-always.service: Scheduled restart job, restart counter is at 1.
systemd: Started …
olai[249066]: serving … url=http://127.0.0.1:46643
```

**Contrast — `Restart=on-failure` (the old unit) stays dead:**

```
$ systemd-run --user --unit=olai-probe-on-failure --service-type=simple \
    --setenv=OLAI_ACP_AGENT= \
    --property=Restart=on-failure \
    --property=SuccessExitStatus=130 --no-block \
    -- $BIN web $vault --port 0 --host 127.0.0.1
Running as unit: olai-probe-on-failure.service

$ systemctl --user show olai-probe-on-failure -p ActiveState,NRestarts,MainPID,Result
ActiveState=active
NRestarts=0
MainPID=249124
Result=success

$ kill -TERM 249124
$ sleep 3
$ systemctl --user show olai-probe-on-failure -p ActiveState,NRestarts,MainPID,Result
ActiveState=inactive
NRestarts=0
MainPID=0
Result=success
```

Journal (the incident: SIGTERM, Consumed, no Scheduled restart):

```
olai[249124]: olai web: received SIGTERM
systemd: olai-probe-on-failure.service: Consumed 857ms CPU time over 1.044s wall clock time, 182.9M memory peak.
```

Probe units stopped afterwards (`ActiveState=inactive`). Production MainPID still 131029.

## Deferrals

No deferrals.