### PR TITLE
One gesture, one commit: Enter owns the chip editor's close, the blur stands down

### DIFF
--- a/packages/tests/features/properties.feature
+++ b/packages/tests/features/properties.feature
@@ -129,6 +129,31 @@ Feature: Properties on a node, from the web
     And the node "handles" says nothing about its properties
     And there should be no page errors
 
+  Scenario: The same chip edited twice — every open answers for itself
+    # THE REMOUNT, DRIVEN. The editor's answer-record is born with the open:
+    # closing disposes the box and REOPENING mints the next editor, so the
+    # second open's blur must still carry the gesture. An editor that kept
+    # the first open's record (a hidden box instead of a disposed one) would
+    # read this second leaving as the first Enter's echo and swallow it —
+    # the typed "submitted" never sent, the file still saying "addressing":
+    # the pinned bug reborn as a silent miss.
+    When I open the node menu of "handles"
+    And I choose "Add property…" from the node menu
+    And I write the property "stage" holding "review" on "handles"
+    When I edit the property "stage" on "handles"
+    And I type "addressing" into the property editor on "handles"
+    Then the node "handles" shows the property "stage" holding "addressing"
+    # Second open, the other half of the rule: typed, then clicked away.
+    When I edit the property "stage" on "handles"
+    Then the property editor on "handles" holds "addressing"
+    When I type "submitted" into the property editor on "handles" without pressing Enter
+    And I click away from the property editor on "handles"
+    Then the property editor on "handles" is closed
+    And the node "handles" shows the property "stage" holding "submitted"
+    And "house.olai" holds the node "handles" with "stage" set to "submitted"
+    And the node "handles" says nothing about its properties
+    And there should be no page errors
+
   Scenario: A value that is not a link is the second way in
     # The gesture rule, in the direction a reader reaches first. A link goes
     # where it says; everything else in a chip opens it.

--- a/packages/tests/features/properties.feature
+++ b/packages/tests/features/properties.feature
@@ -209,6 +209,41 @@ Feature: Properties on a node, from the web
     And the node "handles" says nothing about its properties
     And there should be no page errors
 
+  Scenario: A chip whose key disappears under an open, typed editor is written back — the inherited default
+    # THE THIRD GESTURELESS CLOSE, driven (Opus, review 2 of 2; the law's doc
+    # in `client/props/editor.ts` names all three). The agent's `set_prop`
+    # DROPS the key while its editor is open and typed; the drawer's chip is
+    # disposed, and the blur at that disposal has no gesture and is
+    # byte-identical to a person's leaving — the record is `null`, so the
+    # typed value is committed against the open-time snapshot and the removed
+    # key is born again holding it.
+    #
+    # Pinned as the law's CURRENT default, NOT as a ruling: the gate that
+    # should refuse the resurrect is a `was` riding the op (only the op can
+    # say the record moved — the queued lane), and its refusal on this path
+    # would be drawn nowhere, the drawer being gone. When that lane lands,
+    # the tail below flips to the key staying gone.
+    Given I rewrite "house.olai" as:
+      """
+      {"id":"kitchen","ord":"a0","title":"kitchen remodel #home"}
+      {"id":"handles","parent":"kitchen","ord":"a0","title":"choose the handles","custom":{"stage":"review"}}
+      """
+    And I open the outline "house.olai"
+    And I mark the page
+    When I edit the property "stage" on "handles"
+    And I type "submitted" into the property editor on "handles" without pressing Enter
+    When I rewrite "house.olai" as:
+      """
+      {"id":"kitchen","ord":"a0","title":"kitchen remodel #home"}
+      {"id":"handles","parent":"kitchen","ord":"a0","title":"choose the handles"}
+      """
+    # No key, no click: the rewrite's own frame is what closes the editor.
+    Then the property editor on "handles" is closed
+    And the node "handles" shows the property "stage" holding "submitted"
+    And "house.olai" holds the node "handles" with "stage" set to "submitted"
+    And the node "handles" says nothing about its properties
+    And there should be no page errors
+
   Scenario: A value that names something keeps its link however long it is
     # Both reviewers. The fold is for PROSE; a URL and a deep vault path are the
     # two door kinds most likely to run past it, and folding them took away the

--- a/packages/tests/features/properties.feature
+++ b/packages/tests/features/properties.feature
@@ -64,6 +64,9 @@ Feature: Properties on a node, from the web
     # the moment the file says it is.
     Then the node "handles" shows the property "pr" holding "https://github.com/juspay/olai/pull/179"
     And "house.olai" holds the node "handles" with "pr" set to "https://github.com/juspay/olai/pull/179"
+    # ...and the ADD was one gesture too: the value box's Enter closed the chip,
+    # and the leaving the close fired sent nothing of its own.
+    And the node "handles" says nothing about its properties
     # `handles` has no note, so it has nothing behind a mark — a run that is
     # already on the row is not something to open.
     And the node "handles" shows no pilcrow
@@ -102,6 +105,28 @@ Feature: Properties on a node, from the web
     When I type "addressing" into the property editor on "handles"
     Then the node "handles" shows the property "stage" holding "addressing"
     And "house.olai" holds the node "handles" with "stage" set to "addressing"
+    # ONE GESTURE, ONE COMMIT, and the commit owns the close: the blur the
+    # unmount fires is Enter's own closing, not a second write — the day it is
+    # heard as one, the ops layer's no-change guard draws "already says … —
+    # nothing would change" here (chip-blur-double-commit-2).
+    And the node "handles" says nothing about its properties
+    And there should be no page errors
+
+  Scenario: Clicking away is the other commit — once, and as silently
+    # The path the Enter fix could break: with NO key pressed, the blur IS the
+    # gesture, so it must still write — once: a once-heard leaving is the law,
+    # a silenced one is the cure being worse than the bug, and a twice-heard
+    # one is the bug itself, spelled by the pointer instead of by Enter.
+    When I open the node menu of "handles"
+    And I choose "Add property…" from the node menu
+    And I write the property "stage" holding "review" on "handles"
+    When I edit the property "stage" on "handles"
+    And I type "addressing" into the property editor on "handles" without pressing Enter
+    And I click away from the property editor on "handles"
+    Then the property editor on "handles" is closed
+    And the node "handles" shows the property "stage" holding "addressing"
+    And "house.olai" holds the node "handles" with "stage" set to "addressing"
+    And the node "handles" says nothing about its properties
     And there should be no page errors
 
   Scenario: A value that is not a link is the second way in
@@ -230,6 +255,7 @@ Feature: Properties on a node, from the web
     And I leave the property editor on "handles" without pressing Enter
     Then the property editor on "handles" is closed
     And the node "handles" shows the property "stage" holding "review"
+    And the node "handles" says nothing about its properties
     # Opening a chip and clicking away is a gesture somebody makes several times
     # a minute, and it must be silent rather than a refusal: the ops layer would
     # turn "set it to what it already holds" away in good words, and an

--- a/packages/tests/features/typed_properties.feature
+++ b/packages/tests/features/typed_properties.feature
@@ -41,14 +41,14 @@ Feature: A property key that declares its type
     And "lanes.olai" holds the node "chips" with "merge" set to "auto"
     And the page has not reloaded
     # ONE GESTURE, ONE REFUSAL — the refusal is the one send's own answer; the
-    # stand-down swallows the duplicate and never the answer. The doubled send
-    # would be e2e-invisible here BY CONSTRUCTION (a second send of the same
-    # miss draws the very same words through `createSaying`'s replace, one DOM
-    # line either way — that is why the send count is `editor.test.ts`'s
-    # half): what this scenario CAN hold is that the refusal is still what the
-    # run says when the gesture has fully answered — no `say(null)`, no
-    # replacement, whatever followed the Enter.
-    And the node "chips" refuses the property write with "`merge` is `auto` | `human`"
+    # stand-down swallows the duplicate and never the answer. Argued, not
+    # re-asserted (Opus, review 2 of 2): a second send of the same miss is
+    # refused from the UNCHANGED snapshot and draws the very same words
+    # through `createSaying`'s replace — one DOM line either way, so any
+    # assertion of the claim here could only ever rent the line's 6-second
+    # expiry against a loaded box; it could not go red for one send vs two.
+    # The claim's red-able venues hold it instead: the FITS scenario's silence
+    # pin below, and the `sent` log in `editor.test.ts`.
     And there should be no page errors
 
   Scenario: The refusal offers the variant a value is a typo of
@@ -61,9 +61,9 @@ Feature: A property key that declares its type
     And I type "clade" into the property editor on "chips"
     Then the node "chips" refuses the property write with "did you mean `claude`?"
     And the node "chips" shows the property "agent" holding "pi"
-    # The same standing claim as the first scenario: one Enter, one refusal,
-    # still the run's whole answer when the gesture has fully answered.
-    And the node "chips" refuses the property write with "did you mean `claude`?"
+    # The same one gesture, one refusal — argued at the first scenario; the
+    # words above are the pin this venue can hold, and the send count is the
+    # unit file's half.
     And there should be no page errors
 
   Scenario: A value that FITS lands, and lands as the one stored spelling

--- a/packages/tests/features/typed_properties.feature
+++ b/packages/tests/features/typed_properties.feature
@@ -40,6 +40,15 @@ Feature: A property key that declares its type
     And the node "chips" shows the property "merge" holding "auto"
     And "lanes.olai" holds the node "chips" with "merge" set to "auto"
     And the page has not reloaded
+    # ONE GESTURE, ONE REFUSAL — the refusal is the one send's own answer; the
+    # stand-down swallows the duplicate and never the answer. The doubled send
+    # would be e2e-invisible here BY CONSTRUCTION (a second send of the same
+    # miss draws the very same words through `createSaying`'s replace, one DOM
+    # line either way — that is why the send count is `editor.test.ts`'s
+    # half): what this scenario CAN hold is that the refusal is still what the
+    # run says when the gesture has fully answered — no `say(null)`, no
+    # replacement, whatever followed the Enter.
+    And the node "chips" refuses the property write with "`merge` is `auto` | `human`"
     And there should be no page errors
 
   Scenario: The refusal offers the variant a value is a typo of
@@ -52,6 +61,9 @@ Feature: A property key that declares its type
     And I type "clade" into the property editor on "chips"
     Then the node "chips" refuses the property write with "did you mean `claude`?"
     And the node "chips" shows the property "agent" holding "pi"
+    # The same standing claim as the first scenario: one Enter, one refusal,
+    # still the run's whole answer when the gesture has fully answered.
+    And the node "chips" refuses the property write with "did you mean `claude`?"
     And there should be no page errors
 
   Scenario: A value that FITS lands, and lands as the one stored spelling

--- a/packages/tests/features/typed_properties.feature
+++ b/packages/tests/features/typed_properties.feature
@@ -64,6 +64,9 @@ Feature: A property key that declares its type
     And I type "2026-8-30" into the property editor on "chips"
     Then the node "chips" shows the property "dispatched" holding "2026-08-30"
     And "lanes.olai" holds the node "chips" with "dispatched" set to "2026-08-30"
+    # One gesture, one commit — the Enter's own closing blur sent nothing of
+    # its own, or the no-change guard would be drawing it here.
+    And the node "chips" says nothing about its properties
     And there should be no page errors
 
   Scenario: An undeclared key on the same node still takes anything

--- a/packages/tests/step_definitions/properties_steps.ts
+++ b/packages/tests/step_definitions/properties_steps.ts
@@ -354,6 +354,18 @@ Then(
 /** Type it and press Enter. `fill` then `Enter`, rather than the panel's old
  *  button, because the button is what went. */
 When(
+  "I type {string} into the property editor on {string} without pressing Enter",
+  async function (this: OlaiWorld, value: string, id: string) {
+    // Typed and LEFT there: clicking away is the OTHER commit, the one the
+    // Enter fix must not take with it — no key ever lands on the box, so the
+    // blur alone answers for the gesture.
+    const open = box(this, id);
+    await open.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await open.fill(value);
+  },
+);
+
+When(
   "I type {string} into the property editor on {string}",
   async function (this: OlaiWorld, value: string, id: string) {
     const open = box(this, id);

--- a/packages/web/src/client/props/PropsDrawer.tsx
+++ b/packages/web/src/client/props/PropsDrawer.tsx
@@ -460,6 +460,14 @@ function Chip(props: {
           // unmounted, which Solid reports as a stale-value error — a blur IS
           // that moment, since committing is what closes the editor.
           const snapshot = was()
+          /** ONE OPEN'S ANSWER — minted beside the box, recorded at the two
+           *  gestures that CLOSE it (and by the one that then commits, BEFORE
+           *  the close: the close is what fires the blur this answers). Never
+           *  inside the box's own key handling — `Box`'s `closedBy` argues why.
+           *  The `<Show>`'s dispose is the reset: the next open mints `null`.
+           *  (`./editor.ts`'s `ClosedBy` states the born-with-the-open law.)
+           */
+          let answeredBy: ClosedBy = null
           return (
             <Box
               testid={TESTID.propEdit}
@@ -467,12 +475,19 @@ function Chip(props: {
               value={snapshot.value}
               wide
               focus
+              closedBy={() => answeredBy}
               // The snapshot this chip was opened on, which is what the box is
               // drawn from — so what goes back is what a commit has to be
               // judged against. See {@link Chip.onCommit}.
-              onCommit={(value) => props.onCommit(snapshot, value)}
+              onCommit={(value) => {
+                answeredBy = "enter"
+                props.onCommit(snapshot, value)
+              }}
               onLeave={(value) => props.onCommit(snapshot, value)}
-              onCancel={props.onCancel}
+              onCancel={() => {
+                answeredBy = "escape"
+                props.onCancel()
+              }}
             />
           )
         }}
@@ -768,9 +783,10 @@ function NewChip(props: {
  * ONE GESTURE, ONE OUTCOME: Enter commits and Escape abandons, and both close
  * the box — and closing RE-TAKES the caret, which the browser answers by
  * firing the blur at the very gesture whose close this was. That blur stands
- * down ({@link Box.answeredBy}, asked through `./editor.ts`'s
- * `leavingCommits`): the commit owns the close, or there is no commit — never
- * both, and never twice.
+ * down, asked through `./editor.ts`'s `leavingCommits` of the record the
+ * CLOSER minted ({@link Box.closedBy}) — never a record the box mints for
+ * itself, because a box cannot know whether its `onCommit` closes it: the
+ * commit owns the close, or there is no commit — never both, and never twice.
  *
  * WHAT LEAVING MEANS is the CALLER's, and it is the one thing the two editors
  * genuinely differ about: a chip being changed leaves one box, so `onBlur` is
@@ -795,12 +811,18 @@ function Box(props: {
   /** Leaving this box alone commits it — the single-box editor's rule. Absent
    *  where the chip answers for its boxes together. */
   readonly onLeave?: (value: string) => void
+  /** WHICH GESTURE CLOSED THIS OPEN, read at the blur — the CALLER's record,
+   *  minted beside the box by the one who closes it (`Chip`'s editor
+   *  closure). Never recorded by the box itself: a half-blind `onCommit`
+   *  wrapper is the difference between the chip's value box (its Enter
+   *  closes) and the add chip's KEY box, whose Enter only moves the caret —
+   *  and a record THIS component minted would stand that key box down from
+   *  its first Enter forever. ABSENT leaves the blur armed, which is the add
+   *  chip's boxes' correct answer: their leaving is asked at the chip, whose
+   *  own record the focus-out consults. */
+  readonly closedBy?: () => ClosedBy
 }) {
   const [held, setHeld] = createSignal(props.value)
-  /** WHICH KEY, if either, has had this box's outcome — the record the blur
-   *  the close fires is judged by. See the doc above: the gesture that closes
-   *  the box owns the close. */
-  let answeredBy: ClosedBy = null
   return (
     <input
       type="text"
@@ -848,21 +870,17 @@ function Box(props: {
         if (event.key === "Enter") {
           event.preventDefault()
           event.stopPropagation()
-          // BEFORE the commit: committing closes the box, and the close is
-          // what fires the blur this answer stands down.
-          answeredBy = "enter"
           props.onCommit(held())
           return
         }
         if (event.key === "Escape") {
           event.preventDefault()
           event.stopPropagation()
-          answeredBy = "escape"
           props.onCancel()
         }
       }}
       onBlur={() => {
-        if (!leavingCommits(answeredBy)) return
+        if (!leavingCommits(props.closedBy?.() ?? null)) return
         props.onLeave?.(held())
       }}
     />

--- a/packages/web/src/client/props/PropsDrawer.tsx
+++ b/packages/web/src/client/props/PropsDrawer.tsx
@@ -148,7 +148,7 @@ import { createMemo, createSignal, Index, Show } from "solid-js"
 
 import type { Entry } from "./drawer.ts"
 import { type Door, doorFor } from "./door.ts"
-import { type Editing, openedOn, sending, writes } from "./editor.ts"
+import { type ClosedBy, type Editing, leavingCommits, openedOn, sending, writes } from "./editor.ts"
 import { Link } from "../router.tsx"
 import { useNames } from "../reading.tsx"
 import type { Said } from "../saying.ts"
@@ -706,11 +706,14 @@ function NewChip(props: {
   const [key, setKey] = createSignal("")
   const [value, setValue] = createSignal("")
   let box: HTMLInputElement | undefined
-  /** Escape has already answered; the focus-out it causes must not commit as
-   *  well. One gesture, one outcome. */
-  let cancelled = false
+  /** The chip's own answer to the one law every box here answers to
+   *  (`./editor.ts`'s `leavingCommits`): Escape abandons and the value box's
+   *  Enter commits, and BOTH close the chip — the focus-out the close fires
+   *  must not then send the same property a second time. One gesture, one
+   *  outcome. */
+  let answeredBy: ClosedBy = null
   const cancel = (): void => {
-    cancelled = true
+    answeredBy = "escape"
     props.onCancel()
   }
   return (
@@ -720,7 +723,7 @@ function NewChip(props: {
         // Still inside this chip — the caret moving from the key to the value —
         // is not leaving it.
         if (event.currentTarget.contains(event.relatedTarget as Node | null)) return
-        if (cancelled) return
+        if (!leavingCommits(answeredBy)) return
         props.onCommit(key(), value())
       }}
     >
@@ -741,7 +744,12 @@ function NewChip(props: {
         wide
         ref={(element) => (box = element)}
         onInput={setValue}
-        onCommit={(typed) => props.onCommit(key(), typed)}
+        // The value box's Enter is the whole chip answered — its commit closes
+        // the chip, and the close owns what the focus-out then has to hear.
+        onCommit={(typed) => {
+          answeredBy = "enter"
+          props.onCommit(key(), typed)
+        }}
         onCancel={cancel}
       />
     </span>
@@ -756,6 +764,13 @@ function NewChip(props: {
  * BOTH KEYS STOP. The row's own handling reads Escape as "fold this row" and
  * Enter as "make a sibling", and a gesture inside a box must not also be a
  * gesture at the row it is drawn on.
+ *
+ * ONE GESTURE, ONE OUTCOME: Enter commits and Escape abandons, and both close
+ * the box — and closing RE-TAKES the caret, which the browser answers by
+ * firing the blur at the very gesture whose close this was. That blur stands
+ * down ({@link Box.answeredBy}, asked through `./editor.ts`'s
+ * `leavingCommits`): the commit owns the close, or there is no commit — never
+ * both, and never twice.
  *
  * WHAT LEAVING MEANS is the CALLER's, and it is the one thing the two editors
  * genuinely differ about: a chip being changed leaves one box, so `onBlur` is
@@ -782,9 +797,10 @@ function Box(props: {
   readonly onLeave?: (value: string) => void
 }) {
   const [held, setHeld] = createSignal(props.value)
-  /** Escape has already answered, so the blur it causes must not commit as
-   *  well: one gesture, one outcome. */
-  let cancelled = false
+  /** WHICH KEY, if either, has had this box's outcome — the record the blur
+   *  the close fires is judged by. See the doc above: the gesture that closes
+   *  the box owns the close. */
+  let answeredBy: ClosedBy = null
   return (
     <input
       type="text"
@@ -832,18 +848,21 @@ function Box(props: {
         if (event.key === "Enter") {
           event.preventDefault()
           event.stopPropagation()
+          // BEFORE the commit: committing closes the box, and the close is
+          // what fires the blur this answer stands down.
+          answeredBy = "enter"
           props.onCommit(held())
           return
         }
         if (event.key === "Escape") {
           event.preventDefault()
           event.stopPropagation()
-          cancelled = true
+          answeredBy = "escape"
           props.onCancel()
         }
       }}
       onBlur={() => {
-        if (cancelled) return
+        if (!leavingCommits(answeredBy)) return
         props.onLeave?.(held())
       }}
     />

--- a/packages/web/src/client/props/editor.test.ts
+++ b/packages/web/src/client/props/editor.test.ts
@@ -52,18 +52,37 @@ test("a new key is trimmed, because a key is a name and the space around one is 
 // ── one gesture, one outcome ──────────────────────────────────────────
 
 /**
- * The box's OWN WIRING, spelled the way `./PropsDrawer.tsx`'s `Box` wires it —
- * because what is pinned here is the SEQUENCE, so the pin drives the
- * sequence: the handlers, reduced to the gestures they record and the sends
- * they produce. The wiring itself is locked to a real browser by the chip
- * scenarios in @olai/tests' `properties.feature`; this file's half is that
- * the law `leavingCommits` answers is the one the sequences need.
+ * The box's OWN WIRING, spelled the way `./PropsDrawer.tsx`'s `Chip`'s `Box`
+ * wires it: one answer-record, `onLeave` is the blur. The pin drives the
+ * sequence because what is pinned here IS the sequence — the gestures, and
+ * the sends they produce.
+ *
+ * The ADD chip answers the SAME law through a SECOND record on the chip's own
+ * element (`NewChip`'s `answeredBy`): its echo is the run's `onFocusOut`, not
+ * a value box's `onBlur` — the value box there has no `onLeave` — so this
+ * double cannot see its Enter wrapper at all, dishonest or dropped. The
+ * first-add scenario in `properties.feature` is that half's only lock.
  */
-const sequence = () => {
+const editor = () => {
   const sent: Array<"enter's write" | "the blur's write"> = []
+  /** One OPEN's answer-record. */
   let answeredBy: ClosedBy = null
   return {
     sent,
+    /**
+     * OPEN the box — and REOPEN is the same verb. THE REMOUNT IS THE LAW,
+     * named rather than inherited: in production the record is a `let`
+     * inside the editor's component, and the `<Show>` that mounts the box
+     * DISPOSES it on the close, so a close is also the reset. A keep-alive
+     * editor that HIDES the box (or a `keyed` `<Show>` that preserves the
+     * child) would hold the previous open's answer — a settled design
+     * decision the pins are written against: `properties.feature`'s
+     * same-chip-twice scenario drives the real remount, and this file makes
+     * "reopen" a gesture a test must choose to skip.
+     */
+    open: () => {
+      answeredBy = null
+    },
     enter: () => {
       answeredBy = "enter"
       sent.push("enter's write")
@@ -73,7 +92,9 @@ const sequence = () => {
     },
     // The blur, firing when it fires: leaving the box — OR the unmount the
     // commit's close just caused; the machine is not told which, which is the
-    // whole point.
+    // whole point. The `sent` log counts SENDS, which is the one place a
+    // stand-down can be counted at all: what a send DRAWS (the write landing,
+    // the gate's refusal) is the browser suite's half.
     blur: () => {
       if (leavingCommits(answeredBy)) sent.push("the blur's write")
     },
@@ -86,23 +107,41 @@ test("one Enter, one commit — the blur its close fires stands down", () => {
   // same write again — and the ops layer's no-change guard drew that second
   // send as the spurious "already says … — nothing would change" note under
   // the run.
-  const gestures = sequence()
+  const gestures = editor()
+  gestures.open()
   gestures.enter()
   gestures.blur() // the one the unmount fires
   expect(gestures.sent).toEqual(["enter's write"])
+})
+
+test("a second open answers for itself — the record is born with the open", () => {
+  // `leavingCommits("enter")` is false FOREVER: a record held past its close
+  // turns the next open's LEAVING into a swallowed commit — a typed change
+  // that never sends, which is the same bug reborn as a silent miss and
+  // worse than the note it replaced. The keep-alive editor this fails under
+  // is why `open` above is a verb and not an accident of the mint.
+  const gestures = editor()
+  gestures.open()
+  gestures.enter()
+  gestures.blur()
+  gestures.open()
+  gestures.blur()
+  expect(gestures.sent).toEqual(["enter's write", "the blur's write"])
 })
 
 test("still once on the way out: leaving the box IS the commit", () => {
   // The path the fix could break: with no key pressed, the blur is the
   // gesture, and taking it away would be curing the echo by silencing the
   // speaker.
-  const gestures = sequence()
+  const gestures = editor()
+  gestures.open()
   gestures.blur()
   expect(gestures.sent).toEqual(["the blur's write"])
 })
 
 test("Escape abandons — and the blur its close fires writes nothing", () => {
-  const gestures = sequence()
+  const gestures = editor()
+  gestures.open()
   gestures.escape()
   gestures.blur()
   expect(gestures.sent).toEqual([])

--- a/packages/web/src/client/props/editor.test.ts
+++ b/packages/web/src/client/props/editor.test.ts
@@ -81,11 +81,11 @@ const sequence = () => {
 }
 
 test("one Enter, one commit — the blur its close fires stands down", () => {
-  // THE BUG THIS FILE WAS ASKED TO PIN RED (chip-blur-double-commit-2):
-  // today this sequence is TWO sends — the commit, then the blur the commit's
-  // close fired, sending the same write again — and the ops layer's
-  // no-change guard draws that second send as the spurious "already says … —
-  // nothing would change" note under the run.
+  // THE PINNED ONE (chip-blur-double-commit-2): this sequence used to be TWO
+  // sends — the commit, then the blur the commit's close fired, sending the
+  // same write again — and the ops layer's no-change guard drew that second
+  // send as the spurious "already says … — nothing would change" note under
+  // the run.
   const gestures = sequence()
   gestures.enter()
   gestures.blur() // the one the unmount fires

--- a/packages/web/src/client/props/editor.test.ts
+++ b/packages/web/src/client/props/editor.test.ts
@@ -52,10 +52,12 @@ test("a new key is trimmed, because a key is a name and the space around one is 
 // ── one gesture, one outcome ──────────────────────────────────────────
 
 /**
- * The box's OWN WIRING, spelled the way `./PropsDrawer.tsx`'s `Chip`'s `Box`
- * wires it: one answer-record, `onLeave` is the blur. The pin drives the
- * sequence because what is pinned here IS the sequence — the gestures, and
- * the sends they produce.
+ * The box's OWN WIRING, spelled the way `./PropsDrawer.tsx`'s `Chip`'s editor
+ * wires it: one answer-record minted beside the `Box` by the caller that
+ * CLOSES it (never inside the box's key handling — a box cannot know whether
+ * its `onCommit` closes it; the add chip's key box's Enter only moves the
+ * caret), and `onLeave` is the blur. The pin drives the sequence because what
+ * is pinned here IS the sequence — the gestures, and the sends they produce.
  *
  * The ADD chip answers the SAME law through a SECOND record on the chip's own
  * element (`NewChip`'s `answeredBy`): its echo is the run's `onFocusOut`, not
@@ -79,10 +81,17 @@ const editor = () => {
      * decision the pins are written against: `properties.feature`'s
      * same-chip-twice scenario drives the real remount, and this file makes
      * "reopen" a gesture a test must choose to skip.
+     *
+     * And the ORDER of the two locks is worth keeping straight (Opus, review
+     * 2 of 2): BROWSER first, this double second — the scenario failing at
+     * its `editor is closed` step under a keep-alive editor is the claim;
+     * this sequence is the reading of it.
      */
     open: () => {
       answeredBy = null
     },
+    // Enter as the caller answers it: the wrapper records the close it is
+    // about to own, and then the commit sends.
     enter: () => {
       answeredBy = "enter"
       sent.push("enter's write")

--- a/packages/web/src/client/props/editor.test.ts
+++ b/packages/web/src/client/props/editor.test.ts
@@ -8,7 +8,7 @@
 
 import { expect, test } from "bun:test"
 
-import { openedOn, sending, writes } from "./editor.ts"
+import { type ClosedBy, leavingCommits, openedOn, sending, writes } from "./editor.ts"
 
 const PR = { key: "pr", value: "https://x/1" }
 
@@ -47,6 +47,65 @@ test("a new key is trimmed, because a key is a name and the space around one is 
   // The VALUE is not trimmed: it is somebody's text, and a sentence that ends
   // in a space is still that sentence.
   expect(sending(null, "merge", "the human approves ").value).toBe("the human approves ")
+})
+
+// ── one gesture, one outcome ──────────────────────────────────────────
+
+/**
+ * The box's OWN WIRING, spelled the way `./PropsDrawer.tsx`'s `Box` wires it —
+ * because what is pinned here is the SEQUENCE, so the pin drives the
+ * sequence: the handlers, reduced to the gestures they record and the sends
+ * they produce. The wiring itself is locked to a real browser by the chip
+ * scenarios in @olai/tests' `properties.feature`; this file's half is that
+ * the law `leavingCommits` answers is the one the sequences need.
+ */
+const sequence = () => {
+  const sent: Array<"enter's write" | "the blur's write"> = []
+  let answeredBy: ClosedBy = null
+  return {
+    sent,
+    enter: () => {
+      answeredBy = "enter"
+      sent.push("enter's write")
+    },
+    escape: () => {
+      answeredBy = "escape"
+    },
+    // The blur, firing when it fires: leaving the box — OR the unmount the
+    // commit's close just caused; the machine is not told which, which is the
+    // whole point.
+    blur: () => {
+      if (leavingCommits(answeredBy)) sent.push("the blur's write")
+    },
+  }
+}
+
+test("one Enter, one commit — the blur its close fires stands down", () => {
+  // THE BUG THIS FILE WAS ASKED TO PIN RED (chip-blur-double-commit-2):
+  // today this sequence is TWO sends — the commit, then the blur the commit's
+  // close fired, sending the same write again — and the ops layer's
+  // no-change guard draws that second send as the spurious "already says … —
+  // nothing would change" note under the run.
+  const gestures = sequence()
+  gestures.enter()
+  gestures.blur() // the one the unmount fires
+  expect(gestures.sent).toEqual(["enter's write"])
+})
+
+test("still once on the way out: leaving the box IS the commit", () => {
+  // The path the fix could break: with no key pressed, the blur is the
+  // gesture, and taking it away would be curing the echo by silencing the
+  // speaker.
+  const gestures = sequence()
+  gestures.blur()
+  expect(gestures.sent).toEqual(["the blur's write"])
+})
+
+test("Escape abandons — and the blur its close fires writes nothing", () => {
+  const gestures = sequence()
+  gestures.escape()
+  gestures.blur()
+  expect(gestures.sent).toEqual([])
 })
 
 // ── which chip the editor is open on ───────────────────────────────────

--- a/packages/web/src/client/props/editor.ts
+++ b/packages/web/src/client/props/editor.ts
@@ -147,6 +147,44 @@ export type ClosedBy = "enter" | "escape" | null
  * "already says … — nothing would change" note (`chip-blur-double-commit-2`,
  * and the add chip's focus-out answered the same law without it being the one
  * filed) — was the absence of this record, not a rule somebody preferred.
+ *
+ * And the record is not one way of answering the question; it is the ONLY
+ * place an answer can exist. An unmount-blur is BYTE-IDENTICAL to a person's
+ * click-away at handler time: same `relatedTarget` (`null`), same
+ * `activeElement` (`BODY`), and the target still connected — the browser
+ * unfocuses BEFORE it detaches (Opus's probe on the PR, chromium: the answer
+ * measured, not assumed). No cheaper design hides in the DOM — "just ask the
+ * element" is retired — so the gesture must record itself, BEFORE the close,
+ * next to the close that owns it.
+ *
+ * What `null` must then also carry are the closes that have NO gesture, and
+ * they are named here rather than inherited:
+ *
+ *   - the WINDOW losing focus mid-edit: the blur commits the box as-is, half-
+ *     typed and all, because it cannot be told from the person leaving — and
+ *     a leaving that ATE a half-typed fact would be the worse surprise. On
+ *     the ADD chip the same blur takes the typed key instead: a key with no
+ *     value is nothing to write, so nothing is said either — the chip is
+ *     gone with the tab's leaving, and so is what was typed into it.
+ *   - the ROUTE leaving, or anything that takes the whole drawer with it:
+ *     the same commit fires, and its answer has nowhere to be drawn —
+ *     `saying` is disposed with the run, so the answer lands on a line that
+ *     is gone (the queued `was` lane's second half: its stale-`was` refusal
+ *     is the EXPECTED answer on this path, and it will have no reader).
+ *   - the NODE changing under an open editor: an agent's `set_prop` dropping
+ *     the key disposes the chip, and the blur commits what was typed against
+ *     the OPEN-TIME snapshot — typed nothing, silent; typed something, the
+ *     removed key is born again holding it. Pinned as-is in @olai/tests'
+ *     `properties.feature` ("a chip whose key disappears under an open,
+ *     typed editor") because that is the law's CURRENT default, not a ruling:
+ *     the gate that can refuse the resurrect is a `was` riding the op — only
+ *     the op can say the record moved — and that is the queued lane's
+ *     business and deliberately not this record's.
+ *
+ * Affirming `null` for the three is not saying they are right; it is saying
+ * the BLUR cannot be the one to judge them — byte-identical to a leaving,
+ * each time. The one close this record answers for is the one the gesture
+ * itself closed.
  */
 export const leavingCommits = (closedBy: ClosedBy): boolean => closedBy === null
 

--- a/packages/web/src/client/props/editor.ts
+++ b/packages/web/src/client/props/editor.ts
@@ -3,10 +3,11 @@
  * committing it would write anything at all.
  *
  * The pure half of `./PropsDrawer.tsx`'s editor, beside `./drawer.ts` (which
- * chips there are) and `./door.ts` (where one goes when pressed). Three small
+ * chips there are) and `./door.ts` (where one goes when pressed). Four small
  * decisions live here rather than inside a component because each of them is
  * the kind that goes quietly wrong: what counts as a change, what an empty box
- * MEANS, and which gesture is a write and which is a way out.
+ * MEANS, which gesture is a write and which is a way out — and whether the
+ * box is still LISTENING for one at all.
  *
  * ## An empty value REMOVES the property
  *
@@ -77,6 +78,24 @@ export const sending = (
  *     `+`, then Escape-by-way-of-Enter, is a way out rather than a refusal.
  *   - an EXISTING property set to what it already holds is refused too, which
  *     is what makes "open a chip and click away" have to be silent.
+ *
+ * ## One gesture, one outcome: the close belongs to the gesture that closed it
+ *
+ * Enter commits and Escape abandons — and BOTH close the box, which is where
+ * the ordering trap lives: the browser's answer to the focused box going away
+ * is a blur, fired AT the gesture whose close this already was. Heard
+ * naively, one Enter is then TWO sends of the same write, and the second is
+ * what the ops layer's own no-change guard turns away: a spurious "already
+ * says … — nothing would change" note drawn under the run for a gesture that
+ * did exactly what it was asked (bugs.olai's `chip-blur-double-commit-2`). An
+ * Escape heard twice is worse than spurious: a write the person had declined.
+ *
+ * So the law is one sentence long: the gesture that closes OWNS the close —
+ * once a key has answered, whichever key it was, the blur its wake fires
+ * stands down ({@link leavingCommits}). The leaving itself is no casualty of
+ * the law: a blur that arrives FIRST is the gesture, and "leaving the box
+ * commits what changed" keeps standing for exactly as long as nothing has
+ * answered.
  */
 export const writes = (was: Editing | null, key: string, value: string): boolean => {
   const sent = sending(was, key, value)
@@ -97,6 +116,39 @@ export const writes = (was: Editing | null, key: string, value: string): boolean
   // side declines rather than guesses.
   return value !== was.value
 }
+
+/**
+ * WHAT HAS ANSWERED THIS BOX, once anything has: Enter's commit, or Escape's
+ * abandon. `null` while nothing has — which is the only state in which a
+ * leaving is the gesture rather than the echo of one.
+ *
+ * One type for both editors: the chip's single box and the add chip's pair
+ * answer for themselves in `./PropsDrawer.tsx`, and the law they answer to is
+ * this one.
+ */
+export type ClosedBy = "enter" | "escape" | null
+
+/**
+ * Does LEAVING the box still commit — is the blur the gesture, or its echo?
+ *
+ * The ORDER the events arrive in is the browser's, and it is hostile: a key
+ * closes the box, and removing the focused box FIRES the blur at the gesture
+ * whose close that already was. So the box listens for the gesture only while
+ * none has answered, and records the first one that does.
+ *
+ * THE `enter` ROW IS THE PINNED BUG, shipped law modelled faithfully for one
+ * commit so the pin beside it (`./editor.test.ts`, and the chip scenarios in
+ * @olai/tests' `properties.feature`) can hold it RED: Enter answers the box,
+ * and yet this table leaves the blur ARMED — the commit does not own the
+ * close — so one Enter is heard as two sends of the same write and the ops
+ * layer's no-change guard converts the second into the spurious "already says
+ * … — nothing would change" note of `chip-blur-double-commit-2`. The law the
+ * header argues is `closedBy === null`; the row flips one commit later, with
+ * the red pin already standing watch. (`closedBy !== "escape"` is not — and
+ * never was — an alternative law somebody prefers: it is the bug, spelled as
+ * one predicate so the flip is the whole of the fix.)
+ */
+export const leavingCommits = (closedBy: ClosedBy): boolean => closedBy !== "escape"
 
 /**
  * IS THE EDITOR OPEN ON THIS CHIP — asked by the chip's own identity, never by

--- a/packages/web/src/client/props/editor.ts
+++ b/packages/web/src/client/props/editor.ts
@@ -124,7 +124,14 @@ export const writes = (was: Editing | null, key: string, value: string): boolean
  *
  * One type for both editors: the chip's single box and the add chip's pair
  * answer for themselves in `./PropsDrawer.tsx`, and the law they answer to is
- * this one.
+ * this one. THE RECORD IS BORN WITH THE OPEN: each editor holds it as a `let`
+ * inside its component, and the `<Show>` that mounts the box DISPOSES the
+ * component on the close, so closing is also the reset — `leavingCommits`'s
+ * `null` then genuinely means "nothing has answered THIS open". An editor
+ * that kept its component alive and only hid the box would owe the record a
+ * reset of its own, and that is a design to refuse rather than to support:
+ * the pin suite (`./editor.test.ts`'s reopen sequence, and the same chip
+ * edited twice in @olai/tests' `properties.feature`) is written against it.
  */
 export type ClosedBy = "enter" | "escape" | null
 

--- a/packages/web/src/client/props/editor.ts
+++ b/packages/web/src/client/props/editor.ts
@@ -134,21 +134,14 @@ export type ClosedBy = "enter" | "escape" | null
  * The ORDER the events arrive in is the browser's, and it is hostile: a key
  * closes the box, and removing the focused box FIRES the blur at the gesture
  * whose close that already was. So the box listens for the gesture only while
- * none has answered, and records the first one that does.
- *
- * THE `enter` ROW IS THE PINNED BUG, shipped law modelled faithfully for one
- * commit so the pin beside it (`./editor.test.ts`, and the chip scenarios in
- * @olai/tests' `properties.feature`) can hold it RED: Enter answers the box,
- * and yet this table leaves the blur ARMED — the commit does not own the
- * close — so one Enter is heard as two sends of the same write and the ops
- * layer's no-change guard converts the second into the spurious "already says
- * … — nothing would change" note of `chip-blur-double-commit-2`. The law the
- * header argues is `closedBy === null`; the row flips one commit later, with
- * the red pin already standing watch. (`closedBy !== "escape"` is not — and
- * never was — an alternative law somebody prefers: it is the bug, spelled as
- * one predicate so the flip is the whole of the fix.)
+ * none has answered, and the first key to answer owns the close: the blur its
+ * wake fires stands down. What used to make the `enter` row the exception —
+ * one Enter heard twice, the second send drawn as the no-change guard's
+ * "already says … — nothing would change" note (`chip-blur-double-commit-2`,
+ * and the add chip's focus-out answered the same law without it being the one
+ * filed) — was the absence of this record, not a rule somebody preferred.
  */
-export const leavingCommits = (closedBy: ClosedBy): boolean => closedBy !== "escape"
+export const leavingCommits = (closedBy: ClosedBy): boolean => closedBy === null
 
 /**
  * IS THE EDITOR OPEN ON THIS CHIP — asked by the chip's own identity, never by


### PR DESCRIPTION
The bug (`chip-blur-double-commit-2` on bugs.olai, filed by #395's author): Enter in a chip's value box commits; the commit closes the editor; removing the focused box fires a blur **at the gesture whose close that already was**; the blur handler heard it as a second commit of the same write, and the ops layer's no-change guard converted it into the spurious "_… already says … — nothing would change_" note drawn under the run. Every chip edit drew it.

**The shape.** The box's gesture order has no DOM-free home in `PropsDrawer.tsx`, so it is extracted into `props/editor.ts` — the module whose whole subject is which gesture is a write — as one record (`ClosedBy`) and one answer over it: `leavingCommits(closedBy) ⇒ closedBy === null`. The gesture that closes **owns the close**: the record is minted beside the box by the caller that closes it and read by `Box.closedBy` at the blur; a blur that arrives first is still the gesture itself, so "leaving commits what changed" is untouched. Both editors answer the law — the chip's single box (`Box.onBlur`) and the add chip's pair (`NewChip.onFocusOut`, a second record on the chip element, because the value box there has no `onLeave`).

The red run showed the filed node had understated the blast radius by half: the **add** chip is closed by the same Enter and its focus-out is heard on the same terms, so `I write the property … on <node>` was drawing the same note. Both closings answer through the one law, so the flip closes both halves.

**The gate** (red-first, first two commits — `3150ac4c` is the pins against the shipped law, `3bad953f` is the flip):

- `editor.test.ts` — "one Enter, one commit": **red** on the pin commit (two sends observed from one Enter: `["enter's write", "the blur's write"]`), green on the flip. Blur-only and Escape pinned green beside it from the first run.
- `properties.feature` — "A chip is edited in place…" gained `says nothing about its properties`: **red** in a real browser on the pin commit (the note drawn, `1 !== 0`), green on the flip. New scenario "Clicking away is the other commit — once, and as silently" pins the path the fix could break (green throughout); "The first one is added from the menu…" now pins the add chip's Enter (red → green — the unfiled half); the Escape scenario pins its own silence (red on the pin commit by the *standing* note from its earlier add — same bug, collateral; green whole on the flip).
- `typed_properties.feature` — the FITS scenario carries the silence half; the refusal half carries the one-gesture claim as argued comment (see Opus's SHOULD 2 below).

---

## Fold notes — grok, review 1 of 2 (FOLD; both SHOULDs + the NIT folded at `235740a0`)

**Axis 1 (SHOULD)** — the remount is now law, said rather than inherited. `editor.test.ts`'s harness gains `open()` as the one verb that mints the record — the keep-alive shape (`hide` for `Show`, a `keyed` `Show`) is now a verb a test must choose to skip — and a fourth sequence ("a second open answers for itself"): open, Enter, blur, reopen, blur ⇒ both sends. `ClosedBy`'s doc states the same law on the production side. grok's "no e2e edits the same chip twice" is answered with one: "The same chip edited twice — every open answers for itself", whose second open is typed and *clicked away* — the silent-miss shape a keep-alive editor would ship.

**Axis 5 (SHOULD)** — the pin was on the wrong half of the typed gate, moved: both refusal scenarios were given the one-gesture claim; Opus's SHOULD 2 below then narrowed that to the argued comment. The send count remains `editor.test.ts`'s `sent` log, the silence pin remains on FITS.

**NIT** — folded by comment: the harness names the add chip's *second* record and says the first-add scenario is its only lock.

---

## Fold notes — Opus, review 2 of 2 (FOLD; both SHOULDs + both NITs folded at `14b71e1d`)

**The probe, written in beside the law.** His chromium probe measured the event the whole PR turns on: the unmount-blur is byte-identical to a person's click-away at handler time (`relatedTarget: null`, `activeElement: BODY`, the target *still connected* — the browser unfocuses before it detaches). No DOM discriminator exists, so `ClosedBy` is not one possible design but the only one from inside `Box.onBlur` — "just ask the element" is retired. That argument now lives in `leavingCommits`'s doc.

**SHOULD 1** — the `null` row's three no-gesture closes are now argued, not inherited, in the same doc: the window losing focus (commits the box as-is; on the add chip the typed-key-only half dies silent), the route/drawer leaving (the commit fires; the answer draws nowhere — `saying` disposed), and the node changing under an open editor (typed + key-removed ⇒ the key is born again holding it). The third is DRIVEN, in the venue he named: `properties.feature` gains "A chip whose key disappears under an open, typed editor is written back — the inherited default", pinning today's behavior with the comment naming the flip the was-lane lands (verified: the rewrite's own frame closes the editor and the typed `submitted` does ride back).

**SHOULD 2** — the duplicated refusal assertions are cut from both typed-refusal scenarios: they could never go red for one send vs two (`createSaying`'s replace draws the same words; the only reachable failure would be renting `SAID_MS`' six seconds against a loaded box). The comments stay as the fold-by-argue.

**NIT 1** — the caller that knows records. `Box` no longer mints an answer in its own keydown: it takes `closedBy?: () => ClosedBy`, and `Chip`'s editor closure mints the record and answers at the two gestures that close — the same shape `NewChip`'s span already used. The key box's focus-moving Enter no longer leaves a dishonest `"enter"` to stand a future `onLeave` down.

**NIT 2** — carried into the was-lane's handoff notes below, beside grok's flag, as asked.

---

## Handoff notes — for the queued `was`-carrying lane

The send-side half lands here; the op-side half is theirs. Both reviewers' flags, verbatim:

**grok (axis 2):**

> `SetProp` is still `(key, value)` (`PropsDrawer.tsx:185`). The snapshot is consumed only by local `writes()` and does not ride the wire. `close()` before `await onSet` is the same shape the typed refusal already has (editor gone, then a `Said`). Adding `was` to the op does not fight the stand-down. What *would* fight it is this unmount-blur send: it has no `was` and would fire because nothing recorded an answer. Not a MUST here; it is the default the next lane must not inherit quietly.

**Opus (NIT 2), the answer's other end:**

> `saying.say(await props.onSet?.(…))` runs after `close()`. Fine while the drawer outlives the close — the typed refusal's shape grok names. It is not fine for the closes in SHOULD 1 that take the **drawer** with them: the answer lands on a disposed `createSaying` and nobody reads it. Today the only such answer is the unmount-blur's, and today it usually succeeds. Under a `was`-carrying `set_prop` it becomes the *expected* answer on that path — the stale-`was` refusal is what turns SHOULD 1's silent resurrect into a correct refusal — and it will be drawn into a line that is gone. The lane fixes the write and inherits the silence; worth carrying both halves into it, beside grok's quoted flag.

The resurrect lane's current behavior is pinned at "A chip whose key disappears under an open, typed editor is written back" in `properties.feature` — that scenario's tail is where the lane's flip will show up red.

---

**Suite counts at `14b71e1d`:** typecheck 16/16 packages; unit 3984 + browsertest 77 = 4061 pass / 0 fail; the two touched features 24/24 + 8/8 scenarios (properties 24 / 285 steps, typed_properties 8 / 57 steps). CI by the orchestrator after both folds; **the merge gate is the human's.**
