### PR TITLE
CLAUDE.md stops ordering authors to run CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 ## PR workflow
 
 - Keep docs up to date: README.md, docs/*.md — the engineering docs that change in the same PR as the code. Development docs — brainstorms, RCAs, roadmap, the board — live in https://github.com/juspay/oss.olai; file roadmap items via the olai MCP.
-- CI, reviews, and merging are NOT the author's to run or commission — the dispatch brief that opened your session governs the process. Authors run LOCAL suites only: typecheck, unit, the touched features. CI = [odu SKILL.md](https://github.com/juspay/odu/blob/master/.apm/skills/odu/SKILL.md) (read in FULL) is the reference for whoever runs it: Linux; skip macOS unless the PR impacts macOS (this rule applies to all repos). Merge latest master into the PR only when the PR has conflicts (or CI needs code from master).
+- CI, reviews, and merging are NOT the author's to run or commission — the dispatch brief that opened your session governs the process. Authors run LOCAL suites only: typecheck, unit, the touched features.
 
 ## PR evidence uploads
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 ## PR workflow
 
 - Keep docs up to date: README.md, docs/*.md — the engineering docs that change in the same PR as the code. Development docs — brainstorms, RCAs, roadmap, the board — live in https://github.com/juspay/oss.olai; file roadmap items via the olai MCP.
-- CI = [odu SKILL.md](https://github.com/juspay/odu/blob/master/.apm/skills/odu/SKILL.md) (read in FULL), Linux; skip macOS unless the PR impacts macOS (this rule applies to all repos). On the PR is ready: run CI to satisfy "CI green". Merge latest master into the PR only when the PR has conflicts (or CI needs code from master).
+- CI, reviews, and merging are NOT the author's to run or commission — the dispatch brief that opened your session governs the process. Authors run LOCAL suites only: typecheck, unit, the touched features. CI = [odu SKILL.md](https://github.com/juspay/odu/blob/master/.apm/skills/odu/SKILL.md) (read in FULL) is the reference for whoever runs it: Linux; skip macOS unless the PR impacts macOS (this rule applies to all repos). Merge latest master into the PR only when the PR has conflicts (or CI needs code from master).
 
 ## PR evidence uploads
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,3 @@
 
 - Keep docs up to date: README.md, docs/*.md — the engineering docs that change in the same PR as the code. Development docs — brainstorms, RCAs, roadmap, the board — live in https://github.com/juspay/oss.olai; file roadmap items via the olai MCP.
 - CI, reviews, and merging are NOT the author's to run or commission — the dispatch brief that opened your session governs the process. Authors run LOCAL suites only: typecheck, unit, the touched features.
-
-## PR evidence uploads
-
-- Produce: write the throwaway section at `.saatchi/evidence.ts` and `nix run github:juspay/saatchi` (shots land in `.saatchi/shots/`). Upload: `nix run github:juspay/saatchi#publish` prints a paste-ready markdown block (videos handled, transcode included). Details in [saatchi's README](https://github.com/juspay/saatchi) — read it.
-- Non-media artifacts or endpoint failure: Crabbox artifact publishing plus the manifest URL. Never push proof assets to any product repo branch; do not commit `.github/pr-assets`.


### PR DESCRIPTION
## The change

CLAUDE.md only (AGENTS.md is its symlink, untouched). The file header licenses AI edits only as corrections/updates to existing content — this is such a correction, per the approved RCA ruling: process law leaves the repo file; the dispatch brief is the process authority. Two parts:

**1. The CI bullet in `## PR workflow` is rewritten.**

Old line:

> CI = [odu SKILL.md](https://github.com/juspay/odu/blob/master/.apm/skills/odu/SKILL.md) (read in FULL), Linux; skip macOS unless the PR impacts macOS (this rule applies to all repos). On the PR is ready: run CI to satisfy "CI green". Merge latest master into the PR only when the PR has conflicts (or CI needs code from master).

**Incident:** 2026-08-29 — a lane author ran full CI against its brief's explicit prohibition because this line outranked the brief: repo instruction files re-enter every agent's context every turn, while a brief is read once.

New text (the entire bullet):

> CI, reviews, and merging are NOT the author's to run or commission — the dispatch brief that opened your session governs the process. Authors run LOCAL suites only: typecheck, unit, the touched features.

The CI recipe (odu link, Linux/skip-macOS note) and the merge-master rule go entirely: authors never run CI, so CLAUDE.md has no reader for a CI recipe — the CI watcher's own brief carries it.

**2. The `## PR evidence uploads` section is deleted** — heading and both bullets. Evidence tooling now lives in the orchestrator's vault, not the downstream repo; nothing replaces it.

## Local suites

Doc-only change; the repo's one formatting check (`just fmt-check`) covers nix files only, so nothing applies.

## Deferrals

No deferrals.