### PR TITLE
chat: the + takes a photo too — a camera door beside the roll, on phones only

### DIFF
--- a/docs/chat.md
+++ b/docs/chat.md
@@ -394,10 +394,12 @@ The notification is the one part that needs the browser's permission. olai asks 
 
 ## Attachments
 
-You can paste a file into the box — a screenshot, a photo of a whiteboard — or drag one onto the panel, or pick one with the **+** button, which is the way in on a phone. All three take the same kinds:
+You can paste a file into the box — a screenshot, a photo of a whiteboard — or drag one onto the panel, or pick one with the **+** button — one of the two doors a phone has; the other is the camera, next paragraph. All of those take the same kinds:
 
 - **pictures**: `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.avif`, `.bmp`, `.ico`
 - **documents**: `.pdf`, `.txt`, `.md`, `.csv`, `.json`
+
+**On a phone the `+` has a camera beside it.** One tap opens the camera itself rather than a picker: shoot, the photo lands in the strip above the box like any other attachment, and you can shoot again — tap the camera, one more photo joins the strip — until one send carries them all into the same message. It is drawn only where there is a finger to press it: a desktop has no button at all, because a "camera" that opened a file dialog would be a control that lies, and the roll is exactly as reachable there either way. A picture the list above does not take — say a camera that answers with a `.heic` — is named in the refusal, the same as a drop that misses the gate.
 
 The bytes go into a temporary directory belonging to that conversation, never under the directory being served, and the agent is handed the PATH: it reads the file itself, so nothing rides the prompt into the stored session, and nothing attached here can end up committed with your outlines. The files go away when you start a new conversation or stop the server.
 

--- a/packages/tests/features/the_agent.feature
+++ b/packages/tests/features/the_agent.feature
@@ -1780,6 +1780,59 @@ Feature: Talking to the agent
     Then the agent's answer mentions "read 69 bytes from Type_04-C.pdf"
 
   @scratch:chat
+  Scenario: The camera is offered only where a finger is the pointer
+    # The `+`'s second door is a phone's, and a desktop — which is what this
+    # browser is — gets NO button for it: on a fine pointer the `capture`
+    # attribute is ignored, so the same markup would answer with an ordinary
+    # file dialog, and a camera button that opens a file dialog is a button
+    # that lies (web/src/client/chat/camera.ts). What must survive there is
+    # the roll's reach: one tap, the same picker as ever.
+    Then the composer is not offering a camera
+    When I pick "shot.png" with the attach button
+    Then the composer is holding the picture "shot.png"
+
+  @scratch:chat @phone
+  Scenario: Photos shot straight into the chat all ride one message
+    # The human's ask, verbatim: outside with only the phone, wanting to take
+    # photos into the chat. One invocation of a camera is ONE photo, so the
+    # strip is what makes it several — shoot → chip → shoot again — and the
+    # taps are the same two taps every time, with the `+` beside it exactly
+    # as reachable as it always was.
+    #
+    # The same photo TWICE is two attachments — what the chips pin here is
+    # the SERVER's answer to a name it has already stored (`porch-1.jpg`)
+    # and the strip keeping the order the shots were taken in. What they do
+    # NOT pin is the cleared input underneath: this harness injects files
+    # and fires `change` unconditionally, so an uncleared shutter would pass
+    # unnoticed — which is why the step itself reads the shutter's value
+    # back after every shot instead of leaving that to the chip count.
+    When I take a photo called "porch.jpg" with the camera
+    Then the composer is holding the picture "porch.jpg"
+    When I take a photo called "porch.jpg" with the camera
+    Then the composer is holding "porch.jpg, porch-1.jpg" in that order
+    When I take a photo called "door.jpg" with the camera
+    Then the composer is holding "porch.jpg, porch-1.jpg, door.jpg" in that order
+    When I ask the agent "what are these"
+    Then the agent read "porch.jpg, porch-1.jpg, door.jpg" in that order
+
+  @scratch:chat @phone
+  Scenario: A dismissed capture touches nothing — not even somebody else's refusal
+    # The guard in the composer's `picked` exists for exactly this: the
+    # camera answered with NOTHING — backed out of, permission refused; from
+    # this side the empty FileList is one shape — and the box must be
+    # exactly as it was. "Exactly" is the load-bearing word: the unguarded
+    # path reached `holding.take([])`, whose housekeeping CLEARS the refusal
+    # line — so a dismissal used to erase the record of a drop the app had
+    # just said no to. The refusal is earned first precisely so the last
+    # line has something to lose.
+    When I drop "whatever.zip" on the chat panel
+    Then the chat eventually shows "cannot be attached"
+    And the chat eventually shows "whatever.zip"
+    When I dismiss the camera
+    Then the composer is holding nothing
+    And the chat still shows "cannot be attached"
+
+  @scratch:chat
   Scenario: A dropped file olai cannot take says so, by name
     # HACKING's rule, at the gesture where it is easiest to break: a file that
     # is dragged somewhere and then disappears has been swallowed, and the

--- a/packages/tests/step_definitions/chat_steps.ts
+++ b/packages/tests/step_definitions/chat_steps.ts
@@ -47,6 +47,7 @@ import {
   CHAT_AGENT,
   CHAT_AGENT_MARK,
   CHAT_BUSY,
+  CHAT_CAMERA_BUTTON,
   CHAT_CANCEL,
   CHAT_CHOOSE,
   CHAT_CHOOSE_AGENT,
@@ -410,6 +411,19 @@ Then(
     );
   },
 );
+
+/** A read, not a wait: the question is what a no-op gesture left STANDING.
+ *  If it touched what it should never reach, the line is gone for good —
+ *  nothing restores it — so there is no arrival to wait for, and waiting
+ *  would only blur the answer. */
+Then("the chat still shows {string}", async function (this: OlaiWorld, text: string) {
+  const said = await transcriptText(this);
+  assert.ok(
+    said.includes(text),
+    `the chat no longer says "${text}" — the gesture that answered with ` +
+      "nothing reached something it should never touch",
+  );
+});
 
 /** A read, not a wait: the step before it has already waited for something
  *  that arrives BEFORE the late growth this is about, so if the late line
@@ -2934,7 +2948,10 @@ When(
     // `image/*` would take this PDF here and grey it out for the person. The
     // one half-truth met with no refusal to explain it.
     const accept = await this.page
-      .locator(`${CHAT_PANEL} input[type=file]`)
+      // `[multiple]`: the ROLL input, not the camera's — on a phone there are
+      // two file inputs in the panel and the unscoped selector below is a
+      // strict-mode violation rather than a reading.
+      .locator(`${CHAT_PANEL} input[type=file][multiple]`)
       .getAttribute("accept");
     const extension = name.slice(name.lastIndexOf("."));
     assert.ok(
@@ -2953,6 +2970,74 @@ When(
     });
   },
 );
+
+When(
+  "I take a photo called {string} with the camera",
+  async function (this: OlaiWorld, name: string) {
+    const spec = fileSpec(name);
+    // The DOM fact the whole door hangs on, asserted before the photo is
+    // handed over: what makes a phone's browser open the CAMERA rather than
+    // a picker for this input is `capture="environment"`. No browser this
+    // suite can drive opens a real camera, so the attribute is what the
+    // claim is asserted on — the same arrangement as the pick step beside
+    // it, which asserts `accept` because the dialog itself cannot be
+    // photographed either.
+    const hole = this.page.locator(`${CHAT_PANEL} input[type=file][capture]`);
+    assert.strictEqual(
+      await hole.getAttribute("capture"),
+      "environment",
+      "the camera input must spell capture=\"environment\" — without it a " +
+        "phone opens the file picker, and the button is a second roll door",
+    );
+    const accept = await hole.getAttribute("accept");
+    assert.ok(
+      accept !== null && accept.includes("image/"),
+      `the camera offers "${accept}" — and one shot is only ever a picture`,
+    );
+    const [chooser] = await Promise.all([
+      this.page.waitForEvent("filechooser"),
+      this.page.locator(CHAT_CAMERA_BUTTON).click(),
+    ]);
+    await chooser.setFiles({
+      name: spec.name,
+      mimeType: spec.type,
+      buffer: Buffer.from(spec.data, "base64"),
+    });
+    // The mechanism the identical-second-shot case rides on, asserted AT the
+    // mechanism: this harness INJECTS files and fires `change`
+    // unconditionally, so two identical shots can never see whether the input
+    // was cleared between them — and the clear is the only way a real second
+    // identical shot fires at all. What the chips prove is the server's `-1`
+    // answer and the strip's order; what this proves is the clear.
+    assert.strictEqual(
+      await hole.inputValue(),
+      "",
+      "the shutter input must be cleared after a shot — an identical second " +
+        "capture fires no `change` on an uncleared one",
+    );
+  },
+);
+
+When("I dismiss the camera", async function (this: OlaiWorld) {
+  // The empty answer: backing out of a shutter hands the input no files and
+  // (on the browsers that fire for it) a `change` — the same shape a
+  // cancelled picker takes. The box must then be exactly as it was, which is
+  // what the next step is for.
+  const [chooser] = await Promise.all([
+    this.page.waitForEvent("filechooser"),
+    this.page.locator(CHAT_CAMERA_BUTTON).click(),
+  ]);
+  await chooser.setFiles([]);
+});
+
+Then("the composer is not offering a camera", async function (this: OlaiWorld) {
+  assert.strictEqual(
+    await this.page.locator(CHAT_CAMERA_BUTTON).count(),
+    0,
+    "a desktop draws no camera door: the attribute behind it would be " +
+      "ignored there, and a camera button that opens a file dialog lies",
+  );
+});
 
 When("the drag leaves the panel without dropping", async function (this: OlaiWorld) {
   await emptyDragAt(this, TESTID.chatTranscript, "dragleave");

--- a/packages/tests/support/world.ts
+++ b/packages/tests/support/world.ts
@@ -1050,8 +1050,13 @@ export const CHAT_ATTACHMENT_PREVIEW = selector(TESTID.chatAttachmentPreview);
 /** How big a NON-picture attachment is, beside its name — what a document
  *  chip says where a picture shows itself. */
 export const CHAT_ATTACHMENT_SIZE = selector(TESTID.chatAttachmentSize);
-/** The `+` beside the box: the file picker, and the only way in on a phone. */
+/** The `+` beside the box: the file picker, and one of the two way-ins on a
+ *  phone. */
 export const CHAT_ATTACH_BUTTON = selector(TESTID.chatAttachButton);
+/** The camera beside the `+` — drawn only where the primary pointer is
+ *  coarse (`web/src/client/chat/camera.ts`): on a desktop it is absent by
+ *  design, which is the fact a desktop scenario asserts. */
+export const CHAT_CAMERA_BUTTON = selector(TESTID.chatCameraButton);
 /** The panel saying a dragged file would land HERE. Present only while a drag
  *  carrying files is over the panel's body. */
 export const CHAT_DROP = selector(TESTID.chatDrop);

--- a/packages/web/src/client/chat/Composer.tsx
+++ b/packages/web/src/client/chat/Composer.tsx
@@ -27,23 +27,35 @@
  *     sight looks exactly like an agent that is thinking — and this row is
  *     where a person's attention already is, because it is where they were
  *     about to type.
- *   - **a file can be pasted, dropped, or picked.** Three events, one path:
- *     `attach` sends the bytes to the conversation's tmp directory and answers
- *     with a path, which rides the next `send`. All three ship together
+ *   - **a file can be pasted, dropped, picked, or SHOT.** Four events, one
+ *     path: `attach` sends the bytes to the conversation's tmp directory and
+ *     answers with a path, which rides the next `send`. All four ship together
  *     because they are the same function behind different listeners — paste is
  *     the desktop gesture, drop is the one for a file already on screen, and
- *     the picker is the only one a phone has, since a phone has no Ctrl+V.
+ *     the last two are the doors a phone has, since a phone has no Ctrl+V: the
+ *     roll picker, and a camera beside it whose input carries `capture` — the
+ *     spelling a phone's browser answers by opening the camera itself. That
+ *     door is drawn only where a finger is the pointer ({@link ./camera.ts}):
+ *     anywhere a mouse is, the attribute is ignored and the same button would
+ *     open a file dialog, which is a control lying about what it does — so
+ *     there the `+` is alone, exactly as reachable as it always was.
  *     Attaching does NOT send: the file sits in a strip above the box, where
  *     it can be removed or typed at, because "what is wrong here" needs the
- *     file and the question together. Two of those three listen HERE; the drop
- *     is caught by the panel around this row ({@link ./DropTarget.tsx}),
- *     because a file dragged at a conversation is aimed at the conversation.
- *     What all three land in is one owner above both ({@link ./holding.ts}).
+ *     file and the question together. What that makes of a camera invocation
+ *     is the multi-shot flow: one shot is ONE photo, so shoot → chip → shoot
+ *     again is how several photos come to ride one send. Three of the four
+ *     listen HERE; the drop is caught by the panel around this row
+ *     ({@link ./DropTarget.tsx}), because a file dragged at a conversation is
+ *     aimed at the conversation. What all four land in is one owner above both
+ *     ({@link ./holding.ts}).
  *
- *     All three take the same kinds, and the picker's `accept` is spelled from
- *     the gate's own list to keep that true: a dialog that greys out a PDF the
- *     drop would have taken is the one half-truth a person meets without any
- *     refusal to explain it.
+ *     Paste, drop and the roll take the same kinds, and the roll's `accept`
+ *     is spelled from the gate's own list to keep that true: a dialog that
+ *     greys out a PDF the drop would have taken is the one half-truth a
+ *     person meets without any refusal to explain it. The CAMERA's `accept`
+ *     is the one deliberate exception — `image/*`, argued where the door is
+ *     drawn: a lens makes only pictures, and what its kind misses of the
+ *     gate's list, the gate itself answers by name on the refusal line.
  *   - **a message can be ABOUT a node**, and there are two doors onto that.
  *     "Ask agent" on a row arms this box with that node ({@link ./armed.ts}),
  *     and it sits in a chip above the input until it is sent or taken off — the
@@ -108,6 +120,7 @@ import { agentIn, ATTACHMENT_EXTENSIONS } from "@olai/surface"
 import { batch, createEffect, createMemo, createSignal, on, Show } from "solid-js"
 
 import type { Written } from "../complete/trigger.ts"
+import { camera } from "./camera.ts"
 import { createChipTitles } from "./chips.ts"
 import { SaidLine } from "../SaidLine.tsx"
 import { sameIds } from "../ids.ts"
@@ -132,8 +145,8 @@ import { offers } from "./naming.ts"
 import type { Chat } from "./state.ts"
 
 /** Every control on the toolbar, the same height and the same corners. Written
- *  once because "these line up" is the property, and three copies of a class
- *  list line up only until somebody edits one. */
+ *  once because "these line up" is the property, and a class list copied per
+ *  button lines up only until somebody edits one of the copies. */
 const CONTROL =
   "flex h-8 shrink-0 items-center justify-center rounded border text-xs"
 
@@ -184,6 +197,23 @@ export function Composer(props: {
   const [taken, setTaken] = createSignal<ReadonlySet<string>>(new Set())
   let input: HTMLTextAreaElement | undefined
   let picker: HTMLInputElement | undefined
+  let shutter: HTMLInputElement | undefined
+
+  /**
+   * What either file DOOR does with what it was handed.
+   *
+   * One function, because picked and shot are the same thing below the
+   * listener, which is `./holding.ts`'s whole arrangement. The empty guard is
+   * the dismissal: backing out of a camera — or cancelling a picker, on the
+   * browsers that fire `change` for it — answers with NO files, and a gesture
+   * that ended in nothing must leave the box exactly as it was: no attachment,
+   * and not even the refusal line stirred.
+   */
+  const picked = (files: FileList | null): void => {
+    const chosen = [...(files ?? [])]
+    if (chosen.length === 0) return
+    void props.holding.take(chosen)
+  }
 
   const readCaret = (): void => {
     setCaret(input?.selectionStart ?? 0)
@@ -809,10 +839,14 @@ export function Composer(props: {
       </Show>
 
       <div class="mt-2 flex items-center gap-2">
-        {/* The only way in on a phone, which has no Ctrl+V and nothing to drag
-            from. `capture` is deliberately absent: a picture is usually one
-            already in the roll, and naming a camera would make that the
-            second-class case.
+        {/* One tap to the roll, on every device — and on a phone one of TWO
+            doors, the camera beside it. This comment used to argue
+            `capture`'s absence: a picture is usually one already in the roll,
+            and naming a camera ON THIS INPUT would have made the camera the
+            front door and the roll the second-class case. That was right for
+            one input; two inputs retire it rather than contradict it — each
+            door is one tap, so neither demotes the other, and the camera is
+            simply the next hole over.
 
             `accept` is SPELLED FROM THE GATE rather than said again as
             `image/*`: a picker that will not offer a PDF the gate would take
@@ -826,7 +860,7 @@ export function Composer(props: {
           multiple
           class="hidden"
           onChange={(event) => {
-            void props.holding.take([...(event.currentTarget.files ?? [])])
+            picked(event.currentTarget.files)
             // Cleared so picking the SAME file twice fires `change` twice.
             event.currentTarget.value = ""
           }}
@@ -840,6 +874,60 @@ export function Composer(props: {
         >
           +
         </button>
+        {/* THE CAMERA'S OWN DOOR. `capture="environment"` is the whole of
+            what makes it one: on a phone the browser opens the back camera
+            for it directly, so this button says photo and means photo rather
+            than opening a picker with the camera as one entry of it — which
+            is also why it carries no `multiple`: the platform hands one shot
+            back per invocation, and several photos are made by the
+            shoot → chip → shoot rhythm the strip above the box is for. The
+            value-clearing is the roll's own trick, and it is what makes two
+            IDENTICAL shots two attachments: without it the second fires no
+            `change` at all.
+
+            `accept` is the media WILDCARD rather than the gate's spelled
+            list, and that is not the `+`'s half-truth newly risked: what a
+            camera can produce is only ever a picture, and `image/*` is the
+            spelling the capture prompt itself reads its kind from. What the
+            gate would refuse, it refuses by name when the upload tries — the
+            same answer a drop gets.
+
+            Drawn ONLY where `./camera.ts` says a finger is the pointer: the
+            desktop gets no camera entry at all, because there the attribute
+            is ignored and the button would open an ordinary file dialog —
+            one that lies. Both elements stand or go together: the input alone
+            would be markup nothing can reach. */}
+        <Show when={camera()}>
+          <input
+            ref={shutter}
+            type="file"
+            accept="image/*"
+            capture="environment"
+            class="hidden"
+            onChange={(event) => {
+              picked(event.currentTarget.files)
+              event.currentTarget.value = ""
+            }}
+          />
+          <button
+            type="button"
+            class={`${CONTROL} w-8 border-rule text-muted hover:text-ink`}
+            data-testid={TESTID.chatCameraButton}
+            aria-label="take a photo"
+            onClick={() => shutter?.click()}
+          >
+            {/* A camera, drawn with the `+`'s ink and at the `+`'s weight:
+                the body, the viewfinder hump and the lens as one filled
+                shape, the lens cut out of it. */}
+            <svg viewBox="0 0 16 16" class="size-4" aria-hidden="true" fill="currentColor">
+              <path
+                fill-rule="evenodd"
+                d="M5.5 2h5l1 2h1A1.5 1.5 0 0 1 14 5.5v6a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 11.5v-6A1.5 1.5 0 0 1 3.5 4h1l1-2zM8 11a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </button>
+        </Show>
         {/* Only when the agent offers some: a button that opens nothing lies. */}
         <Show when={props.chat.state().commands.length > 0}>
           <button

--- a/packages/web/src/client/chat/attach.ts
+++ b/packages/web/src/client/chat/attach.ts
@@ -1,9 +1,10 @@
 /**
  * A file, from a Blob in this tab to a path on the server's disk.
  *
- * Three ways in — paste, drop, and the file picker a phone needs because it
- * has no Ctrl+V — and one way through: read the bytes, base64 them once, and
- * send them as a SEQUENCE of bounded `chat.attach` calls. The first creates
+ * Four ways in — paste, drop, and the two doors a phone has because it has
+ * no Ctrl+V (the roll picker, and the camera beside it) — and one way
+ * through: read the bytes, base64 them once, and send them as a SEQUENCE of
+ * bounded `chat.attach` calls. The first creates
  * the file; each later one hands back the path it was given and appends. No
  * single frame scales with the file, which is the whole reason the calls are
  * chunked at all — the size of one is the framework's, derived beside the cap

--- a/packages/web/src/client/chat/camera.ts
+++ b/packages/web/src/client/chat/camera.ts
@@ -1,0 +1,49 @@
+/**
+ * Whether this device may offer a CAMERA beside the roll, and the one line
+ * that decides it.
+ *
+ * The entry exists for a phone: the browser sees the form's `capture`
+ * attribute and opens the camera itself, so the button says "take a photo"
+ * and means it. Everywhere else the SAME markup is a lie: the attribute is
+ * ignored and the button opens an ordinary file dialog, in front of no
+ * camera it could name. So the question is about the POINTER, not the
+ * layout — a laptop's window dragged narrow is still a mouse machine whose
+ * camera button would open a picker, and a phone held sideways is still a
+ * phone.
+ *
+ * `pointer: coarse` is the proxy, and it is worth saying why it is the right
+ * one, since there is no true probe for `capture` (the attribute has no API
+ * behind it) and sniffing the user agent is the worse answer. Every device
+ * whose camera this is for is coarse-FIRST: a phone, a tablet. The device
+ * class that has both a touchscreen and a lens but must NOT get the button —
+ * the touchscreen laptop — reports its PRIMARY pointer as fine (`any-pointer`
+ * is where its screen shows up), so it is excluded by definition rather than
+ * by a list of models somebody has to keep.
+ *
+ * module-scoped like `../layout/media.ts`, and for that file's reason: one
+ * listener for the document's life, shared by every reader.
+ */
+
+import { type Accessor, createSignal } from "solid-js"
+
+/** The platform's own answer to "is the primary pointer a finger". */
+const COARSE_MQ = "(pointer: coarse)"
+
+const [offered, setOffered] = createSignal(
+  typeof window !== "undefined" && window.matchMedia(COARSE_MQ).matches,
+)
+
+let watching = false
+
+/** Start the listener. Idempotent; called from `main.tsx`. */
+export const trackCamera = (): void => {
+  if (watching || typeof window === "undefined") return
+  watching = true
+  const mq = window.matchMedia(COARSE_MQ)
+  const apply = () => setOffered(mq.matches)
+  apply()
+  mq.addEventListener("change", apply)
+}
+
+/** Whether the composer may draw the camera's door. */
+export const camera: Accessor<boolean> = offered

--- a/packages/web/src/client/chat/holding.ts
+++ b/packages/web/src/client/chat/holding.ts
@@ -9,10 +9,12 @@
  * strip at the bottom of it. One owner above both: `Panel.tsx` makes this and
  * hands it to each.
  *
- * Three gestures arrive here and there is deliberately one way through: paste
- * (the desktop one), drop (for a file already on screen), and the picker (the
- * only one a phone has). What differs between them is which listener called
- * {@link Holding.take}; nothing below that line knows which it was.
+ * Four gestures arrive here and there is deliberately one way through: paste
+ * (the desktop one), drop (for a file already on screen), and the two doors a
+ * phone has — the roll picker and the camera beside it. What differs between
+ * them is which listener called {@link Holding.take}; nothing below that line
+ * knows which it was. A camera's one-shot rhythm is no case of its own here:
+ * each invocation is one file, like one file in a drop.
  *
  * These chips refer to something the SERVER owns — files in the conversation's
  * tmp directory — so they are dropped when the conversation is. A chip left

--- a/packages/web/src/client/main.tsx
+++ b/packages/web/src/client/main.tsx
@@ -10,6 +10,7 @@ import App from "./App.tsx"
 import { Fault } from "./errors/Fault.tsx"
 import { followFolders } from "./fold/folders.ts"
 import { followFolds } from "./fold/memory.ts"
+import { trackCamera } from "./chat/camera.ts"
 import { trackDesktop } from "./layout/media.ts"
 import { followLayout } from "./layout/prefs.ts"
 import { followName } from "./named.ts"
@@ -79,6 +80,7 @@ followDoneHidden()
 followOutlinesHidden()
 followFolds()
 followFolders()
+trackCamera()
 trackDesktop()
 
 const root = document.getElementById("root")

--- a/packages/web/src/client/testids.ts
+++ b/packages/web/src/client/testids.ts
@@ -1437,6 +1437,13 @@ export const TESTID = {
   chatNodeRef: "chat-node-ref",
   /** The file picker beside the input — a phone has no Ctrl+V. */
   chatAttachButton: "chat-attach",
+  /** The camera's door beside the `+` — the second entry a phone gets
+   *  (`chat/camera.ts`). Its input carries `capture="environment"`, which is
+   *  what makes a phone's browser open the camera itself. Drawn ONLY where
+   *  the primary pointer is coarse: on a desktop the attribute is ignored
+   *  and the button would open a file dialog, so it is ABSENT there —
+   *  which is the fact a scenario on a desktop asserts. */
+  chatCameraButton: "chat-camera",
   /** The button that opens the WHOLE command list. Drawn only when the agent
    *  offers commands. */
   chatCommands: "chat-commands",


### PR DESCRIPTION
## The ask

> "I was outside yesterday and used Olai in my phone and wanted to capture a photo directly to chat."
> "Make sure I can capture multiple photos into chat before sending message."

The `+` in the chat composer takes a photo too. On a phone it now has a camera door beside it: tap, the browser opens the camera itself, the photo lands in the strip above the box — and tap it again for the next one, as many times as the message needs. One send carries them all.

## What changed where

- `packages/web/src/client/chat/Composer.tsx` — a second hidden input (`accept="image/*"`, `capture="environment"`) behind a camera button drawn beside the `+`. Both doors feed the same `picked()` helper, which feeds the same `holding.take()` as paste/drop/pick. The helper has an empty guard: backing out of a camera (or, on the browsers that fire `change` for it, cancelling the picker) answers with no files and now leaves the box exactly as it was — nothing taken, not even the refusal line stirred.
- `packages/web/src/client/chat/camera.ts` (new) — where the button may live at all: `(pointer: coarse)` — the platform's own "the primary pointer is a finger". The argument: there is no support probe for `capture` (no API behind the attribute) and UA-sniffing is worse; every device whose camera this is for is coarse-first, and a touchscreen laptop reports its PRIMARY pointer as fine, so it is excluded by definition. On a desktop the attribute would be ignored and the camera button would open an ordinary file dialog — a button that lies — so there the entry is simply not drawn, and the roll is exactly as reachable as it was: one tap, one picker, as today.
- `packages/web/src/client/main.tsx`, `testids.ts` — the `trackCamera()` listener wired beside `trackDesktop`; `chatCameraButton: "chat-camera"` declared (its comment says the desktop-absence is the assertable fact).
- `packages/tests/step_definitions/chat_steps.ts`, `features/the_agent.feature`, `support/world.ts` — three scenarios: **Photos shot straight into the chat all ride one message** (`@phone`: three captures across three intakes — one of them the SAME photo twice — accumulate in the strip in order and reach the agent in order on one send; the step itself asserts the shutter's value reads back empty after every shot, because Playwright's injected `setFiles` fires `change` unconditionally and an uncleared shutter is a thing the chip count cannot see); **The camera is offered only where a finger is the pointer** (desktop: no camera button, and the `+` picks exactly as before, its locator scoped `[multiple]` so a phone cannot strict-mode it); and **A dismissed capture touches nothing — not even somebody else's refusal** (`@phone`: earn the gate's refusal with a `.zip` drop, dismiss a capture, assert the strip is empty AND the refusal line is still on screen — the arm proved by re-breaking the guard, which fails exactly there).
- Module headers in `Composer.tsx`, `holding.ts`, `attach.ts` — "three gestures, one path" becomes four; the arrangement did not move.
- `docs/chat.md` §Attachments — the phone's two doors named in the lead, then the camera door and the shoot → chip → shoot rhythm, written the way it behaves.

## How the deliberate omission was retired

`Composer.tsx` used to say, over its one file input: *"`capture` is deliberately absent: a picture is usually one already in the roll, and naming a camera would make that the second-class case."* That argument was right for one input, and it never argued against a camera — it argued against ONE hole being asked to prefer one source, where the losing preference is the roll and the price is a tap on every ordinary attach. Two inputs retire the argument rather than contradict it: the roll input is byte-for-byte the choice it was (same one-tap door on every device), and the camera is simply the next hole over carrying its own `capture` — each exactly as reachable as the other, so nothing is second-class. The comment now says so, in place.

## Evidence

Phone viewport (Playwright emulation — 390×844, touch, the same numbers the `@phone` tag uses), scripted agent, one take: the `+`'s two entries; three captures accumulating across three intakes (`porch.jpg`, `porch.jpg` again → `porch-1.jpg`, `door.jpg`); one send carrying all three into the transcript, where the scripted agent reads each from its path:

https://github.com/user-attachments/assets/9b571a15-a253-48df-b5ea-e61fd19331ca

The strip mid-way, for a still read:

![three captures held in the composer's strip](https://github.com/user-attachments/assets/71cf0667-f55e-4c97-8041-47eea2301690)

The desktop, composer's control row: the `+` unchanged, no camera entry — as intended:

![desktop composer: + and / only](https://github.com/user-attachments/assets/22649589-5c78-4e04-9fde-9591a56a8553)

**The DOM fact, since no drivable browser can open a real camera** — a desktop Chromium ignores `capture`; a real camera is the one thing this evidence cannot show, and it is not faked. What the merge stands on is the attribute itself, read off the live phone-emulated page (and asserted by both new scenarios, the way the pick scenario asserts `accept`):

```html
phone:   <input type="file" accept="image/*" capture="environment" class="hidden">
         (phone: 1 roll button + 1 camera button)
desktop: <input type="file" multiple="" class="hidden" accept=".png,.jpg,.jpeg,.gif,.webp,.avif,.bmp,.ico,.pdf,.txt,.md,.csv,.json">
         (desktop: 1 roll button, 0 camera buttons)
```

## Local gate (serial)

- `just typecheck` — clean (15 packages).
- `just test` — 83 pass, 0 fail (incl. the browser-condition browsertests).
- `features/the_agent.feature` — 100 scenarios pass (the three camera ones included, the dismissal arm proved by re-breaking the guard).
- `features/on_a_phone.feature` — 18 scenarios pass (the composer's other phone face).

## Deferrals

No deferrals.
