### PR TITLE
the moved-key scenario asserts the face #403 draws (master red → green)

### DIFF
--- a/packages/tests/features/typed_properties.feature
+++ b/packages/tests/features/typed_properties.feature
@@ -105,8 +105,10 @@ Feature: A property key that declares its type
     # spent the typed gate at all.
     And the node "chips" refuses the property write with "it now says `human`"
     # ...and nothing was written, either way: the row and the file say what
-    # the agent said.
-    And the node "chips" shows the property "merge" holding "human"
+    # the agent said — the row as the variant's TITLE over the stored id (the
+    # ref chip's own rule, argued at this seam's first scenario), the file as
+    # the id itself, which stays the truth underneath the face.
+    And the node "chips" shows the property "merge" holding "the human merges"
     And "lanes.olai" holds the node "chips" with "merge" set to "human"
     And there should be no page errors
 


### PR DESCRIPTION
## The red

`typed_properties.feature:78` — *"A moved key refuses before the typed gate's work is spent"* (#404's scenario) — failed **3/3 on origin/master**. One stale assertion, nothing else:

- The fixture declares `merge` as a `ref` whose child variant id `human` is TITLED *"the human merges"*.
- #403's meaning socket made the ref chip draw the titled **face** over the stored id.
- The scenario's last-but-one line still asserted the pre-#403 face — the raw value text `human` — and timed out waiting for a row that (correctly) now draws the title.

Reproduced on this branch before the fix (same binary the suite uses, `nix build .#olai`):

```
✔ And the node "chips" refuses the property write with "it now says `human`"
✖ And the node "chips" shows the property "merge" holding "human"
    Error: timed out after 15000ms waiting until `merge` on "chips" to hold "human"
```

## The fix — the assertion, argued over the fixture

One line: the row assertion now expects the face #403's rule draws — `the human merges` — and the comment says the two halves apart (row = the variant's TITLE, file = the stored id underneath). Alternatives considered:

- **Change the fixture's title** (shorten "the human merges" so the long variant title stops making the scenario awkward). Rejected: if the variant's title equalled its id, face and id become the same string and this line could *never go red on a face regression again* — it would pass under the pre-#403 draw too. The long titled variant is exactly what keeps this assertion able to bite, and the fixture's title is already the one the whole seam's vocabulary uses.
- The sibling scenario at the seam's head already pins the rule the same way (`merge: auto` → row shows **automatic**, file holds `auto`, with the comment *"The row says it as the variant's TITLE and the file says it as the stored id"*). This change brings the moved-key scenario onto that same rule rather than inventing a second spelling.
- The refusal words (`it now says \`human\``) **stay as-is**: that sentence is the ops gate's OWN words (`propStale` in `@olai/ops`), which names the stored *value* so the caller can re-read — it is not a face, never went through the meaning socket, and it passed on master as-is.

## Green ×3

After the one-line change, same command, three consecutive runs — 12/12 steps each (including the trailing pin that `lanes.olai` holds `merge` set to `human`, the stored id, which now runs):

```
=== RUN 1 ===  1 scenario (1 passed)  12 steps (12 passed)
=== RUN 2 ===  1 scenario (1 passed)  12 steps (12 passed)
=== RUN 3 ===  1 scenario (1 passed)  12 steps (12 passed)
```

Full-suite CI is left to the orchestrator's single run.