### PR TITLE
A vault's own index.html was never shadowed; its assets/ folder is, and the socket for that is upstream (bundle-reserved-prefix)

### DIFF
--- a/packages/server/src/serve.test.ts
+++ b/packages/server/src/serve.test.ts
@@ -367,3 +367,68 @@ test("the shell names the mark, the viewport, and no service worker", async () =
     expect(touch.headers.get("content-type") ?? "").toMatch(/^image\/png/)
   })
 })
+
+// ── the bundle against the reader's own URL space ───────────────────────
+//
+// Addresses went prefix-free in #256: a served file's address IS its path. So
+// the paths the BUNDLE answers at the dist root are paths a reader's own files
+// can have, and `web/src/client/routes.ts` names the two of them. These are
+// where that claim is measured, because its two halves do not come out the
+// same way and only a request can say which.
+//
+// Unlike the install tests above, the served directory and the dist are two
+// different trees here — the whole question is what happens when one holds a
+// path the other also holds.
+
+/** A served directory holding the two paths the bundle also answers at. */
+const shadowedVault = (): string => {
+  const root = served()
+  fs.writeFileSync(
+    path.join(root, "index.html"),
+    "<!doctype html><h1>the reader's own index</h1>\n",
+  )
+  fs.mkdirSync(path.join(root, "assets"))
+  fs.writeFileSync(path.join(root, "assets", "x.md"), "# a note under assets\n")
+  return root
+}
+
+const withShadowed = (body: (url: string) => Promise<void>): Promise<void> =>
+  withServing(
+    { root: shadowedVault(), clientDist: installDist() },
+    (url) => body(url),
+  )
+
+test("a vault's own index.html has a page — the bundle answers it with the shell the fallback would have", async () => {
+  await withShadowed(async (url) => {
+    const shell = await fetch(`${url}/`)
+    const shadowed = await fetch(`${url}/index.html`)
+    expect(shadowed.status).toBe(200)
+    expect(shadowed.headers.get("content-type") ?? "").toMatch(/^text\/html/)
+    // The bundle wins the path, and winning it costs nothing: what sits there
+    // is the SPA shell, which is exactly what an unmatched path is answered
+    // with. So the address reaches the client's parser and `index.html` opens
+    // as the hypertext page it is — driven in a browser, with a reload, by
+    // `features/html_previews.feature`.
+    expect(await shadowed.text()).toBe(await shell.text())
+    // ...and it is still the shell's own freshness contract, not a cacheable
+    // file: a reader who reloads here must not replay a stale bundle.
+    expect(shadowed.headers.get("cache-control")).toBe("no-store")
+  })
+})
+
+test("a vault file under assets/ has no page — the hashed prefix must 404 rather than reach the shell", async () => {
+  await withShadowed(async (url) => {
+    const answer = await fetch(`${url}/assets/x.md`)
+    // THE COLLISION, pinned rather than described. `/assets/` is the immutable
+    // content-hashed prefix, and a miss under it has to 404: the shell served
+    // under a `.js` URL is the wrong MIME pinned `immutable` for a year
+    // (kolu#1319). So a file the reader keeps in a folder called `assets` is
+    // an address this app can spell and cannot open.
+    //
+    // This is the assertion the follow-up flips. Moving the bundle to
+    // `/_olai/assets/` needs `buildSurfaceClient` to take the prefix its own
+    // server already takes — kolu#2197 — so it lands when the pin carries it.
+    expect(answer.status).toBe(404)
+    expect(answer.headers.get("content-type") ?? "").not.toMatch(/^text\/html/)
+  })
+})

--- a/packages/tests/features/html_previews.feature
+++ b/packages/tests/features/html_previews.feature
@@ -50,6 +50,39 @@ Feature: A `.html` in the vault
     # which is the whole of the new rule read from the console.
     And the only complaints are the browser refusing what the file may not do
 
+  @scratch:good
+  Scenario: A page named index.html at the top of the vault is still that vault's page
+    # THE BUNDLE'S OWN PATH, as a scenario. A file's address is its path since
+    # addresses went prefix-free (#256), so a reader whose folder holds an
+    # `index.html` is asking for the one path the browser bundle also answers
+    # at — `@kolu/surface-app` serves `<dist>/index.html` from the dist root.
+    #
+    # Clicking the row would never notice: that is a client-side route and no
+    # request leaves the tab. A RELOAD is what asks the server, which is why
+    # this scenario spends one. What comes back there is the SPA shell, byte
+    # for byte the one an unmatched path is answered with, so the address
+    # reaches the client's parser and the reader's own page opens.
+    #
+    # `web/src/client/routes.ts` used to say this address could not be reached.
+    # It can. The half that genuinely cannot is a file under an `assets/`
+    # folder, where the immutable prefix has to 404 rather than reach the
+    # shell — pinned at the HTTP layer in `packages/server/src/serve.test.ts`,
+    # since a page that does not exist is not a thing a browser can be shown.
+    When I rewrite "index.html" as:
+      """
+      <h1>The reader's own index</h1>
+      <p>At the top of the vault, where the bundle's shell lives too.</p>
+      """
+    And I open the app
+    Then the pages listed are "index.html, quarter.html, report.html"
+    When I click the page "index.html"
+    Then the address is "/index.html"
+    And the preview shows the heading "The reader's own index"
+    When I reload the page
+    Then the address is "/index.html"
+    And the preview shows the heading "The reader's own index"
+    And there should be no page errors
+
   @corpus:good
   Scenario: The page shows what the file says, with the file's own styling
     When I open the page "report.html"

--- a/packages/tests/features/html_previews.feature
+++ b/packages/tests/features/html_previews.feature
@@ -50,7 +50,7 @@ Feature: A `.html` in the vault
     # which is the whole of the new rule read from the console.
     And the only complaints are the browser refusing what the file may not do
 
-  @scratch:good
+  @scratch:good @own-scratch
   Scenario: A page named index.html at the top of the vault is still that vault's page
     # THE BUNDLE'S OWN PATH, as a scenario. A file's address is its path since
     # addresses went prefix-free (#256), so a reader whose folder holds an
@@ -68,6 +68,11 @@ Feature: A `.html` in the vault
     # folder, where the immutable prefix has to 404 rather than reach the
     # shell — pinned at the HTTP layer in `packages/server/src/serve.test.ts`,
     # since a page that does not exist is not a thing a browser can be shown.
+    #
+    # `@own-scratch` because it LISTS THE WHOLE VAULT, which is this feature's
+    # own rule for a private copy: the assertion is that the new file joined the
+    # two the fixture holds, and on the shared copy that count is a claim about
+    # whatever the last scenario left behind rather than about this write.
     When I rewrite "index.html" as:
       """
       <h1>The reader's own index</h1>

--- a/packages/web/src/client/routes.ts
+++ b/packages/web/src/client/routes.ts
@@ -61,13 +61,29 @@
  *
  * WHAT CAN COLLIDE IS THE BUNDLE, and it is named here because a prefix-free
  * URL space is what makes it possible: the server hands the SPA shell to
- * anything it does not serve itself, and the two things it does serve at the
- * root are `/index.html` and `/assets/…` (`@kolu/surface-app`). A served
- * directory holding an `index.html` at its top level, or any file under an
- * `assets/` folder, is a page this app can address and cannot be reached at —
- * the bundle answers first. Moving the bundle's own paths under a reserved
- * prefix is the fix and it is a server change, so it is filed rather than
- * done here.
+ * anything it does not serve itself, and what it serves at the root is the
+ * bundle's own — `/index.html` and `/assets/…` (`@kolu/surface-app`).
+ *
+ * ONE of those two is a collision, and which one was MEASURED rather than
+ * reasoned about (`packages/server/src/serve.test.ts`, the two tests at the
+ * foot of the install surface). A served directory holding an `index.html` at
+ * its top level is reachable: the bundle answers that path with the shell, and
+ * the shell is byte for byte what the SPA fallback would have answered with, so
+ * the address reaches this parser and the page opens like any other file's. A
+ * file under an `assets/` folder is not, and cannot be made so from here: that
+ * prefix is the immutable, content-hashed one, and a miss under it has to 404
+ * rather than fall through — a `.js` URL answered with the HTML shell is the
+ * wrong MIME pinned `immutable` for a year (kolu#1319). So the reader gets
+ * `not found`, and no page at all.
+ *
+ * The fix is to move the bundle's hashed dir under a prefix this app already
+ * owns — `/_olai/assets/`, the same `_olai/` the shelf and the trash are
+ * minted into, so what it shadows is olai's own namespace rather than the
+ * reader's — and it is a SERVER change. `@kolu/surface-app`'s serving half has
+ * taken an `assetPrefix` since the freshness contract was written; its Bun
+ * build hardcoded the directory, so the input had no producer and nothing here
+ * could reach it. That socket is kolu#2197, and the move lands when the pin
+ * carries it.
  *
  * ## The computed pages, which name nothing on disk
  *

--- a/packages/web/src/client/routes.ts
+++ b/packages/web/src/client/routes.ts
@@ -62,10 +62,13 @@
  * WHAT CAN COLLIDE IS THE BUNDLE, and it is named here because a prefix-free
  * URL space is what makes it possible: the server hands the SPA shell to
  * anything it does not serve itself, and what it serves at the root is the
- * bundle's own — `/index.html` and `/assets/…` (`@kolu/surface-app`).
+ * bundle's own — `/index.html` and `/assets/…`, beside `/sw.js` and
+ * `/manifest.webmanifest` (`@kolu/surface-app`). Only the first two can shadow
+ * a PAGE: the other two carry no suffix the registry claims, so no address this
+ * parser can spell lands on them.
  *
- * ONE of those two is a collision, and which one was MEASURED rather than
- * reasoned about (`packages/server/src/serve.test.ts`, the two tests at the
+ * And ONE of that first pair is a collision, and which one was MEASURED rather
+ * than reasoned about (`packages/server/src/serve.test.ts`, the two tests at the
  * foot of the install surface). A served directory holding an `index.html` at
  * its top level is reachable: the bundle answers that path with the shell, and
  * the shell is byte for byte what the SPA fallback would have answered with, so


### PR DESCRIPTION
## Where the fix lives — the determination, first (Ground 1)

**This is case 3: kolu must change.** The upstream PR is **[juspay/kolu#2197](https://github.com/juspay/kolu/pull/2197)**, open and green locally. This PR is what is olai's *today*: the sentence in `routes.ts` that says what collides, corrected to what a request actually answers, with both halves pinned.

Why olai cannot do it alone, read out of the pinned kolu (`b6378c57`):

- `@kolu/surface-app`'s **serving** half already takes the prefix. `FreshnessPaths.assetPrefix` has been an input since the freshness contract was written — *"Both are INPUTS (not baked-in) so a non-Vite build can override the convention"* — and `serveSurfaceApp` passes it straight through (`SurfaceAppLayerOptions extends FreshnessPaths`).
- Its **build** half hardcodes it. `buildSurfaceClient` resolves `outdir` from `ASSET_DIR` and writes every href off `DEFAULT_ASSET_PREFIX`, with no option in between. So the existing serving input has no producer: olai could pin its server to `/_olai/assets/` and had no way to make the bundle land there.
- The only olai-only route is to build into a nested dist and then hand-rewrite the shell the helper just wrote — which is precisely the debt `packages/web/src/build.ts`'s header records as *removed* ("a second `Bun.build` plus a hand-rewrite of the shell the helper had just written"), and it would be deleted again the moment the pin moves.

kolu#2197 is the smallest socket that makes the existing input usable: `buildSurfaceClient({ assetPrefix })`, with `assetDirOf` deriving the dist-relative directory from the request prefix so the two halves are **one** setting. Per the lane's brief, olai's consumer side (moving the bundle to `/_olai/assets/`, dropping the last paragraph below) is the follow-up once that merges and `npins/sources.json` carries it.

## And one half of the filed claim is not true

`routes.ts` has said since #256 that a served directory holding an `index.html` at its top level, **or** any file under an `assets/` folder, is a page this app can address and cannot reach. Measured against the current pin, only the second is:

| request | answer |
|---|---|
| `GET /index.html` | `200 text/html no-store` — the SPA shell, byte for byte the one `GET /` answers with |
| `GET /assets/x.md` | `404 text/plain no-store` — the immutable prefix answered first |

`/index.html` is a collision the bundle wins and winning costs nothing: what sits at `<dist>/index.html` is the `no-store` shell, which is exactly what an unmatched path is answered with, so the address reaches the client's parser and the reader's own page opens. `/assets/*` is different in kind — that prefix is the content-hashed immutable one, and a miss under it **has** to 404 rather than fall through, because the shell served under a `.js` URL is the wrong MIME pinned `immutable` for a year (kolu#1319). There is no fix for that from inside this repo, which is the whole of Ground 1's answer.

## What changed

- **`packages/web/src/client/routes.ts`** — the "WHAT CAN COLLIDE IS THE BUNDLE" paragraph now says which half collides and why the other does not, names `/_olai/assets/` as the destination (the same `_olai/` the shelf and the trash are minted into, so what it shadows is olai's own namespace rather than the reader's), and points at kolu#2197 instead of at nothing.
- **`packages/server/src/serve.test.ts`** — two tests at the foot of the install surface, over a served directory and a dist that are **two different trees** (the install tests above deliberately use one): the shell answer at `/index.html` is byte-identical to `/` and still `no-store`; `/assets/x.md` is `404` and not HTML. The second is the assertion the follow-up flips.
- **`packages/tests/features/html_previews.feature`** — a browser scenario for the half a reader can see, and it spends a **reload**: clicking the row is a client-side route and never asks the server, so only a reload can catch this.

`docs/search.md` and `docs/format.md` were checked for the same claim (the brief names them) and carry none — `routes.ts` was the only place it was written. `docs/architecture.md` and `packages/web/README.md` mention `/assets/` only as where hashed assets live, which is unchanged by this PR.

## Evidence

**A vault's own `index.html`, opened at its own address** — the app's shell has loaded (header, sidebar, agenda), the `index` row is lit, and the page drawn is the file's:

![the vault's index.html open at /index.html](https://github.com/user-attachments/assets/43d7376f-e98b-486e-8de8-444740d541fe)

**The same vault's `assets/x.md`, reached by clicking the sidebar** — the page exists and draws; nothing was asked of the server, because a click is a client-side route:

![assets/x.md open via the sidebar](https://github.com/user-attachments/assets/3d0162fe-2e2b-4da6-9c08-3eac5638e307)

**…and the same address entered, or reloaded.** This is the collision:

![/assets/x.md answers 404 not found](https://github.com/user-attachments/assets/db75539f-94d5-4cfa-8345-8c2faadd82f6)

The transcript behind the table, against `just build-client` + `olai web <vault> --port 7799` on a directory holding `Notes.olai`, `index.html` and `assets/x.md`:

```
$ curl -s -D- -o /dev/null http://127.0.0.1:7799/
HTTP/1.1 200 OK
ETag: "1c61-1a0281883c4"
Content-Type: text/html; charset=utf-8
Content-Length: 7265
Cache-Control: no-store

$ curl -s -D- -o /dev/null http://127.0.0.1:7799/index.html
HTTP/1.1 200 OK
ETag: "1c61-1a0281883c4"
Content-Type: text/html; charset=utf-8
Content-Length: 7265
Cache-Control: no-store

$ curl -s -D- http://127.0.0.1:7799/assets/x.md
HTTP/1.1 404 Not Found
Cache-Control: no-store
Content-Type: text/plain
Content-Length: 9

not found
```

Local suites at report time:

```
$ just typecheck
@olai/log … @olai/tests typecheck: Exited with code 0        (9 members, all 0)

$ just test
 3305 pass  0 fail  99663 expect() calls   (234 files, 47.63s)
 79 pass    0 fail    179 expect() calls   (8 browser-condition files, 5.13s)

$ bun test packages/server/src/serve.test.ts
 15 pass  0 fail  70 expect() calls        (13 before; 2 new)

$ just e2e — features/html_previews.feature
 48 scenarios (48 passed)
 463 steps (463 passed)
 0m32.141s                                 (47 scenarios before; 1 new)
```

## Assumptions

1. **The spec's premise about `/index.html` is wrong, and the measurement wins.** The roadmap node and `routes.ts` both say that path is unreachable; three requests and a browser say it is not. Where a spec and the code disagree the spec wins, but this is a factual claim the spec makes about the code, disproven by transcript — so it is corrected rather than obeyed. Nothing about the *fix* changes: `/assets/*` still needs the bundle moved.
2. **`/_olai/assets/` is the reserved prefix**, not a new word. `_olai/` is already where olai mints its own files (the shelf, the trash, the inbox — `features/olai_names_its_own_files.feature`), so the namespace the moved bundle shadows is olai's rather than a reader's. Named in the paragraph; the move itself is the follow-up.
3. **The `assets/` 404 is asserted as it stands rather than left undescribed.** A test that pins broken behaviour is unusual; the alternative is a comment that goes stale silently, and this one is written to be flipped by the follow-up, naming kolu#2197 at the assertion.
4. **The bundle's other root files are not collisions and are left alone.** `publicDir`'s icons (`icon.svg`, `apple-touch-icon.png`, the three PNGs) and `/fonts/*.woff2` sit at the dist root too, but none of their suffixes is a page kind (`@olai/format`'s `kinds.ts` claims `.olai`, `.md`, `.html`), and a vault picture is fetched through `/media/` rather than at its own path — so no address a reader can open is shadowed by them.
5. **olai's own routes are out of scope, and both reviewers measured what that leaves.** `/media/` is the one that looks like `/assets/` — a PREFIX, answering `404` from the media route, so a vault folder named `media/` is a folder of pages this app can address and cannot open. The rest are exact paths and shadow less or not at all: `GET /capture` and `GET /mcp` are `405`, `GET /olai/who` is `204`, and `GET /olai/resync` is **not** shadowed at all — that door is POST-only, so a GET falls through to the shell. (My first draft of this assumption listed `/olai/resync` as shadowing; grok and opencode both measured otherwise.) None of them is the bundle, and the node names the bundle. Not a deferral because it is not this node's ask — but `/media/` is the one that wants the human's word on whether the whole reserved-word question is its own node.
6. **CI results are in the comment thread**, run after this round. Originally: Per the campaign pipeline, full CI runs once per PR after the review round — for kolu#2197 that is both `x86_64-linux` (localhost) and `aarch64-darwin` (ci@petit), under the shared flock. Local: 272 unit tests pass, `tsc --noEmit` clean, `biome format` clean.
7. **The kolu changelog entry was folded, not appended.** `changelog/AGENTS.md` says an unreleased entry is edited rather than duplicated, so the prefix rides the existing `buildSurfaceClient` dist entry (#2159, #2163) with #2197 added to its refs.

## Review folds

Both reviewers said do-not-object; both nits are folded.

- **grok** — the new scenario listed the whole vault on shared scratch, which this feature's own header reserves for `@own-scratch`. Tagged, with the reason written at the scenario: on the shared copy that count is a claim about whatever the last scenario left behind rather than about this write.
- **opencode** — the paragraph elided `/sw.js` and `/manifest.webmanifest`, which the bundle also answers at the root. Named now, with why neither can shadow a page: no suffix the registry claims, so no address this parser can spell lands on them.
- **opencode, should-fix** — `docs/_olai/Inbox.olai`'s node still carries the disproven half. That file is written only through olai's own ops and belongs to the orchestrator's ledger, not to a PR diff; it is being corrected there. Deliberately untouched here.
- Both flagged the sibling PR's red-first count (10/77 against the final 12-case suite). kolu#2197's body carries the current run — **12 failed / 66 passed (78)**, all twelve red on master now that the collision test grew a producer arm.

## Deferrals

No deferrals.

The consumer-side move is **not** a deferral: the lane's brief rules the case-3 shape explicitly — open the kolu PR, report, and let the orchestrator dispatch olai's side once kolu merges and the pin moves. Doing it here would mean hand-rewriting the shell that `@kolu/surface-app/bun` writes, which is the exact debt `packages/web/src/build.ts` records as paid off, and deleting it again one pin later.
