### PR TITLE
Tests stop asserting class names, colours, and pixel spellings (test-style-purge)

### DIFF
--- a/packages/web/src/client/agenda/owed.test.ts
+++ b/packages/web/src/client/agenda/owed.test.ts
@@ -67,7 +67,6 @@ test("work on today is the quiet face — a nudge, and the row is untouched", ()
   expect(mark.face).toBe("today")
   expect(mark.count).toBe(1)
   expect(mark.entry).toBe("")
-  expect(mark.chip).toContain("bg-pill")
   expect(mark.said).toBe("Agenda — 1 on today")
 })
 
@@ -76,19 +75,9 @@ test("late work is the loud face, and takes the row with it", () => {
   expect(mark.face).toBe("overdue")
   // Two nodes over two outlines: a mark saying 2 means two things are late.
   expect(mark.count).toBe(2)
-  // More than a colour: the row is washed and weighted too, so the two faces
-  // are still two sights without one.
-  expect(mark.entry).toContain("bg-alarm/10")
-  expect(mark.entry).toContain("font-semibold")
-  expect(mark.chip).toContain("bg-alarm")
+  // The row is marked too, so the two faces are still two sights without one.
+  expect(mark.entry).not.toBe("")
   expect(mark.said).toBe("Agenda — 2 overdue")
-})
-
-test("the rail's two marks differ by SHAPE, not only by colour", () => {
-  // They share one corner over one glyph, so a reader who cannot separate the
-  // two hues still has a filled dot against a ring.
-  expect(markOf(countedOf([LATE])).dot).toBe("bg-alarm")
-  expect(markOf(countedOf([ON_TODAY])).dot).toContain("border")
 })
 
 test("both at once: the alarm wins the row, and the count is the LATE one", () => {

--- a/packages/web/src/client/agenda/spine.test.ts
+++ b/packages/web/src/client/agenda/spine.test.ts
@@ -93,11 +93,3 @@ test("a rung's stretch of line changes across the SILENCE, then holds", () => {
   expect(painted).toContain(`${inkOf("rule")} ${far!.quiet.space}rem`)
   expect(painted).toContain(`${inkOf("rule")} 100%`)
 })
-
-test("ink is a TOKEN, and the absence of one is transparent", () => {
-  // Never a hex: a palette is a redefinition of these same custom properties,
-  // so a line drawn once follows every palette (../theme/palettes.ts).
-  expect(inkOf("alarm")).toBe("var(--color-alarm)")
-  expect(inkOf("rule")).toBe("var(--color-rule)")
-  expect(inkOf(undefined)).toBe("transparent")
-})

--- a/packages/web/src/client/claims.test.ts
+++ b/packages/web/src/client/claims.test.ts
@@ -94,32 +94,6 @@ test("nothing outside connection/status.ts reads the readout's raw states", () =
   ])
 })
 
-// pill.ts's claim — one spelling of the quiet pill button, worn by import.
-// Same construction as the connectSurface sweep: asserting equality keeps it
-// honest, because pill.ts itself must keep matching — a respelled QUIET_PILL
-// fails here rather than rotting the pattern to an empty pass. The lookalikes
-// that deliberately diverge (`pill.ts` says where) do not match, which is the
-// point: what cannot reappear is the SHARED spelling, retyped.
-test("only pill.ts spells the quiet pill button", () => {
-  const spelling = /rounded border border-rule px-2 py-1 text-xs text-muted hover:text-ink/
-  expect(filesSpelling(spelling)).toEqual(["pill.ts"])
-})
-
-// Its twin, swept the same way and for a sharper reason: the two buttons of a
-// confirm are the same question's two answers, so the day one is respelled
-// and the other is not, the panel reads as a layout accident. Two surfaces
-// ask a confirm now — the `•••` menu's and the ⌘K palette's.
-test("only pill.ts spells the alarm pill button", () => {
-  const spelling =
-    /rounded border border-alarm bg-transparent px-2 py-1 text-xs text-alarm hover:bg-alarm\/10/
-  expect(filesSpelling(spelling)).toEqual(["pill.ts"])
-})
-
-// The THIRD button vocabulary, swept for the reason the two above are: the way
-// OUT of a panel a row opened is worn in three files — the shell the three
-// one-value panels share (`Cancel`), and the two that search (`Done`) — and it
-// was written out three times before it was a constant. A fourth file retyping
-// the string fails here rather than drifting a pixel at a time.
 // The LAW two gestures refuse by — one spelling, and it is not in this package
 // any more. A row dragged over another outline's pane and a destination picked
 // out of a search of the whole set are told the same thing about the format,
@@ -131,34 +105,6 @@ test("only pill.ts spells the alarm pill button", () => {
 // spelling this claim exists to forbid.
 test("no file here spells the same-file law — it is the format's", () => {
   expect(filesSpelling(/Every outline is an independent tree/)).toEqual([])
-})
-
-test("only pill.ts spells a panel's way out", () => {
-  const spelling =
-    /cursor-pointer rounded border-0 bg-transparent px-2 py-1 text-sm text-muted hover:text-ink/
-  expect(filesSpelling(spelling)).toEqual(["pill.ts"])
-})
-
-// chat/live.ts's claim — one spelling of the panel's "this is happening now"
-// cue. Two places wear it and they are the same fact one level apart: the
-// header says a TURN is in flight, a spawn's rail says an AGENT the turn sent
-// out is. They were two copies with a comment in one of them asserting they
-// matched, which is the arrangement this file exists to replace.
-test("only chat/live.ts spells the live dot", () => {
-  const spelling = /inline-block size-1\.5 animate-pulse rounded-full bg-doing/
-  expect(filesSpelling(spelling)).toEqual(["chat/live.ts"])
-})
-
-// chat/lanes.ts's claim — one spelling of a lane's rail, and this one is a
-// claim about GEOMETRY rather than about tone. Two things draw the rail and
-// the whole point of the second is that it is the same line continued: a row
-// a subagent made hangs one off the frame above it, and a spawn nobody has
-// reported on yet hangs one off itself, directly above that row. Spelled
-// twice they agreed by coincidence, and the first tweak to either would have
-// drawn a reader one line as two.
-test("only chat/lanes.ts spells the lane rail", () => {
-  const spelling = /border-l-2 border-muted\/70 pl-2/
-  expect(filesSpelling(spelling)).toEqual(["chat/lanes.ts"])
 })
 
 // layer.ts's claim — every `z-index` in this client comes from its table. The

--- a/packages/web/src/client/commit/said.test.ts
+++ b/packages/web/src/client/commit/said.test.ts
@@ -25,7 +25,6 @@ import {
   explain,
   faceOf,
   HOW,
-  HOW_TONE,
   isInert,
   isNews,
   localOf,
@@ -130,16 +129,16 @@ test("a healthy repository is quiet, and not a second green claim", () => {
   // The retired readout's rule, and it outlives it: the connection dot beside
   // this pill is the page's one green claim, and a second one lit permanently
   // in the ordinary case dilutes the thing a reader actually scans for.
-  expect(MARK.committed?.tone).not.toContain("done")
+  expect(MARK.committed?.glyph).toBe("✓")
   expect(MARK.never).toBeNull()
   expect(MARK.waiting).toBeNull()
 })
 
-test("the two a person can act on are marked, and told apart by tone", () => {
+test("the two a person can act on are marked", () => {
   // A repository mid-rebase will take a commit once they finish; a git that
-  // failed will not. Same glyph, different news.
-  expect(MARK.blocked).toEqual({ glyph: "⚠", tone: "text-doing" })
-  expect(MARK.error).toEqual({ glyph: "⚠", tone: "text-alarm" })
+  // failed will not. Same warning glyph; the faces themselves tell them apart.
+  expect(MARK.blocked?.glyph).toBe("⚠")
+  expect(MARK.error?.glyph).toBe("⚠")
 })
 
 test("the fault is reachable, because its whole point is the reason on it", () => {
@@ -304,18 +303,13 @@ test("a refused push says what git said, and a successful one says nothing", () 
     .toContain("nowhere to commit to")
 })
 
-/** Every status a dirty file can have wears a word and a tone. A table, so a
- *  sixth one the format grew would be a compile error here rather than a blank
- *  chip beside somebody's file. */
-test("every status a file can be in has a word and a tone", () => {
+/** Every status a dirty file can have wears a word. A table, so a sixth one
+ *  the format grew would be a compile error here rather than a blank chip
+ *  beside somebody's file. */
+test("every status a file can be in has a word", () => {
   for (const how of ["modified", "added", "deleted", "renamed", "untracked"] as const) {
     expect(HOW[how]).not.toBe("")
-    expect(HOW_TONE[how]).toStartWith("text-")
   }
-  // A file that has LEFT is the one worth a second look, and it is the only one
-  // that wears the alarm tone.
-  expect(HOW_TONE.deleted).toBe("text-alarm")
-  expect(HOW_TONE.modified).not.toBe(HOW_TONE.deleted)
 })
 
 /**

--- a/packages/web/src/client/connection/status.test.ts
+++ b/packages/web/src/client/connection/status.test.ts
@@ -52,7 +52,6 @@ test("a retired wire is drawn as neither live nor merely reconnecting", () => {
 })
 
 test("only a live connection is drawn as one", () => {
-  expect(LOOK.live.dot).toBe("bg-done")
   for (const state of STATES.filter((s) => s !== "live")) {
     const look = lookOf(readoutOf(state))
     expect(look.dot).not.toBe(LOOK.live.dot)

--- a/packages/web/src/client/markdown/render.test.ts
+++ b/packages/web/src/client/markdown/render.test.ts
@@ -20,7 +20,6 @@
 
 import { expect, test } from "bun:test"
 
-import { ANCHOR_CLASS } from "./anchors.ts"
 import { installPipeline } from "./chunk.ts"
 import * as pipeline from "./pipeline.ts"
 import {
@@ -60,16 +59,13 @@ test("a fence in a language nobody registered is left alone", () => {
   expect(html).not.toContain("hljs-")
 })
 
-// The sanitiser decides which of the parser's classes survive, and a task
-// list's are the ones `styles.css` hangs a rule on: the checkbox replaces the
-// bullet, so a dropped class is a list drawn with two markers and nothing in
-// the markup to say why. Pinned here rather than left to the browser test,
-// which can only see the result.
-test("a task list keeps the classes the stylesheet draws it by", () => {
+// A task list is checkboxes, and a plain item beside them is still a bullet.
+// The browser suite is what sees that the checkbox replaced the marker; this
+// pins that the pipeline still emitted the inputs.
+test("a task list is checkboxes, and a plain item beside them is still a bullet", () => {
   const html = renderMarkdown("- [x] done\n- [ ] not\n- plain\n", NOTE)
-  expect(html).toContain(`<ul class="contains-task-list">`)
-  expect(html).toContain(`<li class="task-list-item"><input type="checkbox" checked disabled>`)
-  // The plain item is untouched: it keeps the bullet the other two give up.
+  expect(html).toContain(`<input type="checkbox" checked disabled>`)
+  expect(html).toContain(`<input type="checkbox" disabled>`)
   expect(html).toContain("<li>plain</li>")
 })
 
@@ -261,14 +257,12 @@ test("a fragment-only link is still minted, not routed", () => {
 // ── heading anchors, and the contents derived from them ──────────────────
 //
 // The anchor is minted INSIDE the boundary (./anchors.ts), so what is pinned
-// here is that it comes out the other side: an allowlist that stopped naming
-// the class would leave the link working and the styling gone, which is
-// exactly the kind of thing nothing else notices.
+// here is that it comes out the other side: an id, a href that names it, and
+// a label a screen reader can use.
 test("a heading carries an id and a link to it", () => {
   const html = renderMarkdown("## The sync loop\n", NOTE)
   const id = /<h2 id="([^"]+)"/.exec(html)?.[1]
   expect(id).toMatch(/^md-[a-z0-9]+-the-sync-loop$/)
-  expect(html).toContain(`<a class="${ANCHOR_CLASS}"`)
   expect(html).toContain(`href="#${id}"`)
   // The label names the section: a page of anchors is a page of `#`s to
   // anyone reading by ear.


### PR DESCRIPTION
HACKING.md now says tests assert behavior, not styling. This sweep deletes the assertions that named a class, a colour, or a pixel, and leaves the faces, counts, sentences, and glyphs they were mixed with.

No production code moved. No new semantic hooks. Where a styled state was genuinely semantic (owed, live, blocked) and a hook already existed (`face`, `said`, `glyph`), that hook stays; otherwise the styling line is gone.

## Deleted tests

- `owed.test.ts` — *"the rail's two marks differ by SHAPE, not only by colour"*: only asserted `bg-alarm` vs `border`. The `face` already tells overdue from today.
- `spine.test.ts` — *"ink is a TOKEN, and the absence of one is transparent"*: only asserted `var(--color-alarm)` spelling. Palettes are the theme system's job.
- `claims.test.ts` — *"only pill.ts spells the quiet pill button"*: monopoly sweep over a Tailwind class string.
- `claims.test.ts` — *"only pill.ts spells the alarm pill button"*: same, for the confirm's other answer.
- `claims.test.ts` — *"only pill.ts spells a panel's way out"*: same, for Cancel/Done.
- `claims.test.ts` — *"only chat/live.ts spells the live dot"*: monopoly sweep over `animate-pulse rounded-full bg-doing`.
- `claims.test.ts` — *"only chat/lanes.ts spells the lane rail"*: monopoly sweep over `border-l-2 border-muted/70 pl-2`.

## Stripped assertions (behavior kept)

- `owed.test.ts` *"work on today is the quiet face"* — dropped `chip` contains `bg-pill`. Face, count, empty row, and `said` stay.
- `owed.test.ts` *"late work is the loud face"* — dropped `bg-alarm/10`, `font-semibold`, `bg-alarm`. Face, count, non-empty row, and `said` stay.
- `status.test.ts` *"only a live connection is drawn as one"* — dropped `LOOK.live.dot === "bg-done"`. Distinctness of the other four states stays.
- `said.test.ts` *"a healthy repository is quiet"* — dropped `tone` not containing `done`. The `✓` glyph, and never/waiting wearing no mark, stay.
- `said.test.ts` *"the two a person can act on are marked"* — dropped `text-doing` / `text-alarm`. Both still wear `⚠`; the faces tell them apart.
- `said.test.ts` *"every status a file can be in has a word"* — dropped `HOW_TONE` class-name pins. The words stay.
- `render.test.ts` task-list case — dropped `contains-task-list` / `task-list-item`. Checkboxes and the plain bullet item stay. (The e2e already sees that a checkbox replaced the marker.)
- `render.test.ts` heading-anchor case — dropped `class="${ANCHOR_CLASS}"`. Id, href, and aria-label stay.

## Left standing (styling system, or layout behavior)

- `packages/web/src/client/theme/*` (fonts, scale, sizes, palettes, contrast, css).
- `packages/fonts` CSS emission.
- `tip.test.ts` margin pinning; calendar grid padding; `layout/prefs|resize` and `pane/geometry` width arithmetic; `layer.test.ts` stacking order.

## Verification

`just test` at `a0c49a65`, 2026-08-20:

```
2879 pass
0 fail
69453 expect() calls
Ran 2879 tests across 208 files. [19.73s]
```

browser-condition suite:

```
38 pass
0 fail
93 expect() calls
Ran 38 tests across 7 files. [2.97s]
```

Then `nix run github:juspay/odu -- run --platform x86_64-linux` (macOS skipped). No screenshots: nothing a user sees changed. This enumeration is the evidence.

## Deferrals

Flagged, not deleted, because judgement was unclear or the unit under test is not olai chrome:

- `claims.test.ts` *"only layer.ts spells a z-index"* — architectural monopoly of a stacking table, not a visual spelling. `layer.test.ts` still reads ranks out of those utilities.
- `format` `agenda.test.ts` fade/tone tokens (`alarm` / `accent` / `0.8`) — semantic receding, not CSS classes.
- `spine.test.ts` *"a rung's stretch of line changes across the SILENCE"* — layout of where the gradient holds, via `inkOf` rather than a hex.
- `html_steps.ts` `rgb(20, 83, 45)` — the preview iframe applied the *file's* stylesheet, not olai's.
- `outline_tree_steps.ts` opacity thresholds — hover-reveal is presence/absence implemented as opacity.
- `document_steps.ts` `listStyleType !== "none"` — task-list bullets vs checkboxes, the behavior the unit test just stopped naming classes for.
- `preferences_steps.ts` root `fontSize` — the size preference, which is the theme system.
- `theme_steps.ts` computed paper — the theme system.
- `phone_steps.ts` `--visible-h` — viewport layout.
- markdown `olai-hit` / `TAG_CLASS` HTML snapshots — always paired with `data-testid="hit"` / `data-testid="tag"`.
- `render.test.ts` `hljs-*` classes — the highlighting system, and the test is titled "in classes rather than colours".
- `render.test.ts` `class="footnotes"` — footnote container identity.
- `sanitise.test.ts` `ANCHOR_CLASS` on the allowlist — sanitizer contract, not look.
- `log` `sinks.test.ts` ANSI / `NO_COLOR` — pretty printer, not UI styling.