### PR TITLE
A link in the agent's answer opens the page, not a cold reload of the app (chat-links-reload)

### DIFF
--- a/docs/chat.md
+++ b/docs/chat.md
@@ -156,6 +156,8 @@ Three things in the conversation are ids, and none of them is a syntax anybody h
 
 If the lookup itself fails, the panel says so at the end of the conversation — one line, because one question carries every message's ids. The words are all still there; what is missing is which of them can be pressed.
 
+**A link the agent writes is a link**, and it behaves like every other link in this app: a path to a document (`notes/plan.md`) or an address of olai's own (`/house.olai`, `/#order`, `/today`) opens in the pane you were last reading, in place, with the conversation still beside it — and Alt+click opens it in a pane to the right. A `https://` one opens in a new tab, so a click can never throw the app away.
+
 ## What it shows when it changes something
 
 A tool call is one folded line, and what the call CHANGED is not folded away — the arguments are what was asked for, and this is what happened to your files. There are two kinds of change and the panel draws them differently, because they are different things.

--- a/packages/tests/agent/fake-acp-agent.ts
+++ b/packages/tests/agent/fake-acp-agent.ts
@@ -20,6 +20,9 @@
  * Behaviour is keyed on the prompt text, so a scenario asks for what it needs:
  *
  *   name <id>    say that id in backticks, and nothing else
+ *   links        write two LINKS in prose — a relative `.md` path and an
+ *                address of this app — which is what an agent asked about a
+ *                vault does unprompted, and what used to reload the whole app
  *   done <id>    call `set_done` on that node, then say so
  *   add <title>  call `add_node` under the first outline's first root
  *   edit [file]  report a DIRECT file edit, as a `diff` content block — an
@@ -1565,6 +1568,23 @@ const runTurn = async (id: unknown, text: string): Promise<void> => {
   // this exists for: `set_done` refuses one, and an agent still writes them).
   if (verb === "name") {
     say(`look at \`${argument}\`.`)
+    respond(id, { stopReason: "end_turn" })
+    return
+  }
+
+  // LINKS in prose, which is what an agent asked about a vault writes without
+  // being taught to: a relative path to a document (the renderer resolves it
+  // against the file the markdown was written in, and an agent's answer was
+  // written in no file, so it is resolved from the root) and an address of
+  // this app spelled out. Both are ANCHORS in rendered markdown belonging to
+  // no component — which is why they are worth a verb: the panel is mounted
+  // beside the panes, so nothing above them catches the click, and for a while
+  // one of these reloaded the whole app.
+  if (verb === "links") {
+    say(
+      "the note is [the cabinets note](notes/cabinets.md) " +
+        "and the row is [the order row](/#order).\n",
+    )
     respond(id, { stopReason: "end_turn" })
     return
   }

--- a/packages/tests/features/the_agent.feature
+++ b/packages/tests/features/the_agent.feature
@@ -267,6 +267,41 @@ Feature: Talking to the agent
     And the agent's answer mentions "[image]"
 
   @scratch:chat
+  Scenario: A link the agent wrote opens the page it names, in place
+    # THE REGRESSION THIS EXISTS FOR. The panel is mounted BESIDE the panes, so
+    # an anchor in a rendered answer had nothing above it to catch the click:
+    # a `.md` path the renderer had resolved, and an address of this app the
+    # agent spelled out, both fell through to the browser's default and loaded
+    # the whole app cold — taking the conversation that was on screen with it.
+    When I ask the agent "links"
+    Then the agent's answer mentions "the cabinets note"
+    When I follow the link "the cabinets note" in the agent's answer
+    Then the address is "/notes/cabinets.md"
+    # The line that tells a navigation from a load. Without it a full reload
+    # passes every other assertion here — it lands on this very document.
+    And the page has not reloaded
+    # ...which is what the reader would have lost: the transcript is still the
+    # one they were reading.
+    And the chat shows my message "links"
+    # The other half, and a different path through the renderer: an app address
+    # in an answer is written as-is and rewritten by nothing.
+    When I follow the link "the order row" in the agent's answer
+    Then the address is "/#order"
+    And the page has not reloaded
+
+  @scratch:chat
+  Scenario: Alt+click on a link the agent wrote opens it to the right
+    # A written link inside a pane has given this for free since panes existed.
+    # The panel asks the router the same question the pane does, so a link in a
+    # drawer is not a second kind of link with a shorter list of gestures.
+    When I ask the agent "links"
+    Then the agent's answer mentions "the cabinets note"
+    When I alt-click the link "the cabinets note" in the agent's answer
+    Then there are 2 panes
+    And pane 1 is showing "/notes/cabinets.md"
+    And the page has not reloaded
+
+  @scratch:chat
   Scenario: The input completes the agent's own slash commands
     # The list is the AGENT'S — olai keeps none of its own — so what is offered
     # is whatever that agent reported over the session.

--- a/packages/tests/step_definitions/chat_steps.ts
+++ b/packages/tests/step_definitions/chat_steps.ts
@@ -244,6 +244,34 @@ Then(
   },
 );
 
+/** A link the agent WROTE, found by the words it is written under.
+ *
+ *  By its text and not by an attribute, because there is no attribute to find:
+ *  an anchor in rendered markdown is markup the pipeline produced and belongs
+ *  to no component, which is the whole reason a click on one had to be caught
+ *  by a listener on the panel rather than by a handler on the element. Scoped
+ *  to the ANSWER so a scenario cannot accidentally press a link somewhere else
+ *  in the transcript. */
+const answerLink = (world: OlaiWorld, text: string): Locator =>
+  world.page.locator(`${CHAT_SAID} a`).filter({ hasText: text }).first();
+
+When(
+  "I follow the link {string} in the agent's answer",
+  async function (this: OlaiWorld, text: string) {
+    await this.press(answerLink(this, text));
+  },
+);
+
+When(
+  "I alt-click the link {string} in the agent's answer",
+  async function (this: OlaiWorld, text: string) {
+    const link = answerLink(this, text);
+    await link.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await link.click({ modifiers: ["Alt"] });
+    await this.waitForFrame();
+  },
+);
+
 /** A bubble of my own, by what it says. Two steps ask for one — "the chat
  *  shows my message X" and "… as not sent" — and which element counts as mine
  *  is one answer, not two. */

--- a/packages/tests/step_definitions/chat_steps.ts
+++ b/packages/tests/step_definitions/chat_steps.ts
@@ -265,10 +265,7 @@ When(
 When(
   "I alt-click the link {string} in the agent's answer",
   async function (this: OlaiWorld, text: string) {
-    const link = answerLink(this, text);
-    await link.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await link.click({ modifiers: ["Alt"] });
-    await this.waitForFrame();
+    await this.press(answerLink(this, text), "click", ["Alt"]);
   },
 );
 

--- a/packages/tests/step_definitions/pane_steps.ts
+++ b/packages/tests/step_definitions/pane_steps.ts
@@ -31,20 +31,14 @@ const paneAt = (world: OlaiWorld, index: number) => world.pane(index);
 When(
   "I alt-click the zoom of {string}",
   async function (this: OlaiWorld, id: string) {
-    const zoom = this.within(id, ZOOM);
-    await zoom.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await zoom.click({ modifiers: ["Alt"] });
-    await this.waitForFrame();
+    await this.press(this.within(id, ZOOM), "click", ["Alt"]);
   },
 );
 
 When(
   "I alt-shift-click the zoom of {string}",
   async function (this: OlaiWorld, id: string) {
-    const zoom = this.within(id, ZOOM);
-    await zoom.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await zoom.click({ modifiers: ["Alt", "Shift"] });
-    await this.waitForFrame();
+    await this.press(this.within(id, ZOOM), "click", ["Alt", "Shift"]);
   },
 );
 
@@ -52,19 +46,14 @@ When(
   "I alt-click the zoom of {string} in pane {int}",
   async function (this: OlaiWorld, id: string, index: number) {
     const zoom = paneAt(this, index).locator(`${nodeSelector(id)} ${ZOOM}`).first();
-    await zoom.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await zoom.click({ modifiers: ["Alt"] });
-    await this.waitForFrame();
+    await this.press(zoom, "click", ["Alt"]);
   },
 );
 
 When(
   "I zoom into the node {string} in pane {int}",
   async function (this: OlaiWorld, id: string, index: number) {
-    const zoom = paneAt(this, index).locator(`${nodeSelector(id)} ${ZOOM}`).first();
-    await zoom.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await zoom.click();
-    await this.waitForFrame();
+    await this.press(paneAt(this, index).locator(`${nodeSelector(id)} ${ZOOM}`).first());
   },
 );
 

--- a/packages/tests/support/world.ts
+++ b/packages/tests/support/world.ts
@@ -1531,10 +1531,21 @@ export class OlaiWorld extends World {
    *  mouse, and finding out that a control is reachable without one is the
    *  whole point of tapping it. Everything around it — waiting for the thing
    *  to be visible, waiting out the frame the click schedules — is the same
-   *  either way, and was three copies before it was a parameter. */
-  async press(target: Locator, gesture: "click" | "tap" = "click"): Promise<void> {
+   *  either way, and was three copies before it was a parameter.
+   *
+   *  MODIFIERS are the second parameter for the same reason, and they arrived
+   *  the same way: an Alt-click opens a pane to the right, and every step that
+   *  wanted one had written the trio out again with `{ modifiers }` on the end
+   *  — four copies of the wait and the settle, each with its own spelling of
+   *  the timeout. A tap takes them too (Playwright's own option on both), so
+   *  this stays one call rather than a branch. */
+  async press(
+    target: Locator,
+    gesture: "click" | "tap" = "click",
+    modifiers?: ReadonlyArray<"Alt" | "Shift">,
+  ): Promise<void> {
     await target.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await target[gesture]();
+    await target[gesture](modifiers === undefined ? {} : { modifiers: [...modifiers] });
     await this.waitForFrame();
   }
 

--- a/packages/web/src/client/chat/Transcript.tsx
+++ b/packages/web/src/client/chat/Transcript.tsx
@@ -68,6 +68,7 @@ import { createEffect, createMemo, For, on, onCleanup, onMount, Show } from "sol
 
 import { SaidLine } from "../edit/SaidLine.tsx"
 import { useShowNode } from "../focus.ts"
+import { useFollow } from "../router.tsx"
 import { TESTID } from "../testids.ts"
 import { declaringFailure } from "./declared.ts"
 import { Entry } from "./Entry.tsx"
@@ -82,6 +83,7 @@ import type { Chat } from "./state.ts"
 
 export function Transcript(props: { readonly chat: Chat }) {
   const show = useShowNode()
+  const follow = useFollow()
   let pane: HTMLDivElement | undefined
   let content: HTMLDivElement | undefined
   /** Should new text pull the view down with it? True until the reader scrolls
@@ -208,8 +210,16 @@ export function Transcript(props: { readonly chat: Chat }) {
         }
         following = atBottom()
       }}
+      // A press the chips decline is still a press on the agent's markdown, and
+      // an anchor in there is an address in this vault: a `.md` link the
+      // renderer resolved (`../markdown/rewrite.ts`) or an app path the agent
+      // wrote. This panel is mounted BESIDE the panes, so nothing above it was
+      // ever going to catch one — they fell to the browser and reloaded the app
+      // cold. `useFollow` is the pane's own tail, and it lands in the focused
+      // pane, which is where a link pressed in a drawer belongs.
       onClick={(event) => {
-        pressed(event.target)
+        if (pressed(event.target)) return
+        follow(event)
       }}
       // The keyboard's half of the same control: a marked span is given
       // `role="button"` and a tab stop (`./refs.ts`), and those two promise

--- a/packages/web/src/client/pane/PageView.tsx
+++ b/packages/web/src/client/pane/PageView.tsx
@@ -33,7 +33,7 @@ import { Nothing } from "../Nothing.tsx"
 import { drawnBy, requestFor } from "../page.ts"
 import { createReading, ReadingProvider, useReadings } from "../reading.tsx"
 import { OutlinePage } from "../OutlinePage.tsx"
-import { followed, followedSplit, useGo, useHere, useRouter } from "../router.tsx"
+import { useFollow, useHere, useRouter } from "../router.tsx"
 import { filterOf, hrefOf, narrowable, narrowedTo, samePage } from "../routes.ts"
 import { panesOf } from "../workspace.ts"
 import { visibleIn } from "../settings/done.ts"
@@ -43,7 +43,7 @@ import { TrashPage } from "../trash/TrashPage.tsx"
 export function PageView() {
   const router = useRouter()
   const here = useHere()
-  const go = useGo()
+  const follow = useFollow()
   const today = useToday()
   const route = createMemo(() => panesOf(router.workspace())[here()]!.route)
   const opened = createMemo(route, undefined, { equals: samePage })
@@ -164,16 +164,7 @@ export function PageView() {
           narrow(tag)
           return
         }
-        const split = followedSplit(event)
-        if (split !== null) {
-          event.preventDefault()
-          router.openRight(here(), split, event.shiftKey)
-          return
-        }
-        const next = followed(event)
-        if (next === null) return
-        event.preventDefault()
-        go(next)
+        follow(event)
       }}
     >
       <ReadingProvider reading={reading}>

--- a/packages/web/src/client/router.tsx
+++ b/packages/web/src/client/router.tsx
@@ -303,10 +303,18 @@ export const followedSplit = (event: MouseEvent): Route | null =>
  *
  * {@link followed} and {@link followedSplit} say what a press is ASKING FOR;
  * this is the three lines every surface that draws markdown then writes to
- * answer it, and they must not be three lines anyone can write differently:
- * Alt opens to the right, a plain press goes in place, and everything else —
- * an external link, a modified click, a press something deeper already
+ * answer it, and they must not be three lines each such surface writes for
+ * itself: Alt opens to the right, a plain press goes in place, and everything
+ * else — an external link, a modified click, a press something deeper already
  * answered — is left to the browser.
+ *
+ * {@link Link} answers the same question and does NOT come through here, which
+ * is honest rather than an oversight waiting to be tidied: a `<Link>` is handed
+ * the route it stands for, and reading one back off the `href` it just wrote
+ * would be a round trip through a string for a value already in hand. What the
+ * two must agree on is what a MODIFIER means, and that is `../press.ts`'s, read
+ * by both — which is why the force bit below is `splitClick`'s answer and not a
+ * second look at Shift.
  *
  * It lives here rather than in the pane because the pane is no longer the only
  * one: the chat panel is mounted BESIDE the panes (`./App.tsx`) and its
@@ -329,7 +337,12 @@ export const useFollow = (): ((event: MouseEvent) => void) => {
     const split = followedSplit(event)
     if (split !== null) {
       event.preventDefault()
-      router.openRight(here(), split, event.shiftKey)
+      // `splitClick`'s own answer for "a new pane or the one already there".
+      // The line came out of the pane spelling it `event.shiftKey`, which was
+      // the shift⇒force rule written twice — once in `../press.ts` where
+      // `Link` reads it, once here — and free to disagree the day the gesture
+      // moves.
+      router.openRight(here(), split, splitClick(event) === "force")
       return
     }
     const next = followed(event)

--- a/packages/web/src/client/router.tsx
+++ b/packages/web/src/client/router.tsx
@@ -298,6 +298,46 @@ export const followed = (event: MouseEvent): Route | null =>
 export const followedSplit = (event: MouseEvent): Route | null =>
   routeFrom(event, (event) => splitClick(event) !== null)
 
+/**
+ * TAKE a click on a link inside rendered markdown — the pair above, answered.
+ *
+ * {@link followed} and {@link followedSplit} say what a press is ASKING FOR;
+ * this is the three lines every surface that draws markdown then writes to
+ * answer it, and they must not be three lines anyone can write differently:
+ * Alt opens to the right, a plain press goes in place, and everything else —
+ * an external link, a modified click, a press something deeper already
+ * answered — is left to the browser.
+ *
+ * It lives here rather than in the pane because the pane is no longer the only
+ * one: the chat panel is mounted BESIDE the panes (`./App.tsx`) and its
+ * transcript renders the agent's markdown, so an anchor in an answer used to
+ * fall through to the browser's default and reload the app cold. {@link useHere}
+ * is what makes one function serve both — inside a pane it is that pane, and
+ * outside every pane it is the FOCUSED one, which is where a link pressed in a
+ * drawer belongs and where the palette and the sidebar already land.
+ *
+ * Answers whether it CLAIMED the press, so a caller with a question of its own
+ * to ask first can tell a link it took from one it should go on ignoring.
+ */
+export const useFollow = (): ((event: MouseEvent) => boolean) => {
+  const router = useRouter()
+  const here = useHere()
+  const go = useGo()
+  return (event) => {
+    const split = followedSplit(event)
+    if (split !== null) {
+      event.preventDefault()
+      router.openRight(here(), split, event.shiftKey)
+      return true
+    }
+    const next = followed(event)
+    if (next === null) return false
+    event.preventDefault()
+    go(next)
+    return true
+  }
+}
+
 export function Link(props: LinkProps) {
   const router = useRouter()
   const here = useHere()

--- a/packages/web/src/client/router.tsx
+++ b/packages/web/src/client/router.tsx
@@ -316,10 +316,12 @@ export const followedSplit = (event: MouseEvent): Route | null =>
  * outside every pane it is the FOCUSED one, which is where a link pressed in a
  * drawer belongs and where the palette and the sidebar already land.
  *
- * Answers whether it CLAIMED the press, so a caller with a question of its own
- * to ask first can tell a link it took from one it should go on ignoring.
+ * NOTHING COMES BACK. It either takes the press or leaves it, and there is no
+ * third answer a caller could branch on — a caller with a question of its own
+ * (the transcript's node chips) asks it BEFORE handing the event over, which is
+ * the order that reads correctly anyway.
  */
-export const useFollow = (): ((event: MouseEvent) => boolean) => {
+export const useFollow = (): ((event: MouseEvent) => void) => {
   const router = useRouter()
   const here = useHere()
   const go = useGo()
@@ -328,13 +330,12 @@ export const useFollow = (): ((event: MouseEvent) => boolean) => {
     if (split !== null) {
       event.preventDefault()
       router.openRight(here(), split, event.shiftKey)
-      return true
+      return
     }
     const next = followed(event)
-    if (next === null) return false
+    if (next === null) return
     event.preventDefault()
     go(next)
-    return true
   }
 }
 


### PR DESCRIPTION
The chat panel is mounted BESIDE the panes (`App.tsx`), so an anchor inside a
rendered answer had nothing above it to catch the click. The transcript's only
click question was `nodeRefIn` — the backtick node chips — so every link the
agent wrote fell through to the browser's default and loaded the whole app cold,
taking the conversation on screen with it. The same file clicked in the sidebar
did not, because that is a `<Link>`.

## What changed

**`PageView`'s tail is now one shared function, not two copies.** The three
lines the pane's delegated listener ends with — `followedSplit` → `openRight`,
else `followed` → `go` — moved to `router.tsx` as `useFollow`, and both the pane
and the transcript call it.

*Why the router and not the pane module:* the lines are entirely made of
`router.tsx`'s own exports (`followed`, `followedSplit`, `useHere`, `useGo`,
`router.openRight`) and they are the ANSWER to the question `followed` /
`followedSplit` ask — those two say what a press wants, `useFollow` takes it.
Putting it under `pane/` would have made the chat panel import the pane module
for a function about a link, and would have said that in-place navigation is a
pane's idea rather than the router's. `useHere` is what lets one function serve
both callers: inside a pane it is that pane, outside every pane it falls back to
the FOCUSED one — where a link pressed in a drawer belongs, and where the
palette and the sidebar already land.

`useFollow` answers whether it CLAIMED the press, so the transcript can ask its
chip question first and only then hand the event on.

- `packages/web/src/client/router.tsx` — `useFollow`
- `packages/web/src/client/pane/PageView.tsx` — calls it (net −13 lines)
- `packages/web/src/client/chat/Transcript.tsx` — `if (pressed(…)) return; follow(event)`
- `docs/chat.md` — one paragraph where the transcript's references are described
- `packages/tests/agent/fake-acp-agent.ts` — a `links` verb: the answer carries a
  relative `.md` path and an app address
- `packages/tests/features/the_agent.feature` + `step_definitions/chat_steps.ts` —
  the two scenarios

Untouched, as the node asks: `Reference.tsx` (a button, deliberately), the
external-link rule (`https://` still `_blank` via `openExternal` — `routeIn`
declines it, so `useFollow` never claims it), and the node chips.

## Verified

**The browser, by eye.** One `just run`-style server on port 0 against
`fixtures/chat`, driven with Playwright.

1. Booted on the outline page
![booted](https://github.com/user-attachments/assets/ed3b5307-ea19-4339-aea2-62b304311884)

2. The agent's answer carrying a `.md` link and an app address
![answer](https://github.com/user-attachments/assets/8c9be25a-bbaa-4c3e-841d-d71f3d6f9c03)

3. After clicking the `.md` link — the pane shows the document, **and the chat
   panel is still open with the same transcript**, which is the proof it did not
   reload
![followed](https://github.com/user-attachments/assets/9a42d2bb-fecb-4233-a74f-f51136373c60)

4. After Alt+click on the `/#order` link — opened to the right
![split](https://github.com/user-attachments/assets/845eaec2-45bd-4016-8ff8-a97ab66d4a26)

**The e2e, and the sabotage run that proves it pins the bug.**

With the fix:

```
2 scenarios (2 passed)
21 steps (21 passed)
0m02.609s (executing steps: 0m02.480s)
```

With the transcript's `follow(event)` removed and nothing else changed:

```
1) Scenario: A link the agent wrote opens the page it names, in place
   ✔ Then the address is "/notes/cabinets.md"
   ✖ And the page has not reloaded
       AssertionError: the marker planted on `window` is gone, so the document
       was replaced — something navigated when it should have re-rendered in place

2) Scenario: Alt+click on a link the agent wrote opens it to the right
   ✔ When I alt-click the link "the cabinets note" in the agent's answer
   ✖ Then there are 2 panes
       Error: timed out after 15000ms waiting until 2 panes on screen

2 scenarios (2 failed)
21 steps (2 failed, 6 skipped, 13 passed)
```

Note the first one lands on `/notes/cabinets.md` either way — a full reload
satisfies every assertion but `the page has not reloaded`, which is exactly what
that step is for.

## One correction to the roadmap node

The node lists `/n/<id>` among the app addresses that reload. That spelling is
gone — the address collapse of 2026-08-19 removed the `/o/`, `/doc/` and `/n/`
prefixes, and a node's permalink is `/#<id>` now (`routes.ts`'s header says so;
`routeIn("/n/order")` is `null`). So the scenario uses `/#order`, which is the
current spelling of what the node meant. An unrecognised absolute path is not
this app's link and is deliberately left to the browser.


---

## Refactor passes (each its own commit)

**`9ea7a3b5` — architecture-first-principles / hickey / lowy.** C2
(consumer-ergonomics) landed one finding: `useFollow` returned "whether it
claimed the press" and neither call site read it. A dead knob on a two-caller
API; it returns `void` now.

The other checks came back clean, and the two worth recording: C3 (graduation)
— the volatility here is "what a press means and where it lands", already
encapsulated by `press.ts` (the reading) and `router.tsx` (the landing), so
`useFollow` moved INTO an existing receptacle rather than founding a new one.
Hickey Layer 2 (fragmentation) — this is the un-fragmenting direction: the rule
was one place and was about to become two.

**`b56f7c58` — `/simplify`** (four parallel agents: reuse, simplification,
efficiency, altitude). Three fixes:

- `useFollow` forced a new pane with `event.shiftKey`, while `Link` twenty lines
  below spells the same decision `split === "force"`. That is the shift⇒force
  rule written twice, one copy of which `press.ts`'s tests cannot see. It asks
  `splitClick` now. (The line came out of the pane verbatim — a lift is the
  cheapest moment to unify it.)
- `world.press` takes MODIFIERS. Two agents independently found that the new
  alt-click step had written the helper's wait/click/settle trio out again to
  add `{ modifiers: ["Alt"] }` — a 4th copy, three of them pre-existing in
  `pane_steps.ts`. All four are one `this.press(…)` call now, and the helper's
  own docstring already argued for exactly this (`"was three copies before it
  was a parameter"`).
- The `useFollow` docstring claimed a single spelling that `Link` does not
  share. It now says what the two DO share — `press.ts`'s reading of a modifier
  — and why `Link` keeping its own route is right rather than an oversight.

Skipped, with reasons:

- **"`useFollow` walks the DOM and parses the href twice per press"** (raised by
  two agents) — false. `routeFrom` gates on its `claimed` predicate BEFORE
  `closest("a")`, and `ours` / `splitClick` are mutually exclusive on `altKey`,
  so a press pays at most one walk. Same for `Tree.tsx:396`.
- **`answerLink` should share a helper with `daily_notes_steps.ts`'s "in the
  rendered markdown"** — that step is scoped to `main a`, i.e. the pane, and is
  structurally unable to reach an answer's anchor. The scopes are the point;
  sharing them would be sharing the thing that differs.
- **The `Then the agent's answer mentions …` guard is redundant** — technically
  true (the follow step waits on that anchor), kept for the failure message and
  because it is the scenario's own claim about what the answer carries.

Re-verified after the passes: `the_agent.feature` + `second_pane.feature`
(whose steps the `press` change touches) — **90 scenarios, 845 steps, all
passing**.

## Deferrals

- **No unit test.** The node allows one "only if the shared tail gains a pure
  function worth pinning"; `useFollow` is a hook over `router.openRight` and
  `useGo`, and the pure halves it composes (`followed`, `followedSplit`,
  `routeIn`) already have theirs in `routes.test.ts`. The e2e is the test the
  node asked for.
- **`Link` and `Tree.tsx:396` are not folded into the shared unit.** The
  altitude pass argues for extracting `route-off-the-event` + `open-it` and
  rewiring all three call sites, which would delete two exported functions and
  make the "one spelling" claim structural rather than documentary. It is a
  defensible refactor. It is also `Link` — every navigation in the app — changed
  for zero behaviour on a bug-fix PR whose node says *do not widen scope*, so it
  is recorded here for the human rather than taken. What the passes DID take is
  the part that costs nothing: the two now spell the force bit identically, and
  the docstring no longer overclaims.
- **`pane_steps.ts`'s three alt-click copies were collapsed** onto the new
  `press(…, modifiers)` — pre-existing duplication, inside a test-support file,
  named by the finding as part of its own fix. Covered by `second_pane.feature`,
  which is green.
