### PR TITLE
The two search doors say their denominator (palette-count-cap)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -207,6 +207,10 @@ They are two lines rather than one because a place is somebody's prose. Side by 
 - **A panel under a row** — where searching is how you answer a question the row asked. Three of them, each drawing the same rows over the same procedure: the `((` widget in a title (place a mirror of what you find), the edge panel's box (`see` / `after` — what this node points at), and the move-to picker's (⌘⇧M — which node this row goes under, [editing.md](editing.md)). The last one is the one that draws a REFUSAL beside its hits: a destination is not merely a node, so most of the set is somewhere a given row cannot go, and it says which as you walk the list.
 - **`search_nodes`** — the same answer for an agent, over MCP.
 
+**The two doors that LIST say how much they left out.** Both draw at most eight hits, and eight rows over a directory that matched twenty of something reads as the whole answer. So under the rows each of them draws one line — `8 of 20 matches` — whenever more matched than fit, and **nothing at all** when everything found is on screen: that silence is the same ruling the filtered page's count line makes about a part that is zero, since a number a reader has to take in before they can ignore it is worse than no number. What is counted is the answer's own uncapped total, carried on the wire beside the capped hits for exactly this sentence — what the QUERY found, never what the door had room for. It is a readout beside the rows rather than something announced, because it changes under a hand that is still typing.
+
+The panels under a row are deliberately not part of that. They cap at eight as well, but each of them is a PICKER — which node this row goes under, what it points at, which one to mirror — and the question there is whether what you are spelling is in the list, not how much of the directory answers to it.
+
 ## Documents, by name
 
 **A filter selects nodes, never documents** — it narrows rows of a page, and the one page made of prose is the one page with no filter on it. The two doors below are where the other half of the directory is found.

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -22,7 +22,7 @@ The suite shares constants with `@olai/web` rather than retyping them — a numb
 
 Prefer a shared scratch corpus per **feature** over a private server per scenario. `@share-scratch` at the top of a feature is that opt-in: one copy and one server per worker, and After restores the fixture under the still-running server so overlapping writers can share too. `@own-scratch` on a scenario inside it keeps a private copy, for the things restore cannot make true (a server restart, conversation state, git). A restore that does not put the tree back fails naming the scenario and the files.
 
-This suite is 62 features, 745 scenarios (741 Gherkin `Scenario`/`Scenario Outline` entries; two outlines expand to six examples), 503 `@scratch:`. 26 features carry `@share-scratch` (325 sharing scenarios, 11 `@own-scratch` inside them). A 2026-08-19 audit cut ~160 that did not earn the browser; the grammar, the destination refusals, the trash wording, the install fetch and the rest of that list live in the unit suites now. Four browser-only claims the first cut left unpinned (anchor jump, sidebar inner scroll, same-page never-inside-itself, late-picture rungs) are back.
+This suite is 64 features, 779 scenarios (771 Gherkin `Scenario`/`Scenario Outline` entries; four outlines expand to twelve examples), 558 `@scratch:`. 26 features carry `@share-scratch` (375 sharing scenarios, 13 `@own-scratch` inside them). A 2026-08-19 audit cut ~160 that did not earn the browser; the grammar, the destination refusals, the trash wording, the install fetch and the rest of that list live in the unit suites now. Four browser-only claims the first cut left unpinned (anchor jump, sidebar inner scroll, same-page never-inside-itself, late-picture rungs) are back.
 
 ```
 packages/tests/

--- a/packages/tests/evidence.ts
+++ b/packages/tests/evidence.ts
@@ -645,7 +645,16 @@ const TRASH_EMPTY_LINE = '[data-testid="trash-empty"]'
  *  share a word is not an answer to a query, which is what `data-id` tells
  *  apart (the browser tests read the same pair). */
 const PALETTE_INPUT = '[data-testid="palette-input"]'
-const PALETTE_HIT = '[data-testid="palette-item"][data-id^="node-"]'
+/** A row's id is its printed ADDRESS behind `hit-` (`palette/items.ts`), and a
+ *  record's address is a bare fragment — so `hit-#` is what tells a node hit
+ *  from a document row and from a shell item that shares a word, exactly as
+ *  the browser tests grip it. It read `node-` until 2026-08-20, which is a
+ *  prefix nothing has ever carried: the one section using it printed
+ *  "(nothing)" where its hits should have been. */
+const PALETTE_HIT = '[data-testid="palette-item"][data-id^="hit-#"]'
+/** What a shortlist says it drew of what it found — the same line on both
+ *  doors, absent when the answer fit (`web/src/client/search/count.ts`). */
+const SEARCH_COUNT = '[data-testid="search-count"]'
 /** …and the rows of it that are DOCUMENTS, told apart the same way: a served
  *  file's row carries its whole path in `data-id`, so a shot can print WHICH
  *  file it matched rather than the name a folder may repeat. The header's box
@@ -2693,6 +2702,77 @@ const SECTIONS = {
 
     await inTheDark(page)
     await shot(page, "hidden-dark")
+  },
+
+  /**
+   * A SHORTLIST SAYS ITS TOTAL (`a-shortlist-says-its-total`): both doors onto
+   * the one search reading, over a directory big enough for the cap to bite —
+   * and the same doors over an answer that fits, saying nothing.
+   *
+   * The pair is what a still frame can carry here, because the claim is about
+   * a SILENCE as much as a sentence: eight rows with `8 of 44 matches` under
+   * them and eight rows' worth of query with no line at all are the same
+   * picture apart from the one element this PR draws.
+   *
+   * THE VAULT IS WRITTEN rather than taken from `fixtures/good`, for the
+   * frontmatter section's reason: the fixture is a five-node house and the cap
+   * never bites in it, so a shot taken against it would be a shot of the
+   * absence twice. Forty rows that answer one word is the smallest directory
+   * in which the two doors have something to say.
+   */
+  "a-shortlist-says-its-total": async (page) => {
+    pinnedBy(
+      "a_shortlist_says_its_total.feature",
+      "The palette drew eight of what it found, and says which",
+      "The header's box says the same thing about the same answer",
+      "A palette answer that fits says nothing about a total",
+    )
+    rewrite("stock.olai", [
+      `{"id":"stock","ord":"a0","title":"the supplier's catalogue"}`,
+      ...Array.from(
+        { length: 40 },
+        (_unused, index) =>
+          `{"id":"h${index + 1}","parent":"stock","ord":"a${
+            String(index + 1).padStart(2, "0")
+          }","title":"brass handle no. ${index + 1}"}`,
+      ),
+    ])
+
+    // THE PALETTE, over a word forty rows answer to. The line sits under the
+    // list rather than in it, so it is in frame whether or not a reader has
+    // scrolled the eight.
+    await opened(page, "/house.olai", OUTLINE_TREE)
+    await page.keyboard.press("ControlOrMeta+k")
+    await page.locator(PALETTE_INPUT).waitFor()
+    await page.locator(PALETTE_INPUT).fill("handle")
+    await page.locator(PALETTE_HIT).first().waitFor()
+    await page.waitForTimeout(SETTLE)
+    console.log(`  hits drawn:         ${await page.locator(PALETTE_HIT).count()}`)
+    console.log(`  and it says:        ${await textOf(page, SEARCH_COUNT)}`)
+    await shot(page, "the-palette-says-its-total")
+
+    // …and the same palette over a query the vault answers eight-or-fewer
+    // times: the rows are there, and there is no line under them.
+    await page.locator(PALETTE_INPUT).fill("cabinets")
+    await page.locator(PALETTE_HIT).first().waitFor()
+    await page.waitForTimeout(SETTLE)
+    console.log(
+      `  an answer that fits: ${await page.locator(PALETTE_HIT).count()} hits, and the line is ${
+        (await page.locator(SEARCH_COUNT).count()) === 0 ? "absent" : "STILL THERE"
+      }`,
+    )
+    await shot(page, "an-answer-that-fits-says-nothing")
+    await page.keyboard.press("Escape")
+
+    // THE OTHER DOOR, over the same word and the same answer — one reading,
+    // one sentence, two places it is drawn.
+    const box = page.locator('[data-testid="header-search"]')
+    await box.click()
+    await box.fill("handle")
+    await page.locator(headerHit("#h1")).first().waitFor()
+    await page.waitForTimeout(SETTLE)
+    console.log(`  the header box too: ${await textOf(page, SEARCH_COUNT)}`)
+    await shot(page, "the-header-box-says-it-too")
   },
 } satisfies Record<string, (page: Page) => Promise<void>>
 

--- a/packages/tests/evidence.ts
+++ b/packages/tests/evidence.ts
@@ -652,6 +652,10 @@ const PALETTE_INPUT = '[data-testid="palette-input"]'
  *  prefix nothing has ever carried: the one section using it printed
  *  "(nothing)" where its hits should have been. */
 const PALETTE_HIT = '[data-testid="palette-item"][data-id^="hit-#"]'
+/** The header box itself — the other door, and the one surface here that was
+ *  spelled as a literal at each of its three call sites while every other one
+ *  in this file is a named const. */
+const HEADER_SEARCH = '[data-testid="header-search"]'
 /** What a shortlist says it drew of what it found — the same line on both
  *  doors, absent when the answer fit (`web/src/client/search/count.ts`). */
 const SEARCH_COUNT = '[data-testid="search-count"]'
@@ -2043,7 +2047,7 @@ const SECTIONS = {
       await shot(page, `the-document-opens${suffix}`)
 
       // THE OTHER DOOR, over the same query and drawing the same row.
-      const box = page.locator('[data-testid="header-search"]')
+      const box = page.locator(HEADER_SEARCH)
       await box.click()
       await box.fill("pal")
       await page.locator(HEADER_DOC).first().waitFor()
@@ -2160,7 +2164,7 @@ const SECTIONS = {
 
       // WHAT THE DOCUMENT IS CALLED, in the door that draws a face's title:
       // the body's first real line, not the fence and not the first YAML key.
-      const box = page.locator('[data-testid="header-search"]')
+      const box = page.locator(HEADER_SEARCH)
       await box.click()
       await box.fill("plan")
       const row = page.locator(headerHit("notes/plan.md"))
@@ -2766,7 +2770,7 @@ const SECTIONS = {
 
     // THE OTHER DOOR, over the same word and the same answer — one reading,
     // one sentence, two places it is drawn.
-    const box = page.locator('[data-testid="header-search"]')
+    const box = page.locator(HEADER_SEARCH)
     await box.click()
     await box.fill("handle")
     await page.locator(headerHit("#h1")).first().waitFor()

--- a/packages/tests/extension.test.ts
+++ b/packages/tests/extension.test.ts
@@ -99,7 +99,7 @@ const MAY_SPELL_IT: ReadonlyArray<string> = [
   "docs/RCA/",
   "docs/brainstorming/",
   "docs/format.md",
-  "docs/roadmap.olai",
+  "docs/roadmap/",
   "packages/format/src/kinds.test.ts",
 ];
 

--- a/packages/tests/extension.test.ts
+++ b/packages/tests/extension.test.ts
@@ -53,7 +53,7 @@
 
 import { expect, test } from "bun:test";
 
-import { granting, read, tracked } from "./support/sweep.ts";
+import { granting, read, tracked, unresolved } from "./support/sweep.ts";
 
 /**
  * What may still spell it, and why each one may.
@@ -134,6 +134,14 @@ const spelling = (pattern: RegExp): ReadonlyArray<string> =>
 // not a count.
 test("the sweep is actually reading the repository", () => {
   expect(TRACKED.length).toBeGreaterThan(200);
+});
+
+// …and the list this sweep excuses is checked against the disk too. A grant
+// whose path has MOVED is not a loosened fence but a tightened one — it goes on
+// being spelled and stops covering the ledger it names — which is what happened
+// to this list the day `docs/roadmap.olai` became a directory.
+test("every grant still names a record of the past that is there", () => {
+  expect(unresolved(MAY_SPELL_IT)).toEqual([]);
 });
 
 // The expectation is an EQUALITY to a named list rather than "empty", for

--- a/packages/tests/features/a_shortlist_says_its_total.feature
+++ b/packages/tests/features/a_shortlist_says_its_total.feature
@@ -1,0 +1,47 @@
+@corpus:good
+Feature: A shortlist says how much of the answer it drew
+  Both doors onto the one search reading ask for eight hits and draw what comes
+  back (`client/search/nodes.ts`'s `LIMIT`). A query that matched twenty things
+  and a query that matched eight were therefore the same eight rows under the
+  same silence — so both doors told a reader the directory holds eight of
+  something it holds twenty of, while the honest number was on the wire the
+  whole time (`SearchAnswer.total`, kept uncapped precisely so that "eight of
+  ninety" is sayable).
+
+  The filtered page has said all three of its truths since #248
+  (`filter_in_place.feature`); these are the two doors that were left out of
+  it, saying the one truth they have.
+
+  TWO DOORS, TWO SCENARIOS, which is a deliberate exception to this suite's own
+  rule about one law through one representative door: what is asserted here is
+  not the law but that each door DRAWS it, and a door drawing nothing is
+  precisely the defect. The wording itself is a unit test
+  (`client/search/count.ts`).
+
+  `@corpus:good` — nothing here writes.
+
+  Background:
+    Given I open the outline "house.olai"
+
+  Scenario: The palette drew eight of what it found, and says which
+    When I press the palette shortcut
+    And I type "the" into the palette
+    Then the palette found "8 of 20 matches"
+
+  Scenario: A palette answer that fits says nothing about a total
+    # The silence is the other half of the promise: "3 of 3 matches" is a
+    # number a reader has to take in before they can ignore it, and the rows
+    # already say how many there are.
+    When I press the palette shortcut
+    And I type "cabinets" into the palette
+    Then the palette lists the node "order the new cabinets"
+    And the palette says nothing about a total
+
+  Scenario: The header's box says the same thing about the same answer
+    When I search the header for "the"
+    Then the header search found "8 of 20 matches"
+
+  Scenario: A header answer that fits says nothing about a total
+    When I search the header for "cabinets"
+    Then the header search lists the node "order the new cabinets"
+    And the header search says nothing about a total

--- a/packages/tests/stdio.test.ts
+++ b/packages/tests/stdio.test.ts
@@ -29,15 +29,22 @@
 
 import { expect, test } from "bun:test";
 
-import { exists, granting, read, tracked } from "./support/sweep.ts";
+import { exists, granting, read, tracked, unresolved } from "./support/sweep.ts";
 
-const granted = granting([
+/** The record of the past, as paths. A const rather than an argument spelled
+ *  inline, so the test below can ask whether every one of them still names
+ *  something — a grant that has gone stale is a fence closing on the ledger it
+ *  was written to excuse, which is exactly what `docs/roadmap.olai` becoming a
+ *  directory did to this sweep. */
+const MAY_SPELL_IT: ReadonlyArray<string> = [
   "docs/_olai/Trash.olai",
   "docs/RCA/",
   "docs/brainstorming/",
   "docs/lowy-electricity/",
   "docs/roadmap/",
-]);
+];
+
+const granted = granting(MAY_SPELL_IT);
 
 const TRACKED = tracked(import.meta.filename);
 
@@ -52,6 +59,10 @@ const spelling = (pattern: RegExp): ReadonlyArray<string> =>
 
 test("the sweep is actually reading the repository", () => {
   expect(TRACKED.length).toBeGreaterThan(200);
+});
+
+test("every grant still names a record of the past that is there", () => {
+  expect(unresolved(MAY_SPELL_IT)).toEqual([]);
 });
 
 test("nothing outside the record of the past spells the retired stdio face", () => {

--- a/packages/tests/stdio.test.ts
+++ b/packages/tests/stdio.test.ts
@@ -36,7 +36,7 @@ const granted = granting([
   "docs/RCA/",
   "docs/brainstorming/",
   "docs/lowy-electricity/",
-  "docs/roadmap.olai",
+  "docs/roadmap/",
 ]);
 
 const TRACKED = tracked(import.meta.filename);

--- a/packages/tests/step_definitions/filter_steps.ts
+++ b/packages/tests/step_definitions/filter_steps.ts
@@ -17,6 +17,7 @@
 import * as assert from "node:assert";
 import { Then, When } from "@cucumber/cucumber";
 
+import { foundCount } from "../support/counted.ts";
 import { saysThat } from "../support/said.ts";
 import {
   attr,
@@ -94,35 +95,24 @@ Then(
 );
 
 /**
- * THE WHOLE COUNT LINE, exactly — not a substring of it.
+ * THE WHOLE COUNT LINE, exactly — not a substring of it, which is
+ * `support/counted.ts`'s rule and was this step's before there was anywhere to
+ * keep it. This element holds the count and nothing else
+ * (`client/filter/count.ts` is the only thing that writes it), so a substring
+ * read would cost the two things this feature is made of: `"1 of 10"` is
+ * inside `"1 of 100"`, and — the one that matters — `"1 of 10"` is inside
+ * `"1 of 10 — 2 more matches hidden as done (Prefs)"`, so the scenario that
+ * exists to prove NO clause is said could not see one appear (found by both
+ * reviewers of #248).
  *
- * The suite's one reader (`support/said.ts`) matches a substring, and it is
- * right to: most of the sentences it reads are a phrase inside a paragraph
- * somebody wrote. This element is not one of those. It holds the count line and
- * nothing else (`client/filter/count.ts` is the only thing that writes it), so
- * a substring here buys nothing and costs the two things this feature is made
- * of: `"1 of 10"` is inside `"1 of 100"`, and — the one that matters —
- * `"1 of 10"` is inside `"1 of 10 — 2 more matches hidden as done (Prefs)"`,
- * so the scenario that exists to prove NO clause is said could not see one
- * appear (found by both reviewers of #248).
- *
- * The count settles a frame after the query, so the equality is WAITED for
- * rather than read once; what a failure prints is what the bar actually says.
+ * The reader is shared with the two search doors, which say the same kind of
+ * sentence about the answer they only drew part of: one ritual, three doors,
+ * and the wait that makes it honest kept in one place.
  */
 Then(
   "the filter found {string}",
   async function (this: OlaiWorld, said: string) {
-    const line = this.page.locator(FILTER_COUNT).first();
-    await line.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await this.waitUntil(
-      async () => (await line.innerText().catch(() => "")).trim() === said,
-      `the filter says exactly ${JSON.stringify(said)}`,
-    ).catch(() => undefined);
-    assert.strictEqual(
-      (await line.innerText()).trim(),
-      said,
-      `the filter count reads ${JSON.stringify((await line.innerText()).trim())}`,
-    );
+    await foundCount(this, FILTER_COUNT, said, "filter count");
   },
 );
 

--- a/packages/tests/step_definitions/palette_steps.ts
+++ b/packages/tests/step_definitions/palette_steps.ts
@@ -38,6 +38,7 @@ import {
   PALETTE_ITEM,
   PALETTE_SAID,
   PALETTE_SCRIM,
+  SEARCH_COUNT,
   POLL_TIMEOUT,
   SHORTCUTS,
 } from "../support/world.ts";
@@ -245,14 +246,14 @@ Then(
 Then(
   "the palette found {string}",
   async function (this: OlaiWorld, said: string) {
-    await foundCount(this, PALETTE, said, "palette count");
+    await foundCount(this, `${PALETTE} ${SEARCH_COUNT}`, said, "palette count");
   },
 );
 
 Then(
   "the palette says nothing about a total",
   async function (this: OlaiWorld) {
-    await countsNothing(this, PALETTE, "palette");
+    await countsNothing(this, `${PALETTE} ${SEARCH_COUNT}`, "palette");
   },
 );
 

--- a/packages/tests/step_definitions/palette_steps.ts
+++ b/packages/tests/step_definitions/palette_steps.ts
@@ -24,6 +24,7 @@
 import * as assert from "node:assert";
 import { Then, When } from "@cucumber/cucumber";
 
+import { countsNothing, foundCount } from "../support/counted.ts";
 import { saysThat } from "../support/said.ts";
 import {
   attr,
@@ -231,6 +232,27 @@ Then(
       .locator(`${PALETTE_ITEM}${attr("data-id", `hit-${file}`)}`)
       .count();
     assert.strictEqual(rows, 0, `the palette lists ${JSON.stringify(file)}`);
+  },
+);
+
+// ── how much of the answer it drew ─────────────────────────────────────
+//
+// The ritual is `support/counted.ts`', shared with the header box's steps: one
+// line, one function in the client, one question here. What is the palette's
+// own is the door it is read INSIDE — the modal, so that a scenario says which
+// of the two doors it means even though both draw the line under one name.
+
+Then(
+  "the palette found {string}",
+  async function (this: OlaiWorld, said: string) {
+    await foundCount(this, PALETTE, said, "palette count");
+  },
+);
+
+Then(
+  "the palette says nothing about a total",
+  async function (this: OlaiWorld) {
+    await countsNothing(this, PALETTE, "palette");
   },
 );
 

--- a/packages/tests/step_definitions/panel_steps.ts
+++ b/packages/tests/step_definitions/panel_steps.ts
@@ -12,6 +12,7 @@ import * as assert from "node:assert";
 import { Then, When } from "@cucumber/cucumber";
 
 import { SIDEBAR_WIDTH_KEY } from "@olai/web/src/client/layout/prefs.ts";
+import { countsNothing, foundCount } from "../support/counted.ts";
 import {
   APP_HEADER,
   attr,
@@ -21,6 +22,7 @@ import {
   CHAT_SHEET_HANDLE,
   CHAT_STRIP,
   CHAT_TOGGLE,
+  HEADER_SEARCH_RESULTS,
   HYDRATION_TIMEOUT,
   OUTLINE_TREE,
   POLL_TIMEOUT,
@@ -283,6 +285,26 @@ Then(
   async function (this: OlaiWorld, file: string) {
     await documentRow(this, file)
       .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+// ── how much of the answer it drew ─────────────────────────────────────
+//
+// The palette's steps are the same two, over the same helper
+// (`support/counted.ts`) and the same line in the client: one reading, two
+// doors, one sentence. What is this door's own is the panel it is read inside.
+
+Then(
+  "the header search found {string}",
+  async function (this: OlaiWorld, said: string) {
+    await foundCount(this, HEADER_SEARCH_RESULTS, said, "header search count");
+  },
+);
+
+Then(
+  "the header search says nothing about a total",
+  async function (this: OlaiWorld) {
+    await countsNothing(this, HEADER_SEARCH_RESULTS, "header search");
   },
 );
 

--- a/packages/tests/step_definitions/panel_steps.ts
+++ b/packages/tests/step_definitions/panel_steps.ts
@@ -26,6 +26,7 @@ import {
   HYDRATION_TIMEOUT,
   OUTLINE_TREE,
   POLL_TIMEOUT,
+  SEARCH_COUNT,
   SIDEBAR,
   SIDEBAR_BODY,
   SIDEBAR_COLLAPSE,
@@ -297,14 +298,23 @@ Then(
 Then(
   "the header search found {string}",
   async function (this: OlaiWorld, said: string) {
-    await foundCount(this, HEADER_SEARCH_RESULTS, said, "header search count");
+    await foundCount(
+      this,
+      `${HEADER_SEARCH_RESULTS} ${SEARCH_COUNT}`,
+      said,
+      "header search count",
+    );
   },
 );
 
 Then(
   "the header search says nothing about a total",
   async function (this: OlaiWorld) {
-    await countsNothing(this, HEADER_SEARCH_RESULTS, "header search");
+    await countsNothing(
+      this,
+      `${HEADER_SEARCH_RESULTS} ${SEARCH_COUNT}`,
+      "header search",
+    );
   },
 );
 

--- a/packages/tests/support/counted.ts
+++ b/packages/tests/support/counted.ts
@@ -1,0 +1,76 @@
+/**
+ * WHAT A SHORTLIST SAID ABOUT ITS OWN ANSWER — "8 of 20 matches", or nothing.
+ *
+ * Two doors ask this and it is one question in two places (`support/said.ts`
+ * exists for the same reason, one surface further on): the ⌘K palette and the
+ * header's box draw one line, from one function, under one testid — so a step
+ * file that spelled the ritual for itself would be the second spelling of a
+ * sentence the client keeps in one place.
+ *
+ * WHAT A DOOR STILL OWNS is WHERE the line is, which is why both of these take
+ * the door as a selector to look inside. One name serves both doors, and only
+ * one of them is ever up, but a step that gripped the line globally would be a
+ * step that could not say which door it was reading.
+ */
+
+import * as assert from "node:assert";
+
+import { POLL_TIMEOUT, SEARCH_COUNT } from "./world.ts";
+import type { OlaiWorld } from "./world.ts";
+
+const countIn = (world: OlaiWorld, within: string) =>
+  world.page.locator(`${within} ${SEARCH_COUNT}`).first();
+
+/**
+ * THE WHOLE LINE, exactly — never a substring, which is `filter_steps.ts`'
+ * ruling on the count line beside it and it holds here for the same arithmetic:
+ * `"8 of 2 matches"` is inside `"8 of 20 matches"`, so a substring read would
+ * pass on a denominator off by an order of magnitude.
+ *
+ * Waited for rather than read once: the hits it counts are a debounce and a
+ * round trip behind the keystroke that asked for them.
+ */
+export const foundCount = async (
+  world: OlaiWorld,
+  within: string,
+  said: string,
+  what: string,
+): Promise<void> => {
+  const line = countIn(world, within);
+  await line.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  await world.waitUntil(
+    async () => (await line.innerText().catch(() => "")).trim() === said,
+    `the ${what} to say exactly ${JSON.stringify(said)}`,
+  ).catch(() => undefined);
+  assert.strictEqual(
+    (await line.innerText()).trim(),
+    said,
+    `the ${what} reads ${JSON.stringify((await line.innerText()).trim())}`,
+  );
+};
+
+/**
+ * The other half, and the half the feature is half made of: a door that drew
+ * everything it found says NOTHING.
+ *
+ * Read after a frame rather than polled, because the absence has to be true
+ * NOW — waiting for it would pass on a door that dropped the line a beat
+ * later. What makes it mean something is the step before it in the scenario:
+ * the rows are already listed, so this is a door with an answer in front of it
+ * rather than a door that has not answered yet.
+ */
+export const countsNothing = async (
+  world: OlaiWorld,
+  within: string,
+  what: string,
+): Promise<void> => {
+  await world.waitForFrame();
+  const line = countIn(world, within);
+  assert.strictEqual(
+    await line.count(),
+    0,
+    `the ${what} says ${JSON.stringify(
+      (await line.innerText().catch(() => "")).trim(),
+    )}`,
+  );
+};

--- a/packages/tests/support/counted.ts
+++ b/packages/tests/support/counted.ts
@@ -1,76 +1,86 @@
 /**
- * WHAT A SHORTLIST SAID ABOUT ITS OWN ANSWER — "8 of 20 matches", or nothing.
+ * WHAT A COUNT LINE SAYS, read EXACTLY — and the other half, that there is no
+ * line at all.
  *
- * Two doors ask this and it is one question in two places (`support/said.ts`
- * exists for the same reason, one surface further on): the ⌘K palette and the
- * header's box draw one line, from one function, under one testid — so a step
- * file that spelled the ritual for itself would be the second spelling of a
- * sentence the client keeps in one place.
+ * Three doors ask this and it is one question in three places (`./said.ts`
+ * exists for the same reason, one surface over): the filter bar says "3 of 41"
+ * about the page it narrowed (`client/filter/count.ts`), and the ⌘K palette and
+ * the header's box say "8 of 20 matches" about the answer they only drew part
+ * of (`client/search/count.ts`). Every one of them is an element that holds a
+ * count and nothing else, waited for rather than read once, and printed back
+ * verbatim when it does not match — a ritual each step file spelled for itself
+ * until the third one wanted it.
  *
- * WHAT A DOOR STILL OWNS is WHERE the line is, which is why both of these take
- * the door as a selector to look inside. One name serves both doors, and only
- * one of them is ever up, but a step that gripped the line globally would be a
- * step that could not say which door it was reading.
+ * WHAT A DOOR STILL OWNS is WHICH element, which is why both of these take a
+ * locator. The two search doors draw their line under one testid, so a step
+ * there passes the door and the line together (`${PALETTE} ${SEARCH_COUNT}`)
+ * rather than gripping whichever door happens to be up.
  */
 
 import * as assert from "node:assert";
 
-import { POLL_TIMEOUT, SEARCH_COUNT } from "./world.ts";
+import { POLL_TIMEOUT } from "./world.ts";
 import type { OlaiWorld } from "./world.ts";
 
-const countIn = (world: OlaiWorld, within: string) =>
-  world.page.locator(`${within} ${SEARCH_COUNT}`).first();
-
 /**
- * THE WHOLE LINE, exactly — never a substring, which is `filter_steps.ts`'
- * ruling on the count line beside it and it holds here for the same arithmetic:
- * `"8 of 2 matches"` is inside `"8 of 20 matches"`, so a substring read would
- * pass on a denominator off by an order of magnitude.
+ * THE WHOLE LINE, exactly — never a substring.
  *
- * Waited for rather than read once: the hits it counts are a debounce and a
- * round trip behind the keystroke that asked for them.
+ * `./said.ts`'s reader matches a substring and is right to: the sentences it
+ * reads are phrases inside a paragraph somebody wrote. A count line is not one
+ * of those, and a substring read costs exactly the two things these features
+ * are made of: `"1 of 10"` is inside `"1 of 100"`, and `"1 of 10"` is inside
+ * `"1 of 10 — 2 more matches hidden as done (Prefs)"` — so a scenario that
+ * exists to prove NO clause is said could not see one appear (found by both
+ * reviewers of #248).
+ *
+ * Waited for rather than read once: the count settles a frame after the query
+ * that moved it, and a search door's is a debounce and a round trip behind the
+ * keystroke. What a failure prints is what the line actually says.
  */
 export const foundCount = async (
   world: OlaiWorld,
-  within: string,
+  locator: string,
   said: string,
   what: string,
 ): Promise<void> => {
-  const line = countIn(world, within);
+  const line = world.page.locator(locator).first();
   await line.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-  await world.waitUntil(
-    async () => (await line.innerText().catch(() => "")).trim() === said,
-    `the ${what} to say exactly ${JSON.stringify(said)}`,
-  ).catch(() => undefined);
-  assert.strictEqual(
-    (await line.innerText()).trim(),
-    said,
-    `the ${what} reads ${JSON.stringify((await line.innerText()).trim())}`,
-  );
+  // THE POLL KEEPS WHAT IT READ, and the assertion below reads nothing: an
+  // `assert` message is an eagerly evaluated expression, so re-reading the
+  // element there spent two more browser round trips on every PASSING call —
+  // and, worse, asserted on one frame while printing another.
+  let text = "";
+  await world.waitUntil(async () => {
+    text = (await line.innerText().catch(() => "")).trim();
+    return text === said;
+  }, `the ${what} to say exactly ${JSON.stringify(said)}`).catch(() => undefined);
+  assert.strictEqual(text, said, `the ${what} reads ${JSON.stringify(text)}`);
 };
 
 /**
- * The other half, and the half the feature is half made of: a door that drew
- * everything it found says NOTHING.
+ * The other half, and half of what the shortlist feature is made of: a door
+ * that drew everything it found says NOTHING.
  *
  * Read after a frame rather than polled, because the absence has to be true
  * NOW — waiting for it would pass on a door that dropped the line a beat
- * later. What makes it mean something is the step before it in the scenario:
- * the rows are already listed, so this is a door with an answer in front of it
- * rather than a door that has not answered yet.
+ * later, which is also why this is not `./said.ts`'s `saysNothing` (that one
+ * polls until a surface goes quiet, for a line that is on its way out). What
+ * makes it mean something is the step before it in the scenario: the rows are
+ * already listed, so this is a door with an answer in front of it rather than
+ * a door that has not answered yet.
  */
 export const countsNothing = async (
   world: OlaiWorld,
-  within: string,
+  locator: string,
   what: string,
 ): Promise<void> => {
   await world.waitForFrame();
-  const line = countIn(world, within);
-  assert.strictEqual(
-    await line.count(),
-    0,
+  const lines = world.page.locator(locator);
+  const drawn = await lines.count();
+  if (drawn === 0) return;
+  assert.fail(
     `the ${what} says ${JSON.stringify(
-      (await line.innerText().catch(() => "")).trim(),
+      (await lines.first().innerText().catch(() => "")).trim(),
     )}`,
   );
 };

--- a/packages/tests/support/said.ts
+++ b/packages/tests/support/said.ts
@@ -46,7 +46,12 @@ export const saysThat = async (
 
 /** The other half: nothing is being said at all. Its own function because
  *  "gone" is not a selector — it is the absence of every locator a surface can
- *  say something through, waited for across the render that removes them. */
+ *  say something through, waited for across the render that removes them.
+ *
+ *  WAITED FOR is the half to choose by, and it is the difference between this
+ *  and `./counted.ts`'s `countsNothing`: this one is for a line that is on its
+ *  way out, and that one for a line that must not be there NOW — where waiting
+ *  would pass on a surface that said something and took it back a beat later. */
 export const saysNothing = async (
   world: OlaiWorld,
   locators: ReadonlyArray<string>,

--- a/packages/tests/support/sweep.ts
+++ b/packages/tests/support/sweep.ts
@@ -139,3 +139,24 @@ export const granting = (
 ): ((file: string) => boolean) =>
 (file: string) =>
   allowed.some((one) => (one.endsWith("/") ? file.startsWith(one) : file === one));
+
+/**
+ * Which entries of a grant list name nothing that is there any more — the check
+ * a sweep makes about its OWN list, rather than about the repository.
+ *
+ * A grant is a claim that some named record of the past is allowed to spell the
+ * thing being hunted, and a claim about a path that has been moved is not a
+ * loosened fence — it is a fence that has quietly TIGHTENED onto whatever the
+ * path became. `docs/roadmap.olai` became the `docs/roadmap/` directory on
+ * 2026-08-20, and both sweeps went red on the ledger they were written to
+ * excuse, on master, for two days: the grant was still spelled, and it granted
+ * nothing.
+ *
+ * A directory entry is asked about WITHOUT its trailing slash, which is what
+ * makes `docs/RCA/` a question about the directory rather than about a file
+ * whose name ends in one.
+ */
+export const unresolved = (
+  allowed: ReadonlyArray<string>,
+): ReadonlyArray<string> =>
+  allowed.filter((one) => !exists(one.endsWith("/") ? one.slice(0, -1) : one));

--- a/packages/tests/support/world.ts
+++ b/packages/tests/support/world.ts
@@ -473,6 +473,10 @@ export const PANE_TAB = selector(TESTID.paneTab);
  *  palette and the header box. One name, because it is one sentence about one
  *  grammar; where each door draws it is that door’s own business. */
 export const SEARCH_REFUSAL = selector(TESTID.searchRefusal);
+/** …and the same count line on the same two doors: "8 of 20 matches", or no
+ *  element at all when the door drew everything it found. Scoped by the step
+ *  to the door it means, since one name serves both. */
+export const SEARCH_COUNT = selector(TESTID.searchCount);
 /** The date picker, in place under the row it was opened on — from the pill
  *  above, or from the `•••` menu's `Set date…`. Its box is a native
  *  `<input type="date">`, so what it holds is the ten characters the record

--- a/packages/tests/sweep.test.ts
+++ b/packages/tests/sweep.test.ts
@@ -19,7 +19,14 @@
 
 import { expect, test } from "bun:test";
 
-import { exists, granting, read, tracked, withoutComments } from "./support/sweep.ts";
+import {
+  exists,
+  granting,
+  read,
+  tracked,
+  unresolved,
+  withoutComments,
+} from "./support/sweep.ts";
 
 test("an exact entry grants that file and nothing that merely starts with it", () => {
   const granted = granting(["docs/format.md"]);
@@ -46,6 +53,17 @@ test("an empty list grants nothing, and grants are read together", () => {
   expect(granted("justfile")).toBe(true);
   expect(granted("docs/brainstorming/filter-in-place.md")).toBe(true);
   expect(granted("README.md")).toBe(false);
+});
+
+// …and the grant list held to the DISK, which is the half both sweeps went two
+// days without: `docs/roadmap.olai` became `docs/roadmap/` and the entry naming
+// it went on being spelled while covering nothing, so the ledger it was written
+// to excuse turned both sweeps red on master. A directory is asked about
+// without its trailing slash; a file exactly as written.
+test("an entry that names nothing on disk is reported, and a live one is not", () => {
+  expect(unresolved(["justfile", "docs/brainstorming/"])).toEqual([]);
+  expect(unresolved(["docs/roadmap.olai", "docs/roadmap/", "docs/nowhere/"]))
+    .toEqual(["docs/roadmap.olai", "docs/nowhere/"]);
 });
 
 // The walk itself: the listing is real, it leaves the caller out of it, and the

--- a/packages/web/src/client/palette/Palette.tsx
+++ b/packages/web/src/client/palette/Palette.tsx
@@ -971,8 +971,7 @@ export function Palette(props: {
                   the eight rows scroll, and absent when eight was all there
                   was. */}
               <SearchCount
-                drawn={nodes.hits().length}
-                total={nodes.total()}
+                of={nodes}
                 class="m-0 shrink-0 border-t border-rule px-4 py-2 font-mono text-xs text-muted"
               />
               </>

--- a/packages/web/src/client/palette/Palette.tsx
+++ b/packages/web/src/client/palette/Palette.tsx
@@ -915,65 +915,65 @@ export function Palette(props: {
           <Switch
             fallback={
               <>
-              {/* `overflow-x-hidden` is the doctrine, not a defence: a popover
-                  scrolls down, never sideways. The rows are already built not
-                  to overflow; this makes that a property of the container
-                  rather than of every future row. */}
-              <ul
-                class="m-0 min-h-0 flex-1 list-none overflow-x-hidden overflow-y-auto p-1 md:max-h-72 md:flex-none"
-                data-testid={TESTID.paletteList}
-              >
-                {/* `<Key>` rather than `<For>`, for the reason the tree uses it
-                    (`../Tree.tsx`): the rows are minted fresh on every read, so
-                    every keystroke during the 200 ms settle rebuilt a list whose
-                    hits had not changed, under a cursor somebody was walking
-                    down. `<Key>` and not `<Index>`, unlike the shortlists, for
-                    the same reason the tree is keyed: these rows MOVE — the
-                    hits arrive under the commands and rank against each other —
-                    and {@link PaletteItem.id} already promises the id is unique
-                    in this list, which is what makes it a key. */}
-                <Key
-                  each={items()}
-                  by="id"
-                  fallback={
-                    <li class="px-3 py-2 font-mono text-xs text-muted">
-                      no matches
-                    </li>
-                  }
+                {/* `overflow-x-hidden` is the doctrine, not a defence: a popover
+                    scrolls down, never sideways. The rows are already built not
+                    to overflow; this makes that a property of the container
+                    rather than of every future row. */}
+                <ul
+                  class="m-0 min-h-0 flex-1 list-none overflow-x-hidden overflow-y-auto p-1 md:max-h-72 md:flex-none"
+                  data-testid={TESTID.paletteList}
                 >
-                  {(item, index) => (
-                    <li>
-                      <Result
-                        label={item().label}
-                        of={item().of}
-                        hint={item().hint}
-                        place={item().place}
-                        props={item().props}
-                        active={lit(index())}
-                        testids={PALETTE_ROW}
-                        id={item().id}
-                        onHover={() => {
-                          setChosen(true)
-                          cursor.to(index())
-                        }}
-                        onSelect={() => runItem(item())}
-                      />
-                    </li>
-                  )}
-                </Key>
-              </ul>
-              {/* WHAT IS BEHIND THE HITS, and only ever about them: the rows
-                  above the hits are this tab's own (the zoomed node's verbs,
-                  the shelf's row, the shell), so the count is taken off the
-                  ANSWER rather than off the list it is drawn under — which is
-                  also why the sentence names its subject (`../search/count.ts`).
-                  Under the list rather than inside it, so it stays put while
-                  the eight rows scroll, and absent when eight was all there
-                  was. */}
-              <SearchCount
-                of={nodes}
-                class="m-0 shrink-0 border-t border-rule px-4 py-2 font-mono text-xs text-muted"
-              />
+                  {/* `<Key>` rather than `<For>`, for the reason the tree uses it
+                      (`../Tree.tsx`): the rows are minted fresh on every read, so
+                      every keystroke during the 200 ms settle rebuilt a list whose
+                      hits had not changed, under a cursor somebody was walking
+                      down. `<Key>` and not `<Index>`, unlike the shortlists, for
+                      the same reason the tree is keyed: these rows MOVE — the
+                      hits arrive under the commands and rank against each other —
+                      and {@link PaletteItem.id} already promises the id is unique
+                      in this list, which is what makes it a key. */}
+                  <Key
+                    each={items()}
+                    by="id"
+                    fallback={
+                      <li class="px-3 py-2 font-mono text-xs text-muted">
+                        no matches
+                      </li>
+                    }
+                  >
+                    {(item, index) => (
+                      <li>
+                        <Result
+                          label={item().label}
+                          of={item().of}
+                          hint={item().hint}
+                          place={item().place}
+                          props={item().props}
+                          active={lit(index())}
+                          testids={PALETTE_ROW}
+                          id={item().id}
+                          onHover={() => {
+                            setChosen(true)
+                            cursor.to(index())
+                          }}
+                          onSelect={() => runItem(item())}
+                        />
+                      </li>
+                    )}
+                  </Key>
+                </ul>
+                {/* WHAT IS BEHIND THE HITS, and only ever about them: the rows
+                    above the hits are this tab's own (the zoomed node's verbs,
+                    the shelf's row, the shell), so the count is taken off the
+                    ANSWER rather than off the list it is drawn under — which is
+                    also why the sentence names its subject (`../search/count.ts`).
+                    Under the list rather than inside it, so it stays put while
+                    the eight rows scroll, and absent when eight was all there
+                    was. */}
+                <SearchCount
+                  of={nodes}
+                  class="m-0 shrink-0 border-t border-rule px-4 py-2 font-mono text-xs text-muted"
+                />
               </>
             }
           >

--- a/packages/web/src/client/palette/Palette.tsx
+++ b/packages/web/src/client/palette/Palette.tsx
@@ -96,6 +96,7 @@ import { sayPin, togglePin } from "../pins/pinning.ts"
 import { nameOf, shownIn } from "../address/address.ts"
 import { type Asking } from "./asking.ts"
 import { Question } from "./Question.tsx"
+import { SearchCount } from "../search/Count.tsx"
 import { createCursor } from "../search/cursor.ts"
 import { createSearch } from "../search/nodes.ts"
 import { Result, type RowTestids } from "../search/Result.tsx"
@@ -913,10 +914,11 @@ export function Palette(props: {
           </Show>
           <Switch
             fallback={
-              // `overflow-x-hidden` is the doctrine, not a defence: a popover
-              // scrolls down, never sideways. The rows are already built not
-              // to overflow; this makes that a property of the container
-              // rather than of every future row.
+              <>
+              {/* `overflow-x-hidden` is the doctrine, not a defence: a popover
+                  scrolls down, never sideways. The rows are already built not
+                  to overflow; this makes that a property of the container
+                  rather than of every future row. */}
               <ul
                 class="m-0 min-h-0 flex-1 list-none overflow-x-hidden overflow-y-auto p-1 md:max-h-72 md:flex-none"
                 data-testid={TESTID.paletteList}
@@ -960,6 +962,20 @@ export function Palette(props: {
                   )}
                 </Key>
               </ul>
+              {/* WHAT IS BEHIND THE HITS, and only ever about them: the rows
+                  above the hits are this tab's own (the zoomed node's verbs,
+                  the shelf's row, the shell), so the count is taken off the
+                  ANSWER rather than off the list it is drawn under — which is
+                  also why the sentence names its subject (`../search/count.ts`).
+                  Under the list rather than inside it, so it stays put while
+                  the eight rows scroll, and absent when eight was all there
+                  was. */}
+              <SearchCount
+                drawn={nodes.hits().length}
+                total={nodes.total()}
+                class="m-0 shrink-0 border-t border-rule px-4 py-2 font-mono text-xs text-muted"
+              />
+              </>
             }
           >
             {/* THE QUESTION FIRST, above both prefixes: it is up because

--- a/packages/web/src/client/search/Count.tsx
+++ b/packages/web/src/client/search/Count.tsx
@@ -10,6 +10,15 @@
  * which is why the classes are the caller's — `../edit/SaidLine.tsx` draws the
  * same line between a sentence and its layout, and for the same reason.
  *
+ * IT TAKES THE SEARCH, not two numbers, and that is the whole of what this
+ * component is careful about. The numerator and the denominator are one thing
+ * — an answer, and how much of it fits — and a door handed them over
+ * separately would be free to count something else: the palette's list is its
+ * op rows, the shelf's row and the shell ABOVE the hits, so `items().length`
+ * is a number that is right in one door and wrong in the other. Handed the
+ * reading itself there is nothing to get wrong, and the pair cannot come from
+ * two moments (`./nodes.ts`: both are read off one answer).
+ *
  * NOT A LIVE REGION, and that is a decision rather than an omission. Both doors
  * are answered as somebody types, so a polite region here would queue a fresh
  * "8 of 90 matches" behind every keystroke — a reader who has not changed their
@@ -22,13 +31,18 @@
 import { Show } from "solid-js"
 
 import { TESTID } from "../testids.ts"
-import { countLine, type Drawn } from "./count.ts"
+import { countLine } from "./count.ts"
+import type { Search } from "./nodes.ts"
 
-export function SearchCount(props: Drawn & {
+export function SearchCount(props: {
+  /** The reading this line is about — the hits it drew and the total it found,
+   *  off the one answer that carries both. */
+  readonly of: Pick<Search, "hits" | "total">
   /** Where the line sits, and how it is boxed — the door's own. */
   readonly class?: string
 }) {
-  const said = () => countLine({ drawn: props.drawn, total: props.total })
+  const said = () =>
+    countLine({ drawn: props.of.hits().length, total: props.of.total() })
   return (
     <Show when={said()}>
       {(line) => (

--- a/packages/web/src/client/search/Count.tsx
+++ b/packages/web/src/client/search/Count.tsx
@@ -1,0 +1,39 @@
+/**
+ * The line under a shortlist that says what it could not draw — one component,
+ * because there is one reading and one sentence about it.
+ *
+ * The two doors already share their rows (`./Result.tsx`), their cursor
+ * (`./cursor.ts`) and their reading (`./nodes.ts`); the sentence about how much
+ * of that reading is on screen is the same kind of thing, and a second spelling
+ * of it in the second door is the drift this whole seam exists against. What
+ * the doors genuinely differ about is where the line SITS and how it is boxed,
+ * which is why the classes are the caller's — `../edit/SaidLine.tsx` draws the
+ * same line between a sentence and its layout, and for the same reason.
+ *
+ * NOT A LIVE REGION, and that is a decision rather than an omission. Both doors
+ * are answered as somebody types, so a polite region here would queue a fresh
+ * "8 of 90 matches" behind every keystroke — a reader who has not changed their
+ * mind, read to a second time (`an_answer_leaves_the_rows_standing.feature`
+ * makes that argument for the refusal lines, which are announced because a
+ * refusal is news). This is a READOUT beside the rows it counts: it is there to
+ * be looked at, and the rows are what a screen reader is walking.
+ */
+
+import { Show } from "solid-js"
+
+import { TESTID } from "../testids.ts"
+import { countLine, type Drawn } from "./count.ts"
+
+export function SearchCount(props: Drawn & {
+  /** Where the line sits, and how it is boxed — the door's own. */
+  readonly class?: string
+}) {
+  const said = () => countLine({ drawn: props.drawn, total: props.total })
+  return (
+    <Show when={said()}>
+      {(line) => (
+        <p class={props.class} data-testid={TESTID.searchCount}>{line()}</p>
+      )}
+    </Show>
+  )
+}

--- a/packages/web/src/client/search/HeaderSearch.tsx
+++ b/packages/web/src/client/search/HeaderSearch.tsx
@@ -288,8 +288,7 @@ export function HeaderSearch(props: {
                   in front of them, and absent entirely when the eight are all
                   there was (`./count.ts`). */}
               <SearchCount
-                drawn={items().length}
-                total={nodes.total()}
+                of={nodes}
                 class="m-0 border-t border-rule/40 px-3 py-1.5 font-mono text-xs text-muted"
               />
             </div>

--- a/packages/web/src/client/search/HeaderSearch.tsx
+++ b/packages/web/src/client/search/HeaderSearch.tsx
@@ -65,6 +65,7 @@ import type { Route } from "../routes.ts"
 import { listKey } from "../keys.ts"
 import { TESTID } from "../testids.ts"
 import { TARGET } from "../touch.ts"
+import { SearchCount } from "./Count.tsx"
 import { createCursor } from "./cursor.ts"
 import { createSearch } from "./nodes.ts"
 import { Result, type RowTestids } from "./Result.tsx"
@@ -282,6 +283,15 @@ export function HeaderSearch(props: {
                   )}
                 </Index>
               </ul>
+              {/* WHAT IS BEHIND THE ROWS — under the list rather than inside
+                  it, so a reader who has scrolled the eight rows still has it
+                  in front of them, and absent entirely when the eight are all
+                  there was (`./count.ts`). */}
+              <SearchCount
+                drawn={items().length}
+                total={nodes.total()}
+                class="m-0 border-t border-rule/40 px-3 py-1.5 font-mono text-xs text-muted"
+              />
             </div>
           </Portal>
         )}

--- a/packages/web/src/client/search/count.test.ts
+++ b/packages/web/src/client/search/count.test.ts
@@ -1,0 +1,42 @@
+/**
+ * What a shortlist says about the answer it could not draw all of, over every
+ * shape two numbers can be in.
+ *
+ * A sentence rather than a layout, which is why this is a `bun test` and not a
+ * scenario: what a browser adds is that the numbers are the ANSWER's own and
+ * that the line is drawn where a reader looks, and both doors have a scenario
+ * for that (`packages/tests/features/a_shortlist_says_its_total.feature`).
+ * What is pinned HERE is the English — and, above all, the silence: a door that
+ * drew everything it found says nothing, because "8 of 8" is a number somebody
+ * has to read before they can ignore it (`../filter/count.ts` makes the same
+ * ruling about a zero).
+ */
+
+import { expect, test } from "bun:test"
+
+import { countLine } from "./count.ts"
+
+// The line this file exists for: eight rows, and a reader who would otherwise
+// believe the vault holds eight.
+test("a capped answer says how many it drew and how many there were", () => {
+  expect(countLine({ drawn: 8, total: 90 })).toBe("8 of 90 matches")
+})
+
+test("an answer that fits says nothing at all", () => {
+  expect(countLine({ drawn: 3, total: 3 })).toBe(null)
+})
+
+// Nothing found is not a denominator either: the rows are absent and so is the
+// line, and the door's own empty state is what says so.
+test("nothing found says nothing", () => {
+  expect(countLine({ drawn: 0, total: 0 })).toBe(null)
+})
+
+// A total BELOW what is drawn is arithmetic nobody can read, so the honest
+// answer is the same silence rather than "9 of 2 matches". It cannot happen
+// while both numbers ride on one answer (`./nodes.ts`), which is exactly why
+// it is pinned: the day they come from two places, this is the line that must
+// not start lying.
+test("a total that cannot be right is not said out loud", () => {
+  expect(countLine({ drawn: 9, total: 2 })).toBe(null)
+})

--- a/packages/web/src/client/search/count.ts
+++ b/packages/web/src/client/search/count.ts
@@ -1,0 +1,55 @@
+/**
+ * What a SHORTLIST says about the answer it only drew part of.
+ *
+ * THE DEFECT IT WAS WRITTEN FOR is a door that cannot count past eight. Both
+ * doors onto the one reading — the ⌘K palette and the header's box — ask for
+ * {@link ./nodes.ts}'s `LIMIT` hits and draw exactly what comes back, so a
+ * query that matched ninety nodes and a query that matched eight were the same
+ * eight rows and the same silence underneath them. The number was never
+ * missing from the wire: a search answers with the uncapped `total` beside its
+ * capped `hits` precisely so that "eight of ninety" is sayable
+ * (`@olai/format`'s `searching.ts`, `@olai/ops`' `query.ts`), and the browser
+ * read one field and dropped the other. The filtered page has said all three of
+ * its truths since #248 (`../filter/count.ts`); this is the same honesty at the
+ * two doors that were left out of it.
+ *
+ * A FUNCTION rather than lines inside two components, for that file's reason
+ * twice over: a sentence assembled in a JSX binding is a sentence no test can
+ * ask about, and a sentence assembled in TWO of them is two sentences one
+ * rename away from disagreeing. One reading, two doors, one line about it.
+ *
+ * WHAT IS NOT SAID IS THE WHOLE ANSWER. A door that drew everything it found
+ * says nothing — "8 of 8 matches" is a number a reader has to take in before
+ * they can ignore it, and the rows themselves already say how many there are.
+ * The line appears exactly when there is something behind the rows, which is
+ * the only moment it carries news.
+ *
+ * IT IS ABOUT THE HITS, never about the list. The palette draws its shell
+ * commands, the page's own verbs and the pin row above the hits, and none of
+ * those came from the server or are counted in anything here — which is why
+ * the sentence names its subject (`matches`) rather than leaving two bare
+ * numbers under a list whose top half they say nothing about.
+ */
+
+/** The two numbers a door knows about one answer — both read off the same
+ *  value, which is what keeps them from being arithmetic from two moments
+ *  (`./nodes.ts` hands back an answer that carries its own total). */
+export interface Drawn {
+  /** The rows this door drew: the hits it was sent, capped server-side. */
+  readonly drawn: number
+  /** How many matched in all, uncapped — the denominator the wire has been
+   *  carrying all along. */
+  readonly total: number
+}
+
+/**
+ * The line — "8 of 90 matches" — or `null` when the honest thing is to say
+ * nothing.
+ *
+ * A total that is not GREATER than what was drawn is that silence, and the
+ * comparison is deliberately not an equality: the two numbers ride on one
+ * answer today, so `total < drawn` cannot happen, and the day it can, a line
+ * reading "9 of 2 matches" would be worse than no line at all.
+ */
+export const countLine = ({ drawn, total }: Drawn): string | null =>
+  total > drawn ? `${drawn} of ${total} matches` : null

--- a/packages/web/src/client/search/nodes.ts
+++ b/packages/web/src/client/search/nodes.ts
@@ -55,6 +55,23 @@ export const LIMIT = 8
 
 export interface Search<H extends SearchHit = SearchHit> {
   readonly hits: Accessor<ReadonlyArray<H>>
+  /**
+   * HOW MANY MATCHED IN ALL — uncapped, where {@link hits} is only what
+   * {@link LIMIT} let through. `0` when nothing has answered.
+   *
+   * The cap is a fact about a DOOR and the total is a fact about the QUERY, and
+   * this is the number every door here had and did not pass on: an answer
+   * carries it precisely so that "eight of ninety" is sayable (`@olai/format`'s
+   * `SearchAnswer`, `@olai/ops`' `query.ts`), and the two doors drew eight rows
+   * and said nothing. What a door SAYS with it is `./count.ts`.
+   *
+   * READ OFF THE SAME VALUE THE HITS ARE, which is what keeps the pair from
+   * being two numbers out of two moments: while a newer query is in flight the
+   * rows hold still, and this holds still with them — so a line under them
+   * counts the rows a reader is looking at rather than the answer they are
+   * waiting for.
+   */
+  readonly total: Accessor<number>
   /** A refusal from the server, in its own words — `null` when there is none.
    *  Never silently dropped (`../run.ts` forbids a silent handler). */
   readonly failure: Accessor<string | null>
@@ -137,6 +154,11 @@ export function createSearch(
 
   return {
     hits: () => asked.answer()?.hits ?? [],
+    // The uncapped count, off the same answer the rows come off — never
+    // `hits.length` and never a second call. Nothing answered is `0`, which is
+    // the one reading that makes the sentence under a door disappear rather
+    // than claim a denominator nobody has been given (`./count.ts`).
+    total: () => asked.answer()?.total ?? 0,
     failure: asked.failure,
     refusals: () => asked.answer()?.refusals ?? [],
     // Straight through: which query the rows answer is the primitive's own

--- a/packages/web/src/client/testids.ts
+++ b/packages/web/src/client/testids.ts
@@ -942,6 +942,12 @@ export const TESTID = {
    *  palette and the header box. One name for both, because it is one sentence
    *  about one grammar; where it is drawn is each door's own business. */
   searchRefusal: "search-refusal",
+  /** "8 of 90 matches" — what a shortlist drew of what it found, on the same
+   *  two doors, and ABSENT when it drew the lot. One name for both for the
+   *  refusal's reason above: one sentence about one answer
+   *  (`client/search/count.ts`). A scenario reads it inside the door it means,
+   *  since only one of the two is ever up. */
+  searchCount: "search-count",
   // ── the header's search box, the other door to the same reading ──────
   headerSearch: "header-search",
   /** The phone's door: opens the palette, which is the same modal. */

--- a/website/index.html
+++ b/website/index.html
@@ -841,8 +841,11 @@ The corner unit is the **risky one** — see
     <h2>Finding, and filtering in place</h2>
     <p class="lead">One query language, four doors: the box in the header, the
     ⌘K palette, an agent’s <code>search_nodes</code>, and the filter that
-    narrows the page in front of you. The first three list what they found;
-    the fourth takes rows away and leaves the rest standing where they live.
+    narrows the page in front of you. The first three list what they found —
+    the two in the browser draw at most eight rows and say <code>8 of 20
+    matches</code> underneath when there were more, and nothing at all when
+    there were not; the fourth takes rows away and leaves the rest standing
+    where they live.
     The two that list also find <strong>documents</strong>: a <code>.md</code>
     or a saved page is a hit of its own, looked for in four places that line up
     with a node’s one for one — what it is called, its path, the tags in its


### PR DESCRIPTION
## The defect

Both doors onto the one search reading — the ⌘K palette and the header's box — ask for eight hits (`packages/web/src/client/search/nodes.ts`'s `LIMIT`, sent as `limit` on the request) and draw exactly what comes back. So a query matching forty-four things and a query matching eight were the same eight rows under the same silence: the door told a reader the directory holds eight of something it holds forty-four of.

The number was never missing from the wire. A search answers with an uncapped `total` beside its capped `hits`, kept for exactly this sentence — `packages/format/src/searching.ts:167-170` ("hits is capped; this is not, so 'twelve of ninety' is sayable"), computed at `packages/ops/src/query.ts:351`. The browser read `.hits` and dropped `.total`, and the `Search` interface never exposed it. The filtered page has told all three of its truths since #248; these are the two doors that were left out of it.

## What changed

- **`Search` gains `total`** (`search/nodes.ts`) — read off the same answer the hits come off, so while a newer query is in flight the rows hold still and the count holds still with them. Never `hits.length`, never a second call.
- **The sentence is a pure function** (`search/count.ts`): `8 of 44 matches` when more matched than fit, `null` when the answer fits — the same ruling `filter/count.ts` makes about a part that is zero, since a number a reader must take in before they can ignore it is worse than none. It names its subject (`matches`) because the palette draws op rows, the shelf's row and the shell above the hits, and the count says nothing about those.
- **One row component** (`search/Count.tsx`), shared by both doors exactly as the rows (`Result.tsx`), the cursor and the reading already are; each door owns only where the line sits. It takes the READING rather than two numbers (refactor pass, `69fc1388`), so a door cannot hand it the wrong numerator — `items().length` is right in the header box and wrong in the palette, and that rule is now unrepresentable rather than merely unwritten.
- **Not a live region.** Both doors answer as somebody types, and a polite region would read a fresh count to a reader behind every keystroke. The refusal rows (`role="alert"`) are untouched.
- **One testid for both doors** (`search-count`), following `search-refusal`'s precedent; the steps scope it to the door they mean.
- **Docs**: `docs/search.md` gains the ruling — including why the three picker panels under a row are deliberately not part of it — and the website's find section stops saying the listing doors "list what they found" without qualification.

## Verification

**Red first.** The unit suite was written against a module that did not exist and failed on the import. The two presence scenarios were then run against a client built with the two door components checked out from `master`:

```
✖ Then the palette found "8 of 20 matches" # step_definitions/palette_steps.ts:245
    waitFor: Timeout 15000ms exceeded.
      - waiting for locator('[data-testid="palette"] [data-testid="search-count"]').first() to be visible
✖ Then the header search found "8 of 20 matches" # step_definitions/panel_steps.ts:297
    waitFor: Timeout 15000ms exceeded.
      - waiting for locator('[data-testid="header-search-results"] [data-testid="search-count"]').first() to be visible
```

**Green after** — `features/a_shortlist_says_its_total.feature`, one scenario per door for the count and one per door for the silence:

```
4 scenarios (4 passed)
16 steps (16 passed)
```

…and the features that share the reader the `/simplify` pass unified (`filter_in_place`, `filter_everywhere`, `recurring_dates`, `archived_only_in_trash`, `the_connection`, `it_stays_live`):

```
42 scenarios (42 passed)
408 steps (408 passed)
```

Unit: `packages/web/src/client/search/count.test.ts` (the sentence, the silence when the answer fits, the silence when nothing was found, and the silence for a total that cannot be right). Full `bun test`: 2946 pass, 0 fail. CI: `odu run --platform x86_64-linux` on `8d8779c8` — every node green, and `gh pr checks 306 --required` reports all nine required contexts passing.

**Screenshots** — `packages/tests/evidence.ts`, section `a-shortlist-says-its-total`, which writes forty rows that answer one word (the fixture is a five-node house and the cap never bites in it) and photographs both doors and the silence:

```
  hits drawn:         8
  and it says:        8 of 44 matches
  an answer that fits: 2 hits, and the line is absent
  the header box too: 8 of 44 matches
```

The palette, capped:

<img width="1100" alt="the palette says its total" src="https://github.com/user-attachments/assets/0cabe13d-978a-47fb-a24f-433277acbbe2" />

The same palette over an answer that fits — the rows are there and there is no line under them:

<img width="1100" alt="an answer that fits says nothing" src="https://github.com/user-attachments/assets/58affc57-5362-4353-816c-a2996778614e" />

The header's box, over the same word:

<img width="1100" alt="the header box says it too" src="https://github.com/user-attachments/assets/079848cb-64c4-4665-8894-4c45941aeb01" />

## The refactor passes

- **architecture-first-principles + hickey/lowy** (`69fc1388`): hickey's fragmentation check over the pass just made — "how many were drawn" and "how many matched" are one thing, and the component took them as two props held together by an unenforced rule that is not the same in both doors. It takes the reading now (P4: the mismatched pair became unrepresentable). C1 found nothing to adopt; C3 found no volatility wanting a home of its own.
- **`/simplify`** (`2a787233`), four passes, three of which landed on the same duplicate: the exact-line reader was a copy of the filter bar's own step body. One reader now serves three doors. Efficiency found real waste in it, inherited and doubled: `assert`'s message argument is eager, so the passing path re-read `innerText` twice — and in the absence check that read was against a locator matching **nothing**, i.e. Playwright's 30-second default timeout burned on every green call, twice per suite run. Also: the two sweeps' grant lists are now held to the disk (`sweep.ts`'s `unresolved`), which is the check that would have caught the break below the day it happened.

## Carried, not owned

- `packages/tests/stdio.test.ts` and `packages/tests/extension.test.ts` granted `docs/roadmap.olai` to their record-of-the-past sweeps. That file became the `docs/roadmap/` directory in 694b375d/d8911ecc, and **both sweeps have been red on `master` ever since** (they now catch `docs/roadmap/bugs.olai` and `features.olai`). The grant is the directory now, and a test in each sweep asserts every grant still names something. Unrelated to this lane; fixed here because the test leg cannot be green otherwise.
- `evidence.ts`'s `PALETTE_HIT` gripped `data-id^="node-"`, a prefix no row has ever carried, so `archived-only-in-trash` printed "(nothing)" where its hits should have been.
- `packages/tests/README.md`'s census sentence was recomputed; it had drifted by a feature and ~55 `@scratch:` scenarios before this PR.

## Deferrals

- **The three panels under a row and the composer's `@` list still cap silently.** They share `LIMIT` and get `total` for free from the primitive, and the line is deliberately not drawn there: each is a PICKER — which node this row goes under, what it points at, which one to mirror, which node to arm a message with — and the question there is whether what you are spelling is in the list, not how much of the directory answers to it. Written into `docs/search.md` as the ruling rather than left as an omission.
- **`docs/search.md`'s "Documents, by name" section is stale, and this PR did not fix it.** It still says documents are "matched in your own tab off the list it already holds", "on the NAME and the PATH, and on nothing else", and that finding a note by what it says is "parked" — all three were closed when one reading began answering both kinds (`matchingDocuments`), and the same file contradicts them thirty lines earlier. Out of this lane's scope; it wants a rewrite of that section by whoever owns the documents arc.
- **`packages/tests/README.md`'s census is still hand-recomputed** by every feature-adding PR, which is how it drifted. The review's suggestion — a `bun test` that computes it from `features/*.feature` and asserts the prose — is a good one and a lane of its own.
- **The roadmap node was not marked.** `docs/roadmap/deferred.olai`'s `palette-count-cap` is left untouched so tonight's lanes do not collide in one ledger file; the orchestrator marks it at merge.
