### PR TITLE
fieldIn answers a record, never null; one chat helper block

### DIFF
--- a/packages/chat/src/agents/claude.ts
+++ b/packages/chat/src/agents/claude.ts
@@ -317,7 +317,10 @@ export const backgroundTaskIn = (meta: Meta): Background | null => {
  *  everything read here is nested somewhere inside somebody else's payload, and
  *  each level of the nesting is a place a shape can change under us. `_meta`,
  *  `claudeCode` and a handshake's capabilities are all the same step. */
-const fieldIn = (value: unknown, field: string): Meta => {
+const fieldIn = (
+  value: unknown,
+  field: string,
+): { readonly [key: string]: unknown } | undefined => {
   if (typeof value !== "object" || value === null) return undefined
   const found = (value as { readonly [key: string]: unknown })[field]
   return typeof found === "object" && found !== null
@@ -328,13 +331,13 @@ const fieldIn = (value: unknown, field: string): Meta => {
 /** ... and the one field of it every advertisement hangs off. Named because
  *  `_meta` is the protocol's own word for "an extension said something here",
  *  and both handshake readers start by asking for one. */
-const metaOf = (value: unknown): Meta => fieldIn(value, "_meta")
+const metaOf = (value: unknown) => fieldIn(value, "_meta")
 
 /** The adapter's own corner of a `_meta`, or `undefined` when there is none —
  *  an absent `_meta`, an absent `claudeCode`, one that is not an object. Every
  *  reader here starts by asking for it, and it is {@link fieldIn} under the one
  *  name this file reads everything out of. */
-const claudeIn = (meta: Meta): Meta => fieldIn(meta, "claudeCode")
+const claudeIn = (meta: Meta) => fieldIn(meta, "claudeCode")
 
 /** One field of that corner, when it is a non-empty string and `null` for
  *  everything else — a field of some other type, the empty string. The two

--- a/packages/tests/evidence.ts
+++ b/packages/tests/evidence.ts
@@ -211,14 +211,14 @@ const SETTLE = 1800
  *  window and {@link PANEL_FITS} are built from. */
 const WIDE = 1100
 
-// ── the chat panel, for the one section that talks to an agent ─────────
+// ── the chat panel, for the sections that talk to an agent ─────────────
 
 /** The panel's own rows and controls, by the test ids the client draws them
  *  with. Spelled here rather than imported from `support/world.ts`: that module
  *  is the SUITE's world (it imports cucumber and a browser it did not open),
  *  and a driver reaching into it would drag the runner into a script that has
  *  no runner. The same reason `reads.ts` builds its own session rather than a
- *  scenario's. */
+ *  scenario's. Shared by every chat section in this file. */
 const CHAT_TOGGLE = '[data-testid="chat-toggle"]'
 const CHAT_PANEL = '[data-testid="chat-panel"]'
 const CHAT_INPUT = '[data-testid="chat-input"]'
@@ -231,15 +231,6 @@ const TESTID_WATCHING = "chat-watching"
 const CHAT_WATCHING = `[data-testid="${TESTID_WATCHING}"]`
 const CHAT_TOOL_ELAPSED = '[data-testid="chat-tool-elapsed"]'
 const CHAT_TOOL_PROGRESS = '[data-testid="chat-tool-progress"]'
-
-/** Open the panel if this browser has not remembered it open. Whether it is
- *  open is a preference the client keeps, so a driver that clicked
- *  unconditionally would close it every other run. */
-const openChat = async (page: Page): Promise<void> => {
-  const panel = page.locator(CHAT_PANEL)
-  if (!(await panel.isVisible())) await page.locator(CHAT_TOGGLE).click()
-  await panel.waitFor()
-}
 
 /** Say something to the agent — the driver's half of the suite's own step. */
 const ask = async (page: Page, text: string): Promise<void> => {
@@ -696,15 +687,8 @@ const said = async (page: Page, locator: string) =>
 
 // ── the conversation ───────────────────────────────────────────────────
 
-/** The panel, its door, and the six things the chat section reads. Spelled
- *  here rather than imported from `support/world.ts`, which is the SUITE's
- *  world and builds a Cucumber one on import — the same reason every other
- *  selector in this file is a literal. */
-const CHAT_TOGGLE = '[data-testid="chat-toggle"]'
-const CHAT_PANEL = '[data-testid="chat-panel"]'
-const CHAT_TRANSCRIPT = '[data-testid="chat-transcript"]'
-const CHAT_INPUT = '[data-testid="chat-input"]'
-const CHAT_SEND = '[data-testid="chat-send"]'
+/** Faces this section photographs that the panel block above does not:
+ *  cancel, interrupt, the queued row, the composer's queue promise. */
 const CHAT_CANCEL = '[data-testid="chat-cancel"]'
 /** The other send: into the turn the agent is running. */
 const CHAT_INTERRUPT = '[data-testid="chat-interrupt"]'
@@ -721,11 +705,12 @@ const AGENT_PATIENCE = 180_000
 
 /** Open the panel and wait until it has an agent to talk to.
  *
- *  It REFUSES an `off` panel by timing out here rather than further down: this
- *  section is about what an agent does with a message, so a run against no
- *  agent has nothing to photograph and the honest place to say so is the first
- *  wait. `AGENT=` on `evidence.sh` is what gives it one. */
-const openChat = async (page: Page): Promise<void> => {
+ *  It REFUSES an `off` panel by timing out here rather than further down: a
+ *  section about what an agent does with a message has nothing to photograph
+ *  against no agent, and the honest place to say so is the first wait.
+ *  `AGENT=` on `evidence.sh` is what gives it one. Both chat sections need
+ *  that wait — the background-task one included. */
+const openChatForAgent = async (page: Page): Promise<void> => {
   if (!(await page.locator(CHAT_PANEL).isVisible())) {
     await page.locator(CHAT_TOGGLE).click()
     await page.locator(CHAT_PANEL).waitFor()
@@ -1005,7 +990,7 @@ const SECTIONS = {
    * against a real monitor's clock.
    */
   "a-background-task-the-agent-armed": async (page) => {
-    await openChat(page)
+    await openChatForAgent(page)
     await ask(page, "watch")
     // THE ROW, once the clock has something to say. The readout is quiet for
     // its first seconds on purpose (the reads that land instantly must not
@@ -3599,7 +3584,7 @@ const SECTIONS = {
      *  a glance in a transcript full of prose. */
     const WORD = (word: string) => `Say the word ${word} and nothing else.`
 
-    await openChat(page)
+    await openChatForAgent(page)
     await shot(page, "an-idle-conversation")
 
     // ── ONE: the interrupting gesture ────────────────────────────────


### PR DESCRIPTION
Two same-afternoon merges (#365 × #336, #365 × #366) were green at their own heads and wrong together. Master is red.

## Repair 1 — fieldIn's annotation, not wordIn's

On clean master, `just typecheck` / `tsc --noEmit` in `@olai/chat`:

```
src/agents/claude.ts(346,10): error TS2345: Argument of type 'Meta' is not assignable to parameter of type '{ readonly [field: string]: unknown; } | undefined'.
  Type 'null' is not assignable to type '{ readonly [field: string]: unknown; } | undefined'.
```

#336 widened `Meta` to `record | null | undefined` because the wire can spell `_meta: null`. `fieldIn`'s `value === null` guard already eats that arm; both of its exits answer strictly `object | undefined`. Its docstring already says so ("undefined when there is none"). `claudeIn` / `metaOf` are `fieldIn` under other names, so they inherited the lie, and #365's `stringIn` passed it into `wordIn`.

**Cure chosen: narrow `fieldIn`** (runtime untouched). `wordIn` already takes what `fieldIn` actually produces. `claudeIn` and `metaOf` drop the `: Meta` return so they infer that.

**Not chosen: widen `wordIn` to `Meta`.** `said?.[field]` on null yields the same answer, so it is not a runtime bug — but it makes the parameter advertise a case this file never produces, and erases the distinction `fieldIn`'s own docstring states.

## Repair 2 — one chat helper block

`packages/tests/evidence.ts` has not parsed since #366: the "conversation" section re-declared `CHAT_TOGGLE` / `PANEL` / `INPUT` / `SEND` / `TRANSCRIPT` + `openChat` owned by the "chat panel" block (12× TS2451). That also aborted every full `bun test` mid-discovery via `acp/manifest.test.ts`'s tree scan.

One block. The richer `openChat` (waits for the agent — #365's section needs that anyway) is `openChatForAgent`.

## Verification

- typecheck: clean (14 packages)
- unit: **3593 pass / 0 fail** + **77** under the browser condition
- e2e `the_agent.feature` (#366's eight scenarios + #365's background-task): **9 scenarios (9 passed), 146 steps (146 passed)**

## Observed, not folded

#368 independently hit the same typecheck break and folded the opposite cure (`wordIn` takes `Meta`) plus a partial `evidence.ts` dedup that keeps two `openChat` helpers. If that lands first, this PR will conflict on both files; the arbitration here is the one to keep.