### PR TITLE
reaper.test.ts waits on the child's death and pins 130/143 (reaper-test-flaky)

### DIFF
--- a/packages/tests/reaper.test.ts
+++ b/packages/tests/reaper.test.ts
@@ -5,17 +5,30 @@
  * skipped AfterAll; SIGKILL never ran `exit` at all; and `detached: true`
  * put each olai in a process group the signal never reached. This file is
  * that property as a unit: a parent that uses {@link installReaper} is
- * SIGINT'd, and the detached child it started is gone.
+ * signalled, the detached child it started is gone, and the parent itself
+ * exits 130 (SIGINT) or 143 (SIGTERM) — which is how a cancelled run ends
+ * instead of grinding to AfterAll.
  */
 
 import { expect, test } from "bun:test";
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import * as path from "node:path";
 
 const REAPER = path.join(import.meta.dirname, "support/reaper.ts");
-const BOUND_MS = 5_000;
 
-test("PIN (reaper): SIGINT of the parent kills a detached child", async () => {
+/** Hang detector only. The waits are the pid line, the parent's exit, and
+ *  the child's death; this number tells "never" from "slow". */
+const BOUND_MS = 10_000;
+
+const launch = (): {
+  readonly parent: ChildProcess;
+  readonly said: () => string;
+  readonly err: () => string;
+  readonly exited: Promise<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+  }>;
+} => {
   const parent = spawn(
     process.execPath,
     [
@@ -33,25 +46,138 @@ test("PIN (reaper): SIGINT of the parent kills a detached child", async () => {
     { stdio: ["ignore", "pipe", "pipe"] },
   );
   let said = "";
+  let err = "";
   parent.stdout?.setEncoding("utf8");
+  parent.stderr?.setEncoding("utf8");
   parent.stdout?.on("data", (chunk: string) => {
     said += chunk;
   });
-  try {
+  parent.stderr?.on("data", (chunk: string) => {
+    err += chunk;
+  });
+  const exited = new Promise<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+  }>((resolve) => {
+    parent.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+  return { parent, said: () => said, err: () => err, exited };
+};
+
+/** The pid line, not a poll. Late caller: look once in the box. Early
+ *  caller: the `data` event that carries it. {@link BOUND_MS} is only the
+ *  hang detector. */
+const pidOf = (box: ReturnType<typeof launch>): Promise<number> =>
+  new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (act: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      act();
+    };
+    const look = (): void => {
+      const n = Number(box.said().trim());
+      if (Number.isInteger(n) && n > 0) finish(() => resolve(n));
+    };
+    const timer = setTimeout(() => {
+      finish(() =>
+        reject(
+          new Error(
+            `parent never said the child pid:\nstdout:\n${box.said()}\nstderr:\n${box.err()}`,
+          ),
+        ),
+      );
+    }, BOUND_MS);
+    box.parent.stdout?.on("data", look);
+    void box.exited.then(() => {
+      look();
+      finish(() =>
+        reject(
+          new Error(
+            `parent exited before it said the child pid:\nstdout:\n${box.said()}\nstderr:\n${box.err()}`,
+          ),
+        ),
+      );
+    });
+    look();
+  });
+
+/** ESRCH, not a deadline. SIGKILL of the group is sent and then the parent
+ *  `process.exit`s; the pid can still be in the table (a zombie, or the
+ *  kill not yet scheduled) after the parent's `exit` event. */
+const untilGone = (pid: number): Promise<void> =>
+  new Promise((resolve, reject) => {
     const started = Date.now();
-    while (said.trim() === "" && Date.now() - started < BOUND_MS) {
-      await Bun.sleep(25);
-    }
-    const childPid = Number(said.trim());
+    const poll = (): void => {
+      try {
+        process.kill(pid, 0);
+      } catch {
+        clearInterval(timer);
+        resolve();
+        return;
+      }
+      if (Date.now() - started >= BOUND_MS) {
+        clearInterval(timer);
+        reject(
+          new Error(`detached child ${pid} still alive after the parent exited`),
+        );
+      }
+    };
+    const timer = setInterval(poll, 10);
+    poll();
+  });
+
+const signaled = async (
+  signal: "SIGINT" | "SIGTERM",
+  code: number,
+): Promise<void> => {
+  const box = launch();
+  let childPid = 0;
+  try {
+    childPid = await pidOf(box);
     expect(childPid).toBeGreaterThan(0);
     expect(() => process.kill(childPid, 0)).not.toThrow();
-    parent.kill("SIGINT");
-    await new Promise<void>((resolve) => {
-      parent.once("exit", () => resolve());
-      setTimeout(resolve, BOUND_MS);
-    });
-    expect(() => process.kill(childPid, 0)).toThrow();
+    box.parent.kill(signal);
+    const ended = await Promise.race([
+      box.exited,
+      Bun.sleep(BOUND_MS).then(() => {
+        throw new Error(`parent did not exit after ${signal}`);
+      }),
+    ]);
+    expect(ended.code).toBe(code);
+    await untilGone(childPid);
   } finally {
-    parent.kill("SIGKILL");
+    if (box.parent.exitCode === null && box.parent.signalCode === null) {
+      box.parent.kill("SIGKILL");
+    }
+    if (childPid > 0) {
+      try {
+        process.kill(-childPid, "SIGKILL");
+      } catch {
+        // already gone, or no such process group
+      }
+      try {
+        process.kill(childPid, "SIGKILL");
+      } catch {
+        // already gone
+      }
+    }
   }
-}, BOUND_MS * 2);
+};
+
+test(
+  "PIN (reaper): SIGINT of the parent kills a detached child",
+  async () => {
+    await signaled("SIGINT", 130);
+  },
+  BOUND_MS * 3,
+);
+
+test(
+  "PIN (reaper): SIGTERM of the parent kills a detached child",
+  async () => {
+    await signaled("SIGTERM", 143);
+  },
+  BOUND_MS * 3,
+);

--- a/packages/tests/reaper.test.ts
+++ b/packages/tests/reaper.test.ts
@@ -120,7 +120,9 @@ const untilGone = (pid: number): Promise<void> =>
       if (Date.now() - started >= BOUND_MS) {
         clearInterval(timer);
         reject(
-          new Error(`detached child ${pid} still alive after the parent exited`),
+          new Error(
+            `detached child ${pid} still alive after the parent exited (or that pid was reused)`,
+          ),
         );
       }
     };
@@ -166,12 +168,14 @@ const signaled = async (
   }
 };
 
+// One BOUND_MS more than the three hang detectors, so bun cannot steal
+// the last detector's error with a generic "test timed out".
 test(
   "PIN (reaper): SIGINT of the parent kills a detached child",
   async () => {
     await signaled("SIGINT", 130);
   },
-  BOUND_MS * 3,
+  BOUND_MS * 4,
 );
 
 test(
@@ -179,5 +183,5 @@ test(
   async () => {
     await signaled("SIGTERM", 143);
   },
-  BOUND_MS * 3,
+  BOUND_MS * 4,
 );


### PR DESCRIPTION
`packages/tests/reaper.test.ts` failed in #357's CI unit leg at b8474c6c: SIGINT of the parent kills a detached child — failed in run 1, passed in runs 2–3 at the same sha while `lock.test.ts` took its place; 61/61 on a quiet box. Two test races. The reaper itself is not missing the kill.

Inbox → flaky tests → `reaper-test-flaky`. #347 treatment.

## Cause

| Race | Failure | Why a test race, not a product race |
|---|---|---|
| `parent.once("exit")` then immediate `kill(childPid, 0)` | `expect(…).toThrow()` — function did not throw; received `true`. 87ms / 117ms under 8-way parallel | The reaper SIGKILLs the group and `process.exit`s. The pid can still be in the table (a zombie, or the kill not yet scheduled) after the parent's `exit` event. SIGKILL was sent; the child is gone a beat later. A real cancelled run does not probe `kill(0)` on the grandchild the instant cucumber exits. |
| `once("exit")` also resolves on a 5s timeout as success | #355 re-verdict nit: the test passes with `process.exit(130/143)` deleted | A SIGINT listener disables default termination. Without `process.exit` the parent never leaves, the timeout fires, and if `killLive` already ran the grandchild is dead so the old assertion passes. 130/143 was unpinned. |

No product change. No retries, no `sleep` as the wait, no budget inflation as the wait.

## What changed

1. **Wait on the pid line.** Late caller: look once in the box. Early caller: the `data` event that carries it. Hang detector only.
2. **Wait on the parent's exit, and assert the code.** SIGINT → 130, SIGTERM → 143. Hang detector throws `parent did not exit after SIGINT`; it is not success.
3. **Wait on ESRCH of the child.** The death, not a deadline. Hang detector throws `detached child still alive after the parent exited`.
4. **SIGTERM pin added.** The twin of SIGINT; #355 named both.

Did not touch pending / serve / lock / e2e. `lock.test.ts` failed in the same CI leg on a 10s "the server never said where it was serving" boot timeout — that is the listen-wait `child.testlib.ts` already owns (#359). Not this race; the lock lane keeps it.

## Before (unmodified file)

Alone, idle: **8/8 green**, ~120–238ms.

Alone under `stress-ng --cpu 16`: **12/12 green**, ~68–208ms.

8-way parallel × 3 rounds (the CI-shaped contention — many bun workers plus load): **22/24**. Two failures, same text, not a timeout:

```
error: expect(received).toThrow()

Received function did not throw
Received value: true

      at <anonymous> (packages/tests/reaper.test.ts:53:45)
(fail) PIN (reaper): SIGINT of the parent kills a detached child [117.00ms]
```

and the same at 87ms. Parent had exited; the grandchild was still in the table.

#355 nit, confirmed after the rewrite (old test would have passed): deleting `process.exit(130/143)` from `reaper.ts`, the new tests fail:

```
error: parent did not exit after SIGINT
(fail) PIN (reaper): SIGINT of the parent kills a detached child [10062.12ms]
error: parent did not exit after SIGTERM
(fail) PIN (reaper): SIGTERM of the parent kills a detached child [10045.12ms]
```

## GO pin (`stress-ng --cpu 16 --io 4`, dirty HEAD then `5b6140f6`)

```
===== AFTER run 1 =====  2 pass  Ran 2 tests across 1 file. [533.00ms]  run 1 ok
===== AFTER run 2 =====  2 pass  Ran 2 tests across 1 file. [475.00ms]  run 2 ok
===== AFTER run 3 =====  2 pass  Ran 2 tests across 1 file. [307.00ms]  run 3 ok
===== AFTER run 4 =====  2 pass  Ran 2 tests across 1 file. [412.00ms]  run 4 ok
===== AFTER run 5 =====  2 pass  Ran 2 tests across 1 file. [465.00ms]  run 5 ok
===== AFTER run 6 =====  2 pass  Ran 2 tests across 1 file. [492.00ms]  run 6 ok
===== AFTER run 7 =====  2 pass  Ran 2 tests across 1 file. [534.00ms]  run 7 ok
===== AFTER run 8 =====  2 pass  Ran 2 tests across 1 file. [347.00ms]  run 8 ok
===== AFTER run 9 =====  2 pass  Ran 2 tests across 1 file. [467.00ms]  run 9 ok
===== AFTER run 10 ===== 2 pass  Ran 2 tests across 1 file. [325.00ms]  run 10 ok
===== AFTER run 11 ===== 2 pass  Ran 2 tests across 1 file. [360.00ms]  run 11 ok
===== AFTER run 12 ===== 2 pass  Ran 2 tests across 1 file. [210.00ms]  run 12 ok
===== AFTER run 13 ===== 2 pass  Ran 2 tests across 1 file. [383.00ms]  run 13 ok
===== AFTER run 14 ===== 2 pass  Ran 2 tests across 1 file. [351.00ms]  run 14 ok
===== AFTER run 15 ===== 2 pass  Ran 2 tests across 1 file. [224.00ms]  run 15 ok
===== AFTER run 16 ===== 2 pass  Ran 2 tests across 1 file. [313.00ms]  run 16 ok
===== AFTER run 17 ===== 2 pass  Ran 2 tests across 1 file. [281.00ms]  run 17 ok
===== AFTER run 18 ===== 2 pass  Ran 2 tests across 1 file. [259.00ms]  run 18 ok
===== AFTER run 19 ===== 2 pass  Ran 2 tests across 1 file. [324.00ms]  run 19 ok
===== AFTER run 20 ===== 2 pass  Ran 2 tests across 1 file. [252.00ms]  run 20 ok
AFTER_OK=20 AFTER_FAIL=0
```

The same load, 8-way parallel × 3 rounds (the window that reproduced 2/24 on the unmodified file): **24/24**.

One run verbatim (after HEAD `5b6140f6`):

```
bun test v1.3.13 (bf2e2cec)
packages/tests/reaper.test.ts:
(pass) PIN (reaper): SIGINT of the parent kills a detached child [78.00ms]
(pass) PIN (reaper): SIGTERM of the parent kills a detached child [61.00ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [201.00ms]
```

## Suites

- `just typecheck` — 14/14
- `just test` — **3501 pass**, 1 fail: the already-filed `pending.test.ts` quiet-window flake (other lane tonight; two consecutive full-suite runs under the same `stress-ng` load, then 3501/3502). `reaper.test.ts` green in both. Browser-condition half **77/77**.
- Pin: 20/20 serial full-file under load; 24/24 parallel burst.

## Deferrals

No deferrals.