### PR TITLE
A preview line trims closing heading hashes by scanning, not matching (preview-atx-regex)

### DIFF
--- a/packages/web/src/client/note/preview.test.ts
+++ b/packages/web/src/client/note/preview.test.ts
@@ -36,6 +36,14 @@ test("the closing hashes come off, and a hash that is a word does not", () => {
   expect(plainLine("# Notes ##\n\nbody")).toBe("Notes")
 })
 
+test("a non-breaking space is not the gap a closing run needs", () => {
+  // Chosen, not an accident of the scan: CommonMark wants U+0020 or tab before
+  // the closing hashes, and headingText already spelled those two. The regex
+  // this replaces treated NBSP (and the rest of `\s`) as that gap, so this
+  // line used to preview as `Foo`.
+  expect(plainLine("# Foo\u00a0##")).toBe("Foo\u00a0##")
+})
+
 test("a long run of spaces that does not close a heading is answered at once", () => {
   // The reason this counts rather than matching: `replace(/\s+#+$/, "")` is
   // quadratic on a line of many spaces that do not end in hashes — the

--- a/packages/web/src/client/note/preview.test.ts
+++ b/packages/web/src/client/note/preview.test.ts
@@ -28,6 +28,25 @@ test("a leading heading is named without its marks", () => {
   expect(plainLine("# Notes\n\nbody")).toBe("Notes")
 })
 
+// The closing run markdown allows, and the one place it must NOT come off: a
+// heading that ends in a hash with no space before it is a heading about C#.
+test("the closing hashes come off, and a hash that is a word does not", () => {
+  expect(plainLine("## Install ##")).toBe("Install")
+  expect(plainLine("## C#")).toBe("C#")
+  expect(plainLine("# Notes ##\n\nbody")).toBe("Notes")
+})
+
+test("a long run of spaces that does not close a heading is answered at once", () => {
+  // The reason this counts rather than matching: `replace(/\s+#+$/, "")` is
+  // quadratic on a line of many spaces that do not end in hashes — the
+  // unanchored `\s+` restarts at every position. A tenth of a second here
+  // would be a finding.
+  const started = performance.now()
+  const line = `x${" ".repeat(50_000)}y`
+  expect(plainLine(line)).toBe(line)
+  expect(performance.now() - started).toBeLessThan(100)
+}, 500)
+
 test("an empty note previews as nothing", () => {
   expect(plainLine("")).toBe("")
   expect(plainLine("\n \n")).toBe("")

--- a/packages/web/src/client/note/preview.ts
+++ b/packages/web/src/client/note/preview.ts
@@ -52,6 +52,15 @@ const stripMarks = (line: string): string => {
   text = text.replace(/\*([^*]+)\*/g, "$1")
   text = text.replace(/_([^_]+)_/g, "$1")
   text = text.replace(/`([^`]+)`/g, "$1")
-  text = text.replace(/\s+#+$/, "")
+  // Closing ATX hashes, counted off the end rather than `replace(/\s+#+$/, "")`
+  // — the same linear spelling slug.ts chose. The regex is quadratic: an
+  // unanchored `\s+` restarts at every position of a line of spaces.
+  let end = text.length
+  while (end > 0 && text[end - 1] === "#") end--
+  if (end < text.length) {
+    let before = end
+    while (before > 0 && (text[before - 1] === " " || text[before - 1] === "\t")) before--
+    if (before < end) text = text.slice(0, before)
+  }
   return text.trim()
 }

--- a/packages/web/src/client/note/preview.ts
+++ b/packages/web/src/client/note/preview.ts
@@ -55,6 +55,8 @@ const stripMarks = (line: string): string => {
   // Closing ATX hashes, counted off the end rather than `replace(/\s+#+$/, "")`
   // — the same linear spelling slug.ts chose. The regex is quadratic: an
   // unanchored `\s+` restarts at every position of a line of spaces.
+  // Space and tab only, on purpose: CommonMark's closer, and headingText's two
+  // characters. The old `\s` also took NBSP (and U+2000, U+FEFF, \f, \v).
   let end = text.length
   while (end > 0 && text[end - 1] === "#") end--
   if (end < text.length) {


### PR DESCRIPTION
Closes the remaining half of the ATX heading-trim pair that `packages/format/src/slug.ts` documents as quadratic (`js/polynomial-redos`). Filed from #304's deferral (`preview-atx-regex`).

## What changed and why

`plainLine` trimmed closing heading hashes with `replace(/\s+#+$/, "")`. That regex backtracks polynomially on a long run of spaces that does **not** end in hashes: an unanchored `\s+` restarts at every position.

Closing hashes are now counted off the end, the same linear spelling `headingText` already uses. Honest headings are unchanged: a space-or-tab run in front of trailing `#` comes off, and a hash that is a word (`## C#`) stays. One deliberate narrowing: the old `\s` also treated NBSP (and U+2000–U+200A, U+FEFF, `\f`, `\v`) as that gap; the scan tests space and tab only, which is CommonMark's closer and the two characters `headingText` already spelled. A heading pasted from the web as `# Foo\u00a0##` keeps its trailing hashes. Still a preview of one line, not a second renderer.

## Twin sweep

Repo-wide hunt for the same unanchored ATX-trim pattern (`/\s+#+$/`, `\s+#+$`, trailing `#+` after whitespace):

- `packages/format/src/slug.ts` already scans (the comment names the regex it replaced).
- `packages/web/src/client/markdown/title.ts` only strips a *leading* `^#{1,6}\s+` (anchored; not this class).
- `preview.ts`'s own leading `^#{1,6}\s+` is likewise anchored. Left as-is.

No other live instance of the trailing pattern.

## How it was verified

Red-first unit test against the regex, then the scan. Honest headings (`## Install ##` → `Install`; `## C#` stays `C#`) plus an adversarial `"x" + " ".repeat(50_000) + "y"` with a 100ms bound (500ms test timeout so a regression fails fast rather than hanging). The NBSP case is pinned as the chosen narrowing (`# Foo\u00a0##` → `Foo\u00a0##`), not as a leftover of the scan.

**Red (regex still in place):**

```
(pass) the closing hashes come off, and a hash that is a word does not
error: expect(received).toBeLessThan(expected)

Expected: < 100
Received: 1593.6842040000001

(fail) a long run of spaces that does not close a heading is answered at once [1594.02ms]
  ^ this test timed out after 500ms.

 7 pass
 1 fail
Ran 8 tests across 1 file. [1.61s]
```

**Green (scan):**

```
(pass) the closing hashes come off, and a hash that is a word does not
(pass) a non-breaking space is not the gap a closing run needs
(pass) a long run of spaces that does not close a heading is answered at once

 9 pass
 0 fail
 15 expect() calls
Ran 9 tests across 1 file. [10.00ms]
```

Command: `nix develop --accept-flake-config -c bun test packages/web/src/client/note/preview.test.ts`

## Deferrals

None. The class is closed in this codebase; `docs/roadmap/*` is left to the orchestrator.