### PR TITLE
Kill the pending.test.ts quiet-window flake

### DIFF
--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -75,7 +75,7 @@ Never `--amend` — an audit trail that can be edited after the fact is not one.
 | `LC_ALL=C` | the "not a git repository" classification is a string match, and a translated git would be reported as unusable |
 | `GIT_TERMINAL_PROMPT=0` | a repository that wants a credential fails instead of sitting on a prompt nobody can answer |
 | a 10s budget | a wedged hook or a lock held by another process cannot hold a caller open forever |
-| one git at a time per handle | `git status` refreshes the index and `git commit` writes it; two fibers doing both lose to `index.lock` |
+| the index gate, per `gitDir` | `git status` (`dirty`) refreshes the index and `git commit` writes it; two fibers doing both lose to `index.lock`. The permit is keyed on the git directory — not on the handle — so a second `open` of the same repository cannot disarm it. Only those two verbs take it: `push` is a network call with the ten-second budget (`whyWaiting` must not queue behind it), and git's own ref lockfiles cover `commit` vs `push` on the refs. `state` / `last` / `show` do not touch the index. |
 | `--porcelain -z` | the plain form quotes anything unusual; `-z` does not, and a path may contain a newline |
 | `-uall` | a brand-new outline is untracked, and is exactly what a first commit is for |
 | no pathspec on `status` | the survey is the whole repository: serving `docs/` and being told nothing about a dirty root `README.md` is the bug this package's caller was filed for |

--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -75,6 +75,7 @@ Never `--amend` — an audit trail that can be edited after the fact is not one.
 | `LC_ALL=C` | the "not a git repository" classification is a string match, and a translated git would be reported as unusable |
 | `GIT_TERMINAL_PROMPT=0` | a repository that wants a credential fails instead of sitting on a prompt nobody can answer |
 | a 10s budget | a wedged hook or a lock held by another process cannot hold a caller open forever |
+| one git at a time per handle | `git status` refreshes the index and `git commit` writes it; two fibers doing both lose to `index.lock` |
 | `--porcelain -z` | the plain form quotes anything unusual; `-z` does not, and a path may contain a newline |
 | `-uall` | a brand-new outline is untracked, and is exactly what a first commit is for |
 | no pathspec on `status` | the survey is the whole repository: serving `docs/` and being told nothing about a dirty root `README.md` is the bug this package's caller was filed for |
@@ -86,4 +87,4 @@ Never `--amend` — an audit trail that can be edited after the fact is not one.
 
 `./state` is `RepoState` and `Reason` — the vocabulary with no subprocess in it. It exists because those values travel the wire: `@olai/format` re-exports them for its pending schema, the browser imports that schema, and a browser bundle must never reach `node:child_process`.
 
-`./testlib` is `repoAt` — a real repository in the states a commit path has to tell apart, published so the packages above build their fixtures the same way. Real git rather than a fake, because what those tests are about is what git does; a fake would only reproduce what we already believe.
+`./testlib` is `repoAt` — a real repository in the states a commit path has to tell apart, published so the packages above build their fixtures the same way. Real git rather than a fake, because what those tests are about is what git does; a fake would only reproduce what we already believe. Identity is pinned on the spawn (`GIT_AUTHOR_NAME` and friends, never empty) as well as in the repository-local config: env beats config, and an empty `GIT_AUTHOR_NAME` is empty, not unset.

--- a/packages/git/src/fixtures.testlib.ts
+++ b/packages/git/src/fixtures.testlib.ts
@@ -17,22 +17,51 @@
 import { execFileSync } from "node:child_process"
 
 /**
+ * Who a test's git is. Env beats config, and an empty `GIT_AUTHOR_NAME` (some
+ * CI, some load-bearing shells) is empty, not unset — so a repository-local
+ * `user.name` is not enough. Every spawn this file makes carries these, and
+ * they are the same strings {@link repoAt} writes into the config, so a commit
+ * through either door is the same person.
+ */
+export const GIT_IDENT = {
+  GIT_AUTHOR_NAME: "olai tests",
+  GIT_AUTHOR_EMAIL: "test@olai.invalid",
+  GIT_COMMITTER_NAME: "olai tests",
+  GIT_COMMITTER_EMAIL: "test@olai.invalid",
+} as const
+
+/** The env keys {@link GIT_IDENT} pins — so a test that wants git's own empty
+ *  ident can clear exactly these and nothing else. */
+export const GIT_IDENT_KEYS = Object.keys(GIT_IDENT) as ReadonlyArray<
+  keyof typeof GIT_IDENT
+>
+
+/**
  * Git, in a directory of a test.
  *
  * One spelling of it, because the identity is the load-bearing part — see
- * {@link repoAt}.
+ * {@link repoAt}. Ambient `GIT_AUTHOR_*` is overwritten, empty included: a
+ * fixture that inherited `GIT_AUTHOR_NAME=` used to fail with `fatal: empty
+ * ident name` on the next commit, even after {@link repoAt} had set
+ * `user.name`.
  */
 export const gitIn = (root: string) =>
 (...argv: ReadonlyArray<string>): string =>
-  execFileSync("git", argv, { cwd: root, encoding: "utf8" })
+  execFileSync("git", argv, {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, ...GIT_IDENT },
+  })
 
 /**
  * A git repository around a directory.
  *
- * The identity is repository-local, so a run depends on nothing in the
- * developer's global config and touches none of it, and the branch is named
- * explicitly so a machine whose `init.defaultBranch` differs reads the same as
- * every other.
+ * The identity is pinned two ways, and both are load-bearing: repository-local
+ * config, so a product `git` that inherits the process env still has a name
+ * once that env is clean; and {@link GIT_IDENT} on every spawn this file
+ * itself makes, so an empty `GIT_AUTHOR_NAME` in the ambient env cannot empty
+ * the ident. The branch is named explicitly so a machine whose
+ * `init.defaultBranch` differs reads the same as every other.
  *
  * The default is a repository whose fixtures are already its first commit, so
  * what a test does afterwards is the whole of what git has to say about it.
@@ -56,21 +85,16 @@ export const repoAt = (
     execFileSync("git", argv, {
       cwd: root,
       stdio: "ignore",
-      ...(env === undefined ? {} : { env: { ...process.env, ...env } }),
+      env: { ...process.env, ...GIT_IDENT, ...env },
     })
   }
   const nobody = options.identity === false
   git(["init", "--quiet", "--initial-branch", "main"])
-  git(["config", "user.email", nobody ? "" : "test@olai.invalid"])
-  git(["config", "user.name", nobody ? "" : "olai tests"])
+  git(["config", "user.email", nobody ? "" : GIT_IDENT.GIT_AUTHOR_EMAIL])
+  git(["config", "user.name", nobody ? "" : GIT_IDENT.GIT_AUTHOR_NAME])
   if (options.seed === false) return
   git(["add", "-A"])
-  git(["commit", "--quiet", "--no-verify", "-m", options.message ?? "fixtures"], {
-    GIT_AUTHOR_NAME: "olai tests",
-    GIT_AUTHOR_EMAIL: "test@olai.invalid",
-    GIT_COMMITTER_NAME: "olai tests",
-    GIT_COMMITTER_EMAIL: "test@olai.invalid",
-  })
+  git(["commit", "--quiet", "--no-verify", "-m", options.message ?? "fixtures"])
 }
 
 /** Every commit subject in a repository, newest first. Three test files had

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -717,3 +717,36 @@ test("a commit that lands leaves the index agreeing with it", async () => {
   expect(run("status", "--porcelain").trim()).toBe("")
   expect(run("ls-files", "-s")).toContain("new.olai")
 })
+
+/**
+ * A survey and a commit at once must not lose to git's `index.lock`.
+ *
+ * `git status` refreshes the index; `git commit` writes it. Two fibers doing
+ * both in one repository used to fail the write with `File exists`, and the
+ * quiet window recorded nothing under load. The handle is the lock: one git
+ * at a time, the whole verb.
+ */
+test("a survey and a commit at once never fight index.lock", async () => {
+  const { root, file } = repo()
+  fs.writeFileSync(file, `{"id":"a","ord":"a0","title":"edited"}\n`)
+
+  const rounds = await asked(root, (handle) =>
+    Effect.all(
+      Array.from({ length: 8 }, () =>
+        Effect.all([
+          handle.commit({ paths: [file], message: "olai: concurrent" }),
+          handle.dirty,
+          handle.state,
+          handle.last(OLAI),
+        ], { concurrency: 4 })),
+      { concurrency: 4 },
+    ))
+
+  for (const [done, dirt] of rounds) {
+    expect(done?._tag === "Failed" ? done.said : "").not.toContain("index.lock")
+    expect(dirt?._tag === "Unusable" ? dirt.said : "").not.toContain("index.lock")
+  }
+  expect(
+    rounds.some(([done]) => done?._tag === "Committed"),
+  ).toBe(true)
+})

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -723,8 +723,8 @@ test("a commit that lands leaves the index agreeing with it", async () => {
  *
  * `git status` refreshes the index; `git commit` writes it. Two fibers doing
  * both in one repository used to fail the write with `File exists`, and the
- * quiet window recorded nothing under load. The handle is the lock: one git
- * at a time, the whole verb.
+ * quiet window recorded nothing under load. The permit is per git directory,
+ * and only those two verbs take it.
  */
 test("a survey and a commit at once never fight index.lock", async () => {
   const { root, file } = repo()
@@ -741,6 +741,48 @@ test("a survey and a commit at once never fight index.lock", async () => {
         ], { concurrency: 4 })),
       { concurrency: 4 },
     ))
+
+  for (const [done, dirt] of rounds) {
+    expect(done?._tag === "Failed" ? done.said : "").not.toContain("index.lock")
+    expect(dirt?._tag === "Unusable" ? dirt.said : "").not.toContain("index.lock")
+  }
+  expect(
+    rounds.some(([done]) => done?._tag === "Committed"),
+  ).toBe(true)
+})
+
+/**
+ * TWO HANDLES, one repository — the gate is per `gitDir`, not per handle.
+ * A handle-local semaphore would pass the test above and still lose here.
+ */
+test("two handles on one repository still never fight index.lock", async () => {
+  const { root, file } = repo()
+  fs.writeFileSync(file, `{"id":"a","ord":"a0","title":"edited"}\n`)
+
+  const opened = await Promise.all([
+    Effect.runPromise(open(root)),
+    Effect.runPromise(open(root)),
+  ])
+  const handles = opened.map((one) => {
+    if (one._tag !== "Opened") throw new Error(`${root} is not a work tree: ${one._tag}`)
+    return one.repo
+  })
+  const left = handles[0]
+  const right = handles[1]
+  if (left === undefined || right === undefined) throw new Error("unreachable")
+
+  const rounds = await Effect.runPromise(
+    Effect.all(
+      Array.from({ length: 8 }, () =>
+        Effect.all([
+          left.commit({ paths: [file], message: "olai: concurrent" }),
+          right.dirty,
+          left.state,
+          right.last(OLAI),
+        ], { concurrency: 4 })),
+      { concurrency: 4 },
+    ),
+  )
 
   for (const [done, dirt] of rounds) {
     expect(done?._tag === "Failed" ? done.said : "").not.toContain("index.lock")

--- a/packages/git/src/git.ts
+++ b/packages/git/src/git.ts
@@ -56,7 +56,7 @@
  * than thirteen.
  */
 
-import { Effect } from "effect"
+import { Effect, Semaphore } from "effect"
 import { execFile } from "node:child_process"
 import * as fs from "node:fs"
 import { join, resolve } from "node:path"
@@ -250,19 +250,26 @@ export type Opening =
   | { readonly _tag: "Unusable"; readonly said: string }
 
 export const open = (root: string): Effect.Effect<Opening> =>
-  Effect.map(place(root), (placing) =>
-    placing._tag !== "Placed" ? placing : {
-      _tag: "Opened",
+  Effect.map(place(root), (placing) => {
+    if (placing._tag !== "Placed") return placing
+    // ONE git at a time on this handle. `git status` refreshes the index and
+    // `git commit` writes it; two fibers doing both used to lose to
+    // `index.lock` under load, and the quiet window recorded nothing.
+    const gate = Semaphore.makeUnsafe(1)
+    const hold = <A, E, R>(op: Effect.Effect<A, E, R>) => gate.withPermit(op)
+    return {
+      _tag: "Opened" as const,
       repo: {
         served: placing.placement.prefix,
-        state: state(root, placing.placement),
-        dirty: dirty(root, placing.placement),
-        show: (path) => show(root, path),
-        last: (audit) => last(root, audit),
-        commit: (what) => commit(root, placing.placement, what),
-        push: push(root),
+        state: hold(state(root, placing.placement)),
+        dirty: hold(dirty(root, placing.placement)),
+        show: (path: string) => hold(show(root, path)),
+        last: (audit: Audit) => hold(last(root, audit)),
+        commit: (what: CommitInput) => hold(commit(root, placing.placement, what)),
+        push: hold(push(root)),
       },
-    })
+    }
+  })
 
 const state = (
   root: string,

--- a/packages/git/src/git.ts
+++ b/packages/git/src/git.ts
@@ -50,10 +50,17 @@
  * conflict could swallow the resolution. That hole is what decided manual over
  * automatic, and this is where it is closed.
  *
- * A handle is opened once per round rather than kept, because a directory can
- * become a repository while the server is running — and once per round is what
- * makes a directory with twelve dirty outlines cost one `rev-parse` rather
- * than thirteen.
+ * {@link open} itself is cheap and not a cache — a directory can become a
+ * repository while the server is running, and a handle kept for life would
+ * miss that. The ops layer memoizes a positive answer; this file does not
+ * rely on that. What IS keyed for the life of the process is the index gate:
+ * `git status` refreshes the index and `git commit` writes it, and two fibers
+ * doing both lose to `index.lock`. The permit is per `gitDir`, not per
+ * handle, so a second {@link open} of the same repository cannot disarm it.
+ * Only the two index touchers take it (`dirty` and `commit`). `push` is a
+ * network verb with the ten-second budget, and `whyWaiting` must not queue
+ * behind it; git's own ref lockfiles cover `commit` vs `push` on the refs.
+ * `state` / `last` / `show` do not touch the index.
  */
 
 import { Effect, Semaphore } from "effect"
@@ -67,6 +74,27 @@ import type { How, Reason, RepoState } from "./state.ts"
  *  budget is here so a wedged hook or a lock held by another process cannot
  *  hold a caller open forever. */
 const BUDGET = 10_000
+
+/**
+ * The INDEX GATE: one permit per git directory, held by {@link dirty} and
+ * {@link commit} only. See the file header. Keyed on `gitDir` so two handles
+ * of one repository share it; a handle-local semaphore would re-open the
+ * `index.lock` race the moment anyone called {@link open} twice.
+ */
+const indexGates = new Map<string, Semaphore.Semaphore>()
+
+const indexGate = (gitDir: string): Semaphore.Semaphore => {
+  const had = indexGates.get(gitDir)
+  if (had !== undefined) return had
+  const made = Semaphore.makeUnsafe(1)
+  indexGates.set(gitDir, made)
+  return made
+}
+
+const holdIndex = <A, E, R>(
+  gitDir: string,
+  op: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> => indexGate(gitDir).withPermit(op)
 
 interface Said {
   readonly ok: boolean
@@ -252,21 +280,18 @@ export type Opening =
 export const open = (root: string): Effect.Effect<Opening> =>
   Effect.map(place(root), (placing) => {
     if (placing._tag !== "Placed") return placing
-    // ONE git at a time on this handle. `git status` refreshes the index and
-    // `git commit` writes it; two fibers doing both used to lose to
-    // `index.lock` under load, and the quiet window recorded nothing.
-    const gate = Semaphore.makeUnsafe(1)
-    const hold = <A, E, R>(op: Effect.Effect<A, E, R>) => gate.withPermit(op)
+    const gitDir = placing.placement.gitDir
     return {
       _tag: "Opened" as const,
       repo: {
         served: placing.placement.prefix,
-        state: hold(state(root, placing.placement)),
-        dirty: hold(dirty(root, placing.placement)),
-        show: (path: string) => hold(show(root, path)),
-        last: (audit: Audit) => hold(last(root, audit)),
-        commit: (what: CommitInput) => hold(commit(root, placing.placement, what)),
-        push: hold(push(root)),
+        state: state(root, placing.placement),
+        dirty: holdIndex(gitDir, dirty(root, placing.placement)),
+        show: (path: string) => show(root, path),
+        last: (audit: Audit) => last(root, audit),
+        commit: (what: CommitInput) =>
+          holdIndex(gitDir, commit(root, placing.placement, what)),
+        push: push(root),
       },
     }
   })

--- a/packages/ops/src/fixtures.testlib.ts
+++ b/packages/ops/src/fixtures.testlib.ts
@@ -25,7 +25,7 @@ import { readingOf } from "@olai/format/testlib"
 /** The pairing a snapshot carries, built from text — `@olai/format`'s, like
  *  the set builder beside it, because the pairing is that package's. */
 export { failureOf, readingOf, setOf, STAMP_SHAPE } from "@olai/format/testlib"
-export { gitIn, repoAt, subjectsIn, writerOf } from "@olai/git/testlib"
+export { GIT_IDENT, GIT_IDENT_KEYS, gitIn, repoAt, subjectsIn, writerOf } from "@olai/git/testlib"
 
 /** A planner context with no surprises in it: ids counted up from `n1`, and one
  *  fixed instant. Both of the impure things an op needs, made boring.

--- a/packages/ops/src/pending.test.ts
+++ b/packages/ops/src/pending.test.ts
@@ -1192,11 +1192,15 @@ describe("--push=auto", () => {
         const pushed = fixture.settlements()
         yield* fixture.observe
         yield* fixture.settled(pushed)
-        while (subjects(fixture).filter((line) => line.startsWith("olai:")).length === 0) {
-          yield* fixture.settled(fixture.settlements())
+        while (true) {
+          const n = fixture.settlements()
+          if (subjects(fixture).filter((line) => line.startsWith("olai:")).length > 0) break
+          yield* fixture.settled(n)
         }
-        while ((yield* fixture.ops.pending).unpushed?.commits !== 0) {
-          yield* fixture.settled(fixture.settlements())
+        while (true) {
+          const n = fixture.settlements()
+          if ((yield* fixture.ops.pending).unpushed?.commits === 0) break
+          yield* fixture.settled(n)
         }
 
         expect(gitIn(bare)("log", "--format=%s", "-1").trim()).toStartWith("olai:")
@@ -1226,8 +1230,10 @@ describe("--push=auto", () => {
         const diverged = fixture.settlements()
         yield* fixture.observe
         yield* fixture.settled(diverged)
-        while ((yield* fixture.ops.git).pushSaid === null) {
-          yield* fixture.settled(fixture.settlements())
+        while (true) {
+          const n = fixture.settlements()
+          if ((yield* fixture.ops.git).pushSaid !== null) break
+          yield* fixture.settled(n)
         }
 
         // The COMMIT stands — a refused push is not a rollback.

--- a/packages/ops/src/pending.test.ts
+++ b/packages/ops/src/pending.test.ts
@@ -26,11 +26,11 @@ import { NodeServices } from "@effect/platform-node"
 import { Writer } from "@olai/format"
 import * as Store from "@olai/store"
 import { describe, expect, test } from "bun:test"
-import { Duration, Effect, type Scope } from "effect"
+import { Effect, type Scope } from "effect"
 
 import { codec } from "./codec.ts"
 import type { Store as OutlineStore } from "./deps.ts"
-import { gitIn, repoAt, writerOf } from "./fixtures.testlib.ts"
+import { GIT_IDENT, GIT_IDENT_KEYS, gitIn, repoAt, writerOf } from "./fixtures.testlib.ts"
 import * as Ops from "./ops.ts"
 import { COMMIT_TOOL, fixedPolicy, whyOf } from "./pending.ts"
 
@@ -61,6 +61,18 @@ interface Fixture {
    *  hangs the republish on, so a test can hold that a refusal really does
    *  reach a browser rather than waiting out the thirty-second sweep. */
   readonly settlements: () => number
+  /** Wait until something has SETTLED since `from` — a commit, a push, a
+   *  refusal. Snapshot `settlements()` before the action that should settle,
+   *  then wait on that number, so a commit that lands before the wait is
+   *  still seen. */
+  readonly settled: (from: number) => Effect.Effect<void>
+  /** Empty the ident, env included. Config alone is not enough: `GIT_AUTHOR_NAME=`
+   *  beats `user.name`, which is how a fixture used to fail with `fatal: empty
+   *  ident name` under a CI shell that had the variable empty rather than
+   *  unset. */
+  readonly unident: () => void
+  /** Put the fixture ident back, env included. */
+  readonly reident: () => void
   /** Hand the loop a survey, exactly as the server's publisher does — which is
    *  the only thing that arms the quiet window. */
   readonly observe: Effect.Effect<void>
@@ -93,6 +105,15 @@ const withRepo = <A>(
   }
   for (const [file, contents] of Object.entries(files)) write(file, contents)
 
+  // Product git inherits process.env. Local config does not win against an
+  // empty `GIT_AUTHOR_NAME`, so the ident is pinned here for the whole
+  // fixture and restored after — including on the empty-ident path, which
+  // clears these itself for the window it is about.
+  const savedIdent = Object.fromEntries(
+    GIT_IDENT_KEYS.map((key) => [key, process.env[key]]),
+  )
+  Object.assign(process.env, GIT_IDENT)
+
   const git = gitIn(root)
   const served = options.serve === undefined ? root : path.join(root, options.serve)
   fs.mkdirSync(served, { recursive: true })
@@ -107,6 +128,12 @@ const withRepo = <A>(
   }
 
   let settlements = 0
+  const waiters: Array<() => void> = []
+  const onSettled = () => {
+    settlements += 1
+    const ready = waiters.splice(0)
+    for (const wake of ready) wake()
+  }
   return Effect.gen(function*() {
     const store: OutlineStore = yield* Store.make({
       root: served,
@@ -122,9 +149,7 @@ const withRepo = <A>(
         push: options.pushes ?? null,
       }),
       ...(options.quiet === undefined ? {} : { quiet: options.quiet }),
-      onSettled: () => {
-        settlements += 1
-      },
+      onSettled,
       context: { mint: () => "minted", now: () => "2026-08-10T09:00:00-04:00" },
     })
     return yield* use({
@@ -135,6 +160,27 @@ const withRepo = <A>(
       remote,
       refresh: Effect.orDie(store.refresh),
       settlements: () => settlements,
+      settled: (from: number) =>
+        Effect.callback<void>((resume) => {
+          let done = false
+          const check = () => {
+            if (done || settlements <= from) return
+            done = true
+            resume(Effect.void)
+          }
+          waiters.push(check)
+          check()
+        }),
+      unident: () => {
+        git("config", "user.email", "")
+        git("config", "user.name", "")
+        for (const key of GIT_IDENT_KEYS) process.env[key] = ""
+      },
+      reident: () => {
+        git("config", "user.email", GIT_IDENT.GIT_AUTHOR_EMAIL)
+        git("config", "user.name", GIT_IDENT.GIT_AUTHOR_NAME)
+        Object.assign(process.env, GIT_IDENT)
+      },
       observe: Effect.flatMap(ops.pending, ops.observe),
     })
   }).pipe(
@@ -142,6 +188,11 @@ const withRepo = <A>(
     Effect.provide(NodeServices.layer),
     Effect.runPromise,
   ).finally(() => {
+    for (const key of GIT_IDENT_KEYS) {
+      const was = savedIdent[key]
+      if (was === undefined) delete process.env[key]
+      else process.env[key] = was
+    }
     fs.rmSync(root, { recursive: true, force: true })
   })
 }
@@ -950,10 +1001,6 @@ describe("the agent's door", () => {
  * hand: the loop is armed by the arrival of a survey and by nothing else.
  */
 describe("--commit=auto: the quiet window", () => {
-  /** Give the window its run, and then some — the one wait these tests share,
-   *  so a change to the fixture's span moves every one of them together. */
-  const past = (quiet: number) => Effect.sleep(Duration.millis(quiet * 6))
-
   test("a write does not commit itself, and says what it is waiting for", () =>
     withRepo({ "house.olai": HOUSE }, (fixture) =>
       Effect.gen(function*() {
@@ -974,21 +1021,25 @@ describe("--commit=auto: the quiet window", () => {
   test("a flurry of writes records itself as ONE commit, whoever wrote them", () =>
     withRepo({ "house.olai": HOUSE }, (fixture) =>
       Effect.gen(function*() {
-        yield* Effect.forkScoped(fixture.ops.loop)
-
         // Three writes by three different doors, and a file nobody wrote
         // through olai at all — which is the whole claim: the window watches
         // the DIRECTORY, so a `.md` saved in an editor lands in the same
         // commit as an agent's op.
+        //
+        // The loop starts AFTER the flurry. A 40ms window racing the writes
+        // themselves is how this used to flake under load: each observe
+        // re-armed, and when an op took longer than the window the flurry
+        // landed as two commits. What is waiting is the commit, not a
+        // multiple of the span.
         yield* Effect.orDie(fixture.ops.run({ op: "done", id: "order" }, "chat-agent"))
-        yield* fixture.observe
         yield* Effect.orDie(fixture.ops.run({ op: "done", id: "install" }, "mcp"))
-        yield* fixture.observe
         fixture.write("notes.md", "the cabinets are late\n")
         yield* fixture.refresh
-        yield* fixture.observe
 
-        yield* past(40)
+        yield* Effect.forkScoped(fixture.ops.loop)
+        const flurry = fixture.settlements()
+        yield* fixture.observe
+        yield* fixture.settled(flurry)
         // ONE, and it is the thing no amount of chrome can show.
         expect(subjects(fixture).filter((line) => line.startsWith("olai:"))).toHaveLength(1)
         const pending = yield* fixture.ops.pending
@@ -1009,22 +1060,27 @@ describe("--commit=auto: the quiet window", () => {
    * every thirty seconds and the span is fifteen, so it would close only in
    * the gaps and, on a busy directory, not at all.
    *
-   * IT IS ASSERTED WITHOUT WAITING AFTERWARDS, which is what makes it
-   * discriminating: the surveys run for three times the window, so a loop that
-   * re-armed on each of them has recorded nothing by the time they stop.
+   * The surveys run while the window is armed; what we wait on is the commit
+   * they must not prevent, not a multiple of the span. A second commit after
+   * more of the same surveys is the window having been pushed out.
    */
   test("a survey that says nothing new does not push the window out", () =>
     withRepo({ "house.olai": HOUSE }, (fixture) =>
       Effect.gen(function*() {
         yield* Effect.forkScoped(fixture.ops.loop)
         yield* Effect.orDie(fixture.ops.run({ op: "done", id: "order" }, "web"))
-
+        const sweep = fixture.settlements()
+        yield* fixture.observe
         for (let round = 0; round < 10; round++) {
           yield* fixture.observe
-          yield* Effect.sleep(Duration.millis(60))
+        }
+        yield* fixture.settled(sweep)
+        expect(subjects(fixture).filter((line) => line.startsWith("olai:"))).toHaveLength(1)
+        for (let round = 0; round < 10; round++) {
+          yield* fixture.observe
         }
         expect(subjects(fixture).filter((line) => line.startsWith("olai:"))).toHaveLength(1)
-      }), { commits: "auto", quiet: 200 }))
+      }), { commits: "auto", quiet: 40 }))
 
   test("nothing is attempted while the repository is busy, and it records after", () =>
     withRepo({ "house.olai": HOUSE }, (fixture) =>
@@ -1036,7 +1092,8 @@ describe("--commit=auto: the quiet window", () => {
         // here would bury a half-finished merge.
         yield* Effect.orDie(fixture.ops.run({ op: "done", id: "order" }, "chat-agent"))
         yield* fixture.observe
-        yield* past(40)
+        // The repository is not Ready, so the window does not arm — nothing
+        // to wait out.
         expect(subjects(fixture)[0]).not.toStartWith("olai:")
         // A PAUSE rather than a stop: nothing was attempted, so nothing
         // refused, so there is nothing for anybody to resume.
@@ -1051,8 +1108,9 @@ describe("--commit=auto: the quiet window", () => {
         fixture.git("add", "notes.md")
         fixture.git("commit", "--quiet", "--no-edit")
         yield* fixture.refresh
+        const afterMerge = fixture.settlements()
         yield* fixture.observe
-        yield* past(40)
+        yield* fixture.settled(afterMerge)
         expect(subjects(fixture).filter((line) => line.startsWith("olai:"))).toHaveLength(1)
       }), { commits: "auto", quiet: 40 }))
 
@@ -1063,13 +1121,14 @@ describe("--commit=auto: the quiet window", () => {
         // An identity nobody set — git's own "Author identity unknown", the
         // failure people actually hit on a fresh machine or under a service
         // account. Every probe answers happily and every commit refuses, which
-        // is the one failure a survey cannot see.
-        fixture.git("config", "user.email", "")
-        fixture.git("config", "user.name", "")
+        // is the one failure a survey cannot see. Env as well as config:
+        // empty `GIT_AUTHOR_NAME` beats `user.name`.
+        fixture.unident()
 
         yield* Effect.orDie(fixture.ops.run({ op: "done", id: "order" }, "web"))
+        const refused = fixture.settlements()
         yield* fixture.observe
-        yield* past(40)
+        yield* fixture.settled(refused)
 
         const stopped = yield* fixture.ops.git
         expect(stopped.status).toBe("error")
@@ -1078,25 +1137,24 @@ describe("--commit=auto: the quiet window", () => {
         // server's memory and nothing told a browser for thirty seconds.
         expect(fixture.settlements()).toBeGreaterThan(0)
 
-        // NOTHING GOES ROUND AGAIN. A second write, a full window, and the
-        // loop is still where git left it.
+        // NOTHING GOES ROUND AGAIN. A second write, and the loop is still
+        // where git left it — the window does not arm while paused.
         fixture.write("notes.md", "and another thing\n")
         yield* fixture.refresh
         yield* fixture.observe
-        yield* past(40)
         expect(subjects(fixture).filter((line) => line.startsWith("olai:"))).toHaveLength(0)
 
         // ... and Resume is the one way out. With the identity back, the same
         // waiting work records.
-        fixture.git("config", "user.email", "test@olai.invalid")
-        fixture.git("config", "user.name", "olai tests")
+        fixture.reident()
         yield* fixture.ops.resume
         expect((yield* fixture.ops.git).paused).toBeNull()
         // ... and pressing it again is not an error, it is nothing: two people
         // looking at one directory can both press it.
         yield* fixture.ops.resume
+        const resumed = fixture.settlements()
         yield* fixture.observe
-        yield* past(40)
+        yield* fixture.settled(resumed)
         expect(subjects(fixture).filter((line) => line.startsWith("olai:"))).toHaveLength(1)
         expect((yield* fixture.ops.git).paused).toBeNull()
       }), { commits: "auto", quiet: 40 }))
@@ -1112,8 +1170,6 @@ describe("--commit=auto: the quiet window", () => {
  * commit olai makes by whichever door.
  */
 describe("--push=auto", () => {
-  const past = (quiet: number) => Effect.sleep(Duration.millis(quiet * 6))
-
   test("a commit the AGENT asked for is pushed", () =>
     withRepo({ "house.olai": HOUSE }, (fixture) =>
       Effect.gen(function*() {
@@ -1133,8 +1189,15 @@ describe("--push=auto", () => {
         yield* Effect.forkScoped(fixture.ops.loop)
         fixture.write("notes.md", "the cabinets are late\n")
         yield* fixture.refresh
+        const pushed = fixture.settlements()
         yield* fixture.observe
-        yield* past(40)
+        yield* fixture.settled(pushed)
+        while (subjects(fixture).filter((line) => line.startsWith("olai:")).length === 0) {
+          yield* fixture.settled(fixture.settlements())
+        }
+        while ((yield* fixture.ops.pending).unpushed?.commits !== 0) {
+          yield* fixture.settled(fixture.settlements())
+        }
 
         expect(gitIn(bare)("log", "--format=%s", "-1").trim()).toStartWith("olai:")
         expect((yield* fixture.ops.pending).unpushed?.commits).toBe(0)
@@ -1160,8 +1223,12 @@ describe("--push=auto", () => {
 
         fixture.write("notes.md", "the cabinets are late\n")
         yield* fixture.refresh
+        const diverged = fixture.settlements()
         yield* fixture.observe
-        yield* past(40)
+        yield* fixture.settled(diverged)
+        while ((yield* fixture.ops.git).pushSaid === null) {
+          yield* fixture.settled(fixture.settlements())
+        }
 
         // The COMMIT stands — a refused push is not a rollback.
         expect(subjects(fixture).filter((line) => line.startsWith("olai:"))).toHaveLength(1)
@@ -1537,8 +1604,9 @@ test("a boot says nothing about a branch that has no upstream at all", () =>
       yield* Effect.forkScoped(fixture.ops.loop)
       fixture.write("notes.md", "the herb bed needs splitting\n")
       yield* fixture.refresh
+      const boot = fixture.settlements()
       yield* fixture.observe
-      yield* Effect.sleep(Duration.millis(240))
+      yield* fixture.settled(boot)
       expect(subjects(fixture).filter((line) => line.startsWith("olai:"))).toHaveLength(1)
     }), { commits: "auto", pushes: "auto", quiet: 40 }))
 

--- a/packages/ops/src/pending.ts
+++ b/packages/ops/src/pending.ts
@@ -676,7 +676,10 @@ export const make = (options: Options): Committing => {
     const git = opening.repo
     // Independent questions, asked together: what state the repository is in,
     // what has moved in it (and how far ahead of its upstream it is, off the
-    // same subprocess), and what olai last recorded there.
+    // same subprocess), and what olai last recorded there. `dirty` may wait
+    // on a `commit` in the same repository — they share the index — but
+    // `state` and `last` do not, which is why these three still start
+    // together rather than in a line.
     const [repo, dirt, last] = yield* Effect.all(
       [git.state, git.dirty, git.last(AUDIT)],
       { concurrency: 3 },
@@ -789,6 +792,7 @@ export const make = (options: Options): Committing => {
       // CONCURRENTLY: each is its own subprocess, and they do not depend on
       // each other. Bounded, because a `git pull` can make a hundred outlines
       // dirty at once and a hundred simultaneous processes is its own problem.
+      // `show` does not take the index, so the bound is still the bound.
       // HEAD's copy is asked for under the name HEAD HAD IT UNDER, which for a
       // rename is the side it came from — read against the name it has now,
       // which HEAD has never had, every node in it reports as created.
@@ -1006,7 +1010,9 @@ export const make = (options: Options): Committing => {
     // uses, and it earns it twice over now that this verb is on the commit path
     // rather than behind a button: `state` is a subprocess AND a synchronous
     // walk of the git directory, so serialising them stalls the loop's own
-    // round trip for no reason.
+    // round trip for no reason. `dirty` may wait on a `commit` (the index);
+    // `state` does not. `push` itself is not on that gate: a network call
+    // with the ten-second budget must not stall `whyWaiting`.
     const [repo, dirt] = yield* Effect.all(
       [opening.repo.state, opening.repo.dirty],
       { concurrency: 2 },


### PR DESCRIPTION
Stacked overnight flake: `packages/ops/src/pending.test.ts` → "a flurry of writes records itself as ONE commit". Three sightings on 2026-08-23, including `fatal: empty ident name` under load with a 40ms window.

## Races

### 1. Empty git ident (TEST / fixture)

**Verdict:** test/fixture, not product. Git's own rule: env beats config, and `GIT_AUTHOR_NAME=` is empty, not unset. `repoAt` wrote `user.name` locally; product `git.ts` inherits `process.env`, so an empty ambient ident refused the auto-commit with `fatal: empty ident name (for <>) not allowed`. Reproduced on the unmodified file: `GIT_AUTHOR_NAME= bun test -t flurry` → 0 olai commits.

**Fix:** `GIT_IDENT` on every `gitIn` / `repoAt` spawn. `withRepo` pins the same keys on `process.env` for the product path and restores them; the empty-ident scenario clears env *and* config (`unident` / `reident`).

### 2. 40ms window vs the flurry (TEST)

**Verdict:** test, not product. The product window is 15s; the test compressed it to 40ms and slept `quiet * 6`. Under load, `ops.run` between observes exceeded 40ms, so a flurry honestly recorded as two commits. Reproduced unmodified: 1 of 10 sequential flurry runs got length 2.

**Fix:** the loop starts *after* the writes (one observe of the combined pending set). Quiet-window tests wait on `onSettled`, snapshotted *before* the action, not on a multiple of the span.

### 3. `index.lock` between survey and commit (PRODUCT)

**Verdict:** product. `git status` refreshes the index; `git commit` writes it. Two fibers on one handle (the publisher's survey and the quiet-window commit) lost to `Unable to create '.../.git/index.lock': File exists`, and the window recorded nothing. Seen on the survey test under load after (1) and (2) were fixed.

**Fix:** one `Semaphore` permit per `Repo` handle, held for the whole verb. Covered by `a survey and a commit at once never fight index.lock`.

## Pin (20 consecutive full-file runs, 16 busy loops, nproc=16)

```
run=1 ok  Ran 46 tests across 1 file. [13.89s]
run=2 ok  [12.36s]
run=3 ok  [23.11s]
run=4 ok  [15.55s]
run=5 ok  [14.18s]
run=6 ok  [14.91s]
run=7 ok  [12.21s]
run=8 ok  [14.14s]
run=9 ok  [11.59s]
run=10 ok [11.40s]
run=11 ok [12.80s]
run=12 ok [11.75s]
run=13 ok [15.03s]
run=14 ok [13.06s]
run=15 ok [15.05s]
run=16 ok [18.04s]
run=17 ok [18.35s]
run=18 ok [21.14s]
run=19 ok [19.50s]
run=20 ok [18.76s]
empty-ident flurry ×5 under the same load: all ok
pin-fails=0
```

Unmodified-file reproductions (before the fix): empty `GIT_AUTHOR_*` → flurry length 0; 1/10 sequential flurry runs → length 2.

## Suite

- typecheck: green
- `just test`: 3502 pass / 0 fail (251 files) + 77 pass / 0 fail (browser conditions)
- `pending.test.ts`: 46 pass, 203 expect()

## Deferrals

No deferrals.