### PR TITLE
mcp: #406's same-stamp fixture manufactures its rewrite through one handle — master's three HIGH js/file-system-race alerts closed

### DIFF
--- a/packages/server/src/mcp/tools.test.ts
+++ b/packages/server/src/mcp/tools.test.ts
@@ -2646,16 +2646,32 @@ test("PIN (the rebase shape): a read whose set the disk has moved past says so",
 test("PIN (what `stale: false` is worth): a same-stamp rewrite reads confirmed", async () => {
   await withTools({ "house.olai": HOUSE }, async ({ client, root }) => {
     const file = path.join(root, "house.olai")
-    const stamp = fs.statSync(file)
-    // The same line, the same length — `cabinets` for `CABINETS` — and the
-    // clock put back afterwards. Nothing a stat can see about this file moved.
-    const rewritten = (fs.readFileSync(file, "utf8")).replace(
-      "order the cabinets",
-      "order the CABINETS",
-    )
-    expect(rewritten).not.toBe(fs.readFileSync(file, "utf8"))
-    fs.writeFileSync(file, rewritten)
-    fs.utimesSync(file, stamp.atime, stamp.mtime)
+    // One handle for the whole manipulation, stat through re-stamp: a path
+    // named four times, checked and then used, is a check-then-use race
+    // (CodeQL js/file-system-race, and it is right about the general case),
+    // while an open followed by handle operations can only ever be talking
+    // about one file. The fixture's claim is unchanged — the stamp is taken
+    // of the SAME inode that is then read, rewritten and re-stamped.
+    const fd = fs.openSync(file, "r+")
+    try {
+      const stamp = fs.fstatSync(fd)
+      // The same line, the same length — `cabinets` for `CABINETS` — and the
+      // clock put back afterwards. Nothing a stat can see about this file moved.
+      const original = fs.readFileSync(fd, "utf8")
+      const rewritten = original.replace(
+        "order the cabinets",
+        "order the CABINETS",
+      )
+      expect(rewritten).not.toBe(original)
+      // The write starts from offset 0 and does not truncate, so the
+      // same-length half of the fixture's point is now load-bearing for the
+      // overwrite, not just for the stat — say so with an assertion.
+      expect(rewritten.length).toBe(original.length)
+      fs.writeSync(fd, rewritten, 0, "utf8")
+      fs.futimesSync(fd, stamp.atime, stamp.mtime)
+    } finally {
+      fs.closeSync(fd)
+    }
 
     const answered = await call(client, "read_node", { id: "order" })
     expect(answered.isError).toBe(false)


### PR DESCRIPTION
## What

Master carries three open HIGH CodeQL alerts (`js/file-system-race`) that #406's vintage staleness fixtures merged past the gate (CodeQL was not yet a required check — it is now):

- `packages/server/src/mcp/tools.test.ts:2652` — `readFileSync(file)` after `statSync(file)`
- `packages/server/src/mcp/tools.test.ts:2656` — second `readFileSync(file)`
- `packages/server/src/mcp/tools.test.ts:2657` — `writeFileSync(file)` after both

A path-named check followed by path-named uses is a check-then-use race, and the rule is right about the general case.

## How

Closed at the sites, kolu#2216's single-file-handle shape: open the file once (`openSync(file, "r+")`), then `fstatSync` / `readFileSync(fd)` / `writeSync(fd, …, 0)` / `futimesSync(fd)` all through the descriptor, `closeSync` in `finally`. The block's only remaining path-named operation is the `openSync` itself, so no check-then-use pair remains for the rule to bind.

## Why behavior is identical (no suppression needed)

The fixture's point survives whole — a stat-level look cannot see a same-length put-back, asserted below the edit as `stale: false, proof: "confirmed"` over the old title:

- `fstatSync` of the opened inode returns the same stamp `statSync(path)` did;
- `readFileSync` on a fresh descriptor at offset 0 reads the same bytes as the path read;
- the replace-fired guard now compares against the captured `original`, equal to the old second path read across the synchronous stretch — same guarantee, one read;
- the overwrite now relies on same-length (offset-0 write does not truncate), so that half of the fixture's point gets its own assertion (`rewritten.length === original.length`) — truncate-write and same-length overwrite-at-0 leave identical final bytes;
- `futimesSync` restores the same atime/mtime on the same inode.

No test weakened, so no CodeQL suppression was argued for — the honest-race fix was available and taken.

## Verified

- `bun test packages/server/src/mcp/tools.test.ts` → **69/69 pass, ×3 runs** (443 expect calls each)
- `bun test packages/store` → **64/64 pass** (2 files)
- `bun test packages/server/src/mcp` → **94/94 pass** (3 files)
- `tsc --noEmit` (packages/server) → clean
- Alert pattern statically gone: the fixture's remaining path-named fs op is the single `openSync`; every other op is descriptor-scoped

Auto-merge (squash) armed: test-only change closing master-carried HIGHs.