### PR TITLE
The commit pill brightens on hover, like the rest of the bar

### DIFF
--- a/packages/web/src/client/commit/Commit.tsx
+++ b/packages/web/src/client/commit/Commit.tsx
@@ -205,8 +205,14 @@ export function Commit() {
           // when the rest of it goes. `min-w-9` is the floor of THAT shrink:
           // without it a 360pt bar (an iPhone mini) ate the glyph too and
           // left an empty oval between `live` and the agent toggle.
+          //
+          // Hover brightens to paper, the same token the agent and prefs
+          // already use (`../readout.ts`'s ICON_BUTTON). `hover:text-ink` is
+          // the paper-page hover — muted words going dark — and on this bar
+          // it painted the label the colour of the bar. The tip is a hover;
+          // asking what the pill says made the pill unreadable.
           class={`${PILL} min-w-9 max-w-[9rem] sm:max-w-none ${
-            inert() ? "opacity-60" : "hover:text-ink"
+            inert() ? "opacity-60" : "hover:text-paper"
           }`}
           data-testid={TESTID.commitPill}
           // The STATE as an attribute, so a scenario asserts on which face this
@@ -234,7 +240,7 @@ export function Commit() {
         >
           <Show when={MARK[face()]}>
             {(mark) => (
-              <span class={`shrink-0 ${mark().tone}`} aria-hidden="true">
+              <span class={`shrink-0 ${mark().tone ?? ""}`} aria-hidden="true">
                 {mark().glyph}
               </span>
             )}

--- a/packages/web/src/client/commit/said.test.ts
+++ b/packages/web/src/client/commit/said.test.ts
@@ -131,7 +131,9 @@ test("a healthy repository is quiet, and not a second green claim", () => {
   // The retired readout's rule, and it outlives it: the connection dot beside
   // this pill is the page's one green claim, and a second one lit permanently
   // in the ordinary case dilutes the thing a reader actually scans for.
-  expect(MARK.committed?.glyph).toBe("✓")
+  // Quiet is also no extra paint: a `text-muted` tick is a paper-page token
+  // and vanishes into the ink header this mark actually lives on.
+  expect(MARK.committed).toEqual({ glyph: "✓" })
   expect(MARK.never).toBeNull()
   expect(MARK.waiting).toBeNull()
 })

--- a/packages/web/src/client/commit/said.ts
+++ b/packages/web/src/client/commit/said.ts
@@ -214,13 +214,19 @@ export const newsSays = (
  * and a second one permanently lit in the ordinary case dilutes the thing a
  * reader actually scans for. Recency is what the committed face carries
  * (`✓ committed · 3m ago`); the colour was only ever decoration.
+ *
+ * It is also not `text-muted`. Muted is a paper-page token, and this mark
+ * lives on the ink header: muted-on-ink is the same colour as the bar, so
+ * the tick vanished. Quiet here means the chip's own ink — no tone, so the
+ * glyph inherits the pill and brightens with the words on hover.
  */
 export interface Mark {
   /** One character, already in the font — nothing to load and nothing to
    *  disagree with the words beside it. */
   readonly glyph: string
-  /** The token that paints it. A theme token, never a literal colour. */
-  readonly tone: string
+  /** The token that paints it, when the glyph has a colour of its own.
+   *  A theme token, never a literal colour. Absent is the chip's own ink. */
+  readonly tone?: string
 }
 
 export const MARK: Readonly<Record<Face, Mark | null>> = {
@@ -230,7 +236,7 @@ export const MARK: Readonly<Record<Face, Mark | null>> = {
   error: { glyph: "⚠", tone: "text-alarm" },
   blocked: { glyph: "⚠", tone: "text-doing" },
   waiting: null,
-  committed: { glyph: "✓", tone: "text-muted" },
+  committed: { glyph: "✓" },
   never: null,
 }
 


### PR DESCRIPTION
Hovering `✓ committed · 6m ago` to read the tip painted the label `text-ink` — the colour of the header — so the chip vanished while `>_ agent` and `prefs` stayed readable. The tick also wore `text-muted`, a paper-page token that is the same colour as the bar.

The hover is now `text-paper`, the same token the agent and prefs already use. The tick inherits the chip, so it brightens with the words.