### PR TITLE
A bad property type is refused naming the legal vocabulary

### DIFF
--- a/docs/format.md
+++ b/docs/format.md
@@ -151,6 +151,12 @@ set_prop {"id":"lane","key":"merge","value":"AUTO: grok review folded + CI green
 set_prop {"id":"lane","key":"agent","value":"clade"}
 → `agent` names a node under `agents-roster` — those are `claude`, `grok`, `pi` —
   got "clade" — did you mean `claude`?
+
+add_node {file: "_olai/Properties.olai", title: "took", props: {type: "took"}}
+→ `type` is `took`, which is not a property type — write `text` (anything),
+  `date` (an ISO day or instant), `int` (a digit run), `path` (no whitespace;
+  optional `base`), `doc` (a served `.md`; optional `base`), `ref` (a child's
+  id; `under` names the parent), `node` (any node id)
 ```
 
 A hand edit that lands a bad value makes the file **broken, naming the key** (`bad-prop`), exactly how every other validation rule reports. Every door that writes a property is covered, because the check sits at the plan/validate seam: `set_prop`, `add_node`'s `props` (children included), `apply`, `update`, `capture`. `duplicate_node` needs no rule of its own — a copy is isomorphic to a subtree the validator has already approved.
@@ -449,7 +455,7 @@ The rules:
 - Dates (the marks and `date`) are valid ISO; the four marks are mutually exclusive, and a record carrying two is refused whichever two they are. Validated as text, because a writer must reproduce what it read: a date-only `2026-08-10` round-tripped through an instant would come back a datetime.
 - `repeat` is a rule the grammar holds, and the node carries a `date` for it to repeat from. Both are `bad-repeat`, and both are per-line for the reason the mark exclusion is: the whole question is on one line, and two branches that broke it between them would conflict in git rather than merging into a set nothing loads ([Repeating](#repeating)).
 - `doc` resolves, against the naming outline's own directory, to an `.md` file that is actually served.
-- Every property value fits what its key DECLARES, and every declaration in `_olai/Properties.olai` says a type the built-in table knows ([Typed properties](#typed-properties)). Both are `bad-prop`, and both name the key. A ref or a `node` value resolves a bare id across files, so the code is withheld while any file is unreadable — the same staging rule an unknown target gets, and a withheld finding still refuses the set.
+- Every property value fits what its key DECLARES, and every declaration in `_olai/Properties.olai` says a type the built-in table knows ([Typed properties](#typed-properties)). Both are `bad-prop`, and both name the key. A declaration whose `type` the table does not know names the legal kinds and each one's required shape in the same sentence. A ref or a `node` value resolves a bare id across files, so the code is withheld while any file is unreadable — the same staging rule an unknown target gets, and a withheld finding still refuses the set.
 
 There is deliberately **no rule about a mark and the children under it**, and the fourth mark added none: `set_cancelled` is not gated on the branch at all ([Status](#status)), so the format grew a word without growing a cross-line invariant. There was one — no stored derived state, which refused any mark on a node with children — and it existed only to keep a computed status and a written one from contradicting each other. Nothing computes one now, so it has nothing to defend: it dissolved with derivation rather than needing an exception ([Status](#status)). What replaced it is a pair of write-time gates and a nudge ([Status](#status)), which are the ops layer's policy and never a reason a set fails to load: a merge can write a mark in one branch and a task under it in another and both land cleanly, so this file has to read that set, and the next write through the ops layer is what fixes it.
 

--- a/docs/format.md
+++ b/docs/format.md
@@ -156,7 +156,7 @@ add_node {file: "_olai/Properties.olai", title: "took", props: {type: "took"}}
 → `type` is `took`, which is not a property type — write `text` (anything),
   `date` (an ISO day or instant), `int` (a digit run), `path` (no whitespace;
   optional `base`), `doc` (a served `.md`; optional `base`), `ref` (a child's
-  id; `under` names the parent), `node` (any node id)
+  id; `under` names the parent), `node` (any node id).
 ```
 
 A hand edit that lands a bad value makes the file **broken, naming the key** (`bad-prop`), exactly how every other validation rule reports. Every door that writes a property is covered, because the check sits at the plan/validate seam: `set_prop`, `add_node`'s `props` (children included), `apply`, `update`, `capture`. `duplicate_node` needs no rule of its own — a copy is isomorphic to a subtree the validator has already approved.

--- a/packages/format/src/index.ts
+++ b/packages/format/src/index.ts
@@ -385,7 +385,8 @@ export type { HasCustom } from "./custom.ts"
  * ONE key by declaring it in `_olai/Properties.olai`, and everything in it is
  * public because the rule is worn at two doors: the validator refuses a file
  * (in this package) and the write planner refuses a call (`@olai/ops`), in one
- * sentence, which is what `wrongValue` and `storedValue` are.
+ * sentence, which is what `wrongValue`, `storedValue` and `wrongDeclaration`
+ * are.
  *
  * `PROP_KINDS` and `PROPERTIES` are on the surface because they are the
  * VOCABULARY a tool description and a doc page teach; `declarationsOf` and
@@ -403,9 +404,11 @@ export {
   NO_TYPING,
   offsetIn,
   PATH_BASES,
+  PROP_KIND_TAKES,
   PROP_KINDS,
   storedValue,
   variantsOf,
+  wrongDeclaration,
   wrongValue,
 } from "./typing.ts"
 export type { Declared, PathBase, PropDeclarations, PropType, Typed } from "./typing.ts"

--- a/packages/format/src/typing.test.ts
+++ b/packages/format/src/typing.test.ts
@@ -359,6 +359,32 @@ test("the bootstrap table is the words a declaration says about itself", () => {
   expect(PATH_BASES).toEqual(["root", "file"])
 })
 
+test("a bad type is refused naming the legal kinds and each one's shape", () => {
+  const bent = derive(nodesOfFiles({
+    "_olai/Properties.olai": `{"id":"p","ord":"a0","title":"took","custom":{"type":"took"}}`,
+  }))
+  const said = wrongDeclaration(bent, bent.byId.get("p")!, new Set())
+  expect(said).toContain("`type` is `took`, which is not a property type")
+  expect(said).toContain("`text` (anything)")
+  expect(said).toContain("`date` (an ISO day or instant)")
+  expect(said).toContain("`int` (a digit run)")
+  expect(said).toContain("`path` (no whitespace; optional `base`)")
+  expect(said).toContain("`doc` (a served `.md`; optional `base`)")
+  expect(said).toContain("`ref` (a child's id; `under` names the parent)")
+  expect(said).toContain("`node` (any node id)")
+})
+
+test("a declaration missing its type is refused naming the same vocabulary", () => {
+  const bent = derive(nodesOfFiles({
+    "_olai/Properties.olai": `{"id":"p","ord":"a0","title":"musts"}`,
+  }))
+  const said = wrongDeclaration(bent, bent.byId.get("p")!, new Set())
+  expect(said).toContain("does not say its `type`")
+  expect(said).toContain("`text` (anything)")
+  expect(said).toContain("`ref` (a child's id; `under` names the parent)")
+  expect(said).toContain("`int` (a digit run)")
+})
+
 test("a vault cannot declare `type`, `under` or `base` — the recursion stops in the table", () => {
   const claiming = derive(nodesOfFiles({
     ...FILES,

--- a/packages/format/src/typing.test.ts
+++ b/packages/format/src/typing.test.ts
@@ -371,7 +371,8 @@ test("a bad type is refused naming the legal kinds and each one's shape", () => 
   expect(said).toContain("`path` (no whitespace; optional `base`)")
   expect(said).toContain("`doc` (a served `.md`; optional `base`)")
   expect(said).toContain("`ref` (a child's id; `under` names the parent)")
-  expect(said).toContain("`node` (any node id)")
+  expect(said).toContain("`node` (any node id).")
+  expect(said?.endsWith(".")).toBe(true)
 })
 
 test("a declaration missing its type is refused naming the same vocabulary", () => {

--- a/packages/format/src/typing.ts
+++ b/packages/format/src/typing.ts
@@ -408,7 +408,7 @@ export const BOOTSTRAP: ReadonlyMap<string, Grounded> = new Map<string, Grounded
     wrong: (value) =>
       isPropKind(value) ? undefined : `is not a property type — write ${
         kindsTaken()
-      }${didYouMean(value, PROP_KINDS)}`,
+      }${didYouMean(value, PROP_KINDS)}.`,
   }],
   [UNDER_KEY, {
     takes: "the id of a node in the set — where a `ref`'s variants live",

--- a/packages/format/src/typing.ts
+++ b/packages/format/src/typing.ts
@@ -174,6 +174,27 @@ export const PROP_KINDS = [
 ] as const satisfies ReadonlyArray<PropType["kind"]>
 
 /**
+ * What each kind TAKES, as the clause a refusal names it with — the legal
+ * word and the shape it requires, in one phrase per kind.
+ *
+ * Read by {@link BOOTSTRAP} so a kind added to the union above and forgotten
+ * here is a type error rather than a word the declarations file quietly stops
+ * explaining. The order is {@link PROP_KINDS}' so the sentence a bad `type` is
+ * refused with cannot drift from the list the table accepts.
+ */
+export const PROP_KIND_TAKES = {
+  text: "`text` (anything)",
+  date: "`date` (an ISO day or instant)",
+  int: "`int` (a digit run)",
+  path: "`path` (no whitespace; optional `base`)",
+  doc: "`doc` (a served `.md`; optional `base`)",
+  ref: "`ref` (a child's id; `under` names the parent)",
+  node: "`node` (any node id)",
+} as const satisfies Record<PropType["kind"], string>
+
+const kindsTaken = (): string => PROP_KINDS.map((kind) => PROP_KIND_TAKES[kind]).join(", ")
+
+/**
  * WHERE A RELATIVE `doc` OR `path` VALUE RESOLVES FROM — the key's own answer,
  * declared beside its type.
  *
@@ -383,10 +404,10 @@ interface Grounded {
  */
 export const BOOTSTRAP: ReadonlyMap<string, Grounded> = new Map<string, Grounded>([
   [TYPE_KEY, {
-    takes: `one of ${PROP_KINDS.map((kind) => `\`${kind}\``).join(", ")}`,
+    takes: kindsTaken(),
     wrong: (value) =>
-      isPropKind(value) ? undefined : `is not a property type — write one of ${
-        PROP_KINDS.map((kind) => `\`${kind}\``).join(", ")
+      isPropKind(value) ? undefined : `is not a property type — write ${
+        kindsTaken()
       }${didYouMean(value, PROP_KINDS)}`,
   }],
   [UNDER_KEY, {
@@ -1146,7 +1167,7 @@ export const wrongDeclaration = (
   }
   const said = customText(located, TYPE_KEY)
   if (said === undefined) {
-    return `\`${written}\` declares a property key but does not say its \`${TYPE_KEY}\` — ` +
+    return `\`${written}\` declares a property key but does not say its \`${TYPE_KEY}\` — write ` +
       `${BOOTSTRAP.get(TYPE_KEY)?.takes ?? ""}.`
   }
   // The one rule about the PAIR, which no per-word table can hold: `under` says

--- a/packages/format/src/validate.test.ts
+++ b/packages/format/src/validate.test.ts
@@ -758,7 +758,9 @@ test("a declaration the built-in table does not know is a broken declarations fi
   })
   expect(codes(errors)).toEqual(["bad-prop"])
   expect(errors[0]?.file).toBe("_olai/Properties.olai")
-  expect(errors[0]?.message).toContain("which is not a property type — write one of `text`, `date`, `int`")
+  expect(errors[0]?.message).toContain("which is not a property type — write `text` (anything)")
+  expect(errors[0]?.message).toContain("`ref` (a child's id; `under` names the parent)")
+  expect(errors[0]?.message).toContain("`int` (a digit run)")
 })
 
 test("a declaration with no type at all says so", () => {
@@ -767,6 +769,8 @@ test("a declaration with no type at all says so", () => {
   })
   expect(codes(errors)).toEqual(["bad-prop"])
   expect(errors[0]?.message).toContain("does not say its `type`")
+  expect(errors[0]?.message).toContain("`text` (anything)")
+  expect(errors[0]?.message).toContain("`ref` (a child's id; `under` names the parent)")
 })
 
 test("`under` on something that is not a ref, and `under` naming nothing", () => {

--- a/packages/ops/src/ops.test.ts
+++ b/packages/ops/src/ops.test.ts
@@ -1133,3 +1133,50 @@ describe("a broken file beside a healthy one", () => {
         }),
     ))
 })
+
+/**
+ * A bad `type` in a Properties declaration used to pass the planner and meet
+ * the generic write gate — "`capture: took` would leave `_olai/Properties.olai`
+ * invalid" — which named nothing. The planner now refuses as `usage`, naming
+ * the legal kinds, so this layer never reaches that sentence.
+ */
+test("a bad type in a Properties declaration is refused naming the legal vocabulary", () =>
+  withOps(
+    {
+      "_olai/Properties.olai":
+        `{"id":"prop-pr","ord":"a0","title":"pr","custom":{"type":"int"}}\n`,
+    },
+    (fixture) =>
+      Effect.gen(function*() {
+        const unknown = yield* Effect.orDie(
+          Effect.flip(
+            fixture.ops.run({
+              op: "add",
+              file: "_olai/Properties.olai",
+              title: "took",
+              props: { type: "took" },
+            }, "mcp"),
+          ),
+        )
+        expect(unknown._tag).toBe("UsageFailure")
+        expect(unknown.message).toContain("`type` is `took`, which is not a property type")
+        expect(unknown.message).toContain("`int` (a digit run)")
+        expect(unknown.message).toContain("`ref` (a child's id; `under` names the parent)")
+        expect(unknown.message).not.toContain("would leave")
+
+        const missing = yield* Effect.orDie(
+          Effect.flip(
+            fixture.ops.run({
+              op: "add",
+              file: "_olai/Properties.olai",
+              title: "musts",
+            }, "mcp"),
+          ),
+        )
+        expect(missing._tag).toBe("UsageFailure")
+        expect(missing.message).toContain("does not say its `type`")
+        expect(missing.message).toContain("`text` (anything)")
+        expect(missing.message).toContain("`ref` (a child's id; `under` names the parent)")
+        expect(missing.message).not.toContain("would leave")
+      }),
+  ))

--- a/packages/ops/src/plan.test.ts
+++ b/packages/ops/src/plan.test.ts
@@ -5185,6 +5185,75 @@ describe("typed properties", () => {
 
   // ── the births ───────────────────────────────────────────────────────
 
+  test("a bad type in a Properties declaration is refused naming the legal vocabulary", () => {
+    const held = setOf({
+      "_olai/Properties.olai":
+        `{"id":"prop-pr","ord":"a0","title":"pr","custom":{"type":"int"}}`,
+    })
+    const failure = refused(held, {
+      op: "add",
+      file: "_olai/Properties.olai",
+      title: "took",
+      props: { type: "took" },
+    })
+    expect(failure._tag).toBe("UsageFailure")
+    expect(failure.message).toContain("`type` is `took`, which is not a property type")
+    expect(failure.message).toContain("`text` (anything)")
+    expect(failure.message).toContain("`date` (an ISO day or instant)")
+    expect(failure.message).toContain("`int` (a digit run)")
+    expect(failure.message).toContain("`path` (no whitespace; optional `base`)")
+    expect(failure.message).toContain("`doc` (a served `.md`; optional `base`)")
+    expect(failure.message).toContain("`ref` (a child's id; `under` names the parent)")
+    expect(failure.message).toContain("`node` (any node id)")
+  })
+
+  test("a Properties declaration missing its type is refused naming the same vocabulary", () => {
+    const held = setOf({
+      "_olai/Properties.olai":
+        `{"id":"prop-pr","ord":"a0","title":"pr","custom":{"type":"int"}}`,
+    })
+    const failure = refused(held, {
+      op: "add",
+      file: "_olai/Properties.olai",
+      title: "musts",
+    })
+    expect(failure._tag).toBe("UsageFailure")
+    expect(failure.message).toContain("does not say its `type`")
+    expect(failure.message).toContain("`text` (anything)")
+    expect(failure.message).toContain("`ref` (a child's id; `under` names the parent)")
+    expect(failure.message).toContain("`int` (a digit run)")
+  })
+
+  test("set_prop of a bad type on a declaration is the same refusal", () => {
+    const held = setOf({
+      "_olai/Properties.olai":
+        `{"id":"prop-pr","ord":"a0","title":"pr","custom":{"type":"int"}}`,
+    })
+    const failure = refused(held, {
+      op: "prop",
+      id: "prop-pr",
+      key: "type",
+      value: "colour",
+    })
+    expect(failure._tag).toBe("UsageFailure")
+    expect(failure.message).toContain("`type` is `colour`, which is not a property type")
+    expect(failure.message).toContain("`ref` (a child's id; `under` names the parent)")
+  })
+
+  test("a ref declaration without `under` is still legal — variants hang under it", () => {
+    const held = setOf({
+      "_olai/Properties.olai":
+        `{"id":"prop-pr","ord":"a0","title":"pr","custom":{"type":"int"}}`,
+    })
+    const plan = planned(held, {
+      op: "add",
+      file: "_olai/Properties.olai",
+      title: "merge",
+      props: { type: "ref" },
+    })
+    expect(record(fileOf(plan, "_olai/Properties.olai"), "n1").custom).toEqual({ type: "ref" })
+  })
+
   test("add_node refuses a bad value on the node being born", () => {
     expect(
       refused(board(), {

--- a/packages/ops/src/plan.ts
+++ b/packages/ops/src/plan.ts
@@ -58,6 +58,7 @@ import {
   type OpFailure,
   ordBetween,
   OUTLINE_EXT,
+  propertiesIn,
   type Reading,
   type RegularNode,
   REPEAT_GRAMMAR,
@@ -79,6 +80,7 @@ import {
   ValidationFailure,
   verdictOf,
   withCustom,
+  wrongDeclaration,
   type WriteRequest as Request,
 } from "@olai/format"
 import { Result } from "effect"
@@ -1010,7 +1012,15 @@ const emit = (
   // here (https://github.com/juspay/oss.olai/blob/main/projects/olai/brainstorming/typed-properties.md: births are gated too).
   const stored = typedProps(scope, file, capture.props)
   if (Result.isFailure(stored)) return locus(capture, stored.failure)
-  into.records.push(capturedNode(scope, capture, at, stored.success))
+  const born = capturedNode(scope, capture, at, stored.success)
+  // A record of `_olai/Properties.olai` is a DECLARATION, and a bad `type` on
+  // it used to pass this seam and meet the generic write gate — "`capture: x`
+  // would leave the file invalid" — which named nothing. The sentence is the
+  // format's ({@link wrongDeclaration}); this is {@link typedProps}' twin for
+  // the bootstrap rather than for a value.
+  const bent = declaredWrong(scope, file, born)
+  if (bent !== undefined) return bent
+  into.records.push(born)
   if ((capture.see?.length ?? 0) > 0 || (capture.waitsOn?.length ?? 0) > 0) {
     into.wires.push({ id: at.id, see: capture.see, after: capture.waitsOn })
   }
@@ -2289,6 +2299,35 @@ const typedProps = (
 }
 
 /**
+ * What is wrong with a record landing in `_olai/Properties.olai` — the
+ * bootstrap, raised as a usage refusal one moment before the validator would
+ * raise it as a finding about bytes.
+ *
+ * THE SENTENCE IS THE FORMAT'S (`@olai/format`'s {@link wrongDeclaration}).
+ * Nothing is worded here: a person moving between a refused `add_node` and a
+ * broken declarations file has to read one wording, and this layer's job is to
+ * raise it as a `usage` refusal the way {@link typedProps} raises a value's.
+ *
+ * SCOPED TO THE DECLARATIONS FILE: a write that would leave `lanes.olai`
+ * invalid still meets the generic gate, because that file is not a vocabulary.
+ * A node already in the map is taken out of `claimed` so editing its own type
+ * is not reported as declaring the key twice.
+ */
+const declaredWrong = (
+  scope: Scope,
+  file: string,
+  node: RegularNode,
+): OpFailure | undefined => {
+  if (propertiesIn([...scope.derived.byFile.keys(), file]) !== file) return undefined
+  const claimed = new Set(scope.typed.declarations.keys())
+  for (const [key, declared] of scope.typed.declarations) {
+    if (declared.at === node.id) claimed.delete(key)
+  }
+  const wrong = wrongDeclaration(scope.derived, { file, line: 0, node }, claimed)
+  return wrong === undefined ? undefined : new UsageFailure({ reason: wrong })
+}
+
+/**
  * The CONDITION a prop write may carry — the text verbs' `was`, one map in.
  *
  * `undefined` is not conditional at all, and anything else must match what the
@@ -2423,6 +2462,15 @@ const planProp = (
     if (Result.isFailure(said)) return Result.fail(said.failure)
     value = said.success[key] ?? value
   }
+  // THE DECLARATION, after the map is the map this write would leave — so a
+  // `type` of `took` on a Properties root is refused HERE, naming the legal
+  // kinds, rather than at the generic gate after the plan has already said yes.
+  const next: RegularNode = {
+    ...located.success.node,
+    custom: withCustom(located.success.node.custom, key, value ?? undefined),
+  }
+  const bent = declaredWrong(scope, located.success.file, next)
+  if (bent !== undefined) return Result.fail(bent)
   return planEdit(
     scope,
     request.id,

--- a/packages/server/src/mcp/tools.test.ts
+++ b/packages/server/src/mcp/tools.test.ts
@@ -1172,6 +1172,51 @@ test("move_node with a `file` lands the subtree at that outline's top level", as
  * file is written — which is the law working, and is why this is a refusal with
  * nothing on disk rather than a hole.
  */
+/**
+ * A bad `type` in a Properties declaration used to meet the generic write
+ * gate — `add_node was refused (validation): \`capture: took\` would leave
+ * \`_olai/Properties.olai\` invalid` — which named nothing. The planner now
+ * refuses as `usage`, naming the legal kinds, which is the sentence an agent
+ * actually reads.
+ */
+test("add_node of a bad type in Properties.olai names the legal vocabulary", async () => {
+  await withTools(
+    {
+      "_olai/Properties.olai":
+        `{"id":"prop-pr","ord":"a0","title":"pr","custom":{"type":"int"}}\n`,
+    },
+    async ({ client }) => {
+      const unknown = await call(client, "add_node", {
+        file: "_olai/Properties.olai",
+        title: "took",
+        props: { type: "took" },
+      })
+      expect(unknown.isError).toBe(true)
+      expect(unknown.structured).toMatchObject({ kind: "usage" })
+      expect(String(unknown.structured["reason"])).toContain(
+        "`type` is `took`, which is not a property type",
+      )
+      expect(String(unknown.structured["reason"])).toContain("`int` (a digit run)")
+      expect(String(unknown.structured["reason"])).toContain(
+        "`ref` (a child's id; `under` names the parent)",
+      )
+      expect(String(unknown.structured["reason"])).not.toContain("would leave")
+
+      const missing = await call(client, "add_node", {
+        file: "_olai/Properties.olai",
+        title: "musts",
+      })
+      expect(missing.isError).toBe(true)
+      expect(missing.structured).toMatchObject({ kind: "usage" })
+      expect(String(missing.structured["reason"])).toContain("does not say its `type`")
+      expect(String(missing.structured["reason"])).toContain("`text` (anything)")
+      expect(String(missing.structured["reason"])).toContain(
+        "`ref` (a child's id; `under` names the parent)",
+      )
+    },
+  )
+})
+
 test("move_node is refused when it would take a `ref` variant out of its root", async () => {
   await withTools(
     {

--- a/packages/server/src/mcp/tools.test.ts
+++ b/packages/server/src/mcp/tools.test.ts
@@ -1172,51 +1172,6 @@ test("move_node with a `file` lands the subtree at that outline's top level", as
  * file is written — which is the law working, and is why this is a refusal with
  * nothing on disk rather than a hole.
  */
-/**
- * A bad `type` in a Properties declaration used to meet the generic write
- * gate — `add_node was refused (validation): \`capture: took\` would leave
- * \`_olai/Properties.olai\` invalid` — which named nothing. The planner now
- * refuses as `usage`, naming the legal kinds, which is the sentence an agent
- * actually reads.
- */
-test("add_node of a bad type in Properties.olai names the legal vocabulary", async () => {
-  await withTools(
-    {
-      "_olai/Properties.olai":
-        `{"id":"prop-pr","ord":"a0","title":"pr","custom":{"type":"int"}}\n`,
-    },
-    async ({ client }) => {
-      const unknown = await call(client, "add_node", {
-        file: "_olai/Properties.olai",
-        title: "took",
-        props: { type: "took" },
-      })
-      expect(unknown.isError).toBe(true)
-      expect(unknown.structured).toMatchObject({ kind: "usage" })
-      expect(String(unknown.structured["reason"])).toContain(
-        "`type` is `took`, which is not a property type",
-      )
-      expect(String(unknown.structured["reason"])).toContain("`int` (a digit run)")
-      expect(String(unknown.structured["reason"])).toContain(
-        "`ref` (a child's id; `under` names the parent)",
-      )
-      expect(String(unknown.structured["reason"])).not.toContain("would leave")
-
-      const missing = await call(client, "add_node", {
-        file: "_olai/Properties.olai",
-        title: "musts",
-      })
-      expect(missing.isError).toBe(true)
-      expect(missing.structured).toMatchObject({ kind: "usage" })
-      expect(String(missing.structured["reason"])).toContain("does not say its `type`")
-      expect(String(missing.structured["reason"])).toContain("`text` (anything)")
-      expect(String(missing.structured["reason"])).toContain(
-        "`ref` (a child's id; `under` names the parent)",
-      )
-    },
-  )
-})
-
 test("move_node is refused when it would take a `ref` variant out of its root", async () => {
   await withTools(
     {
@@ -1267,6 +1222,51 @@ test("move_node is refused when it would take a `ref` variant out of its root", 
       expect(read("agents.olai")).toBe("")
       expect(read("lanes.olai")).toContain(`{"id":"claude","parent":"roster"`)
       expect(read("lanes.olai")).toContain(`"custom":{"agent":"claude"}`)
+    },
+  )
+})
+
+/**
+ * A bad `type` in a Properties declaration used to meet the generic write
+ * gate — `add_node was refused (validation): \`capture: took\` would leave
+ * \`_olai/Properties.olai\` invalid` — which named nothing. The planner now
+ * refuses as `usage`, naming the legal kinds, which is the sentence an agent
+ * actually reads.
+ */
+test("add_node of a bad type in Properties.olai names the legal vocabulary", async () => {
+  await withTools(
+    {
+      "_olai/Properties.olai":
+        `{"id":"prop-pr","ord":"a0","title":"pr","custom":{"type":"int"}}\n`,
+    },
+    async ({ client }) => {
+      const unknown = await call(client, "add_node", {
+        file: "_olai/Properties.olai",
+        title: "took",
+        props: { type: "took" },
+      })
+      expect(unknown.isError).toBe(true)
+      expect(unknown.structured).toMatchObject({ kind: "usage" })
+      expect(String(unknown.structured["reason"])).toContain(
+        "`type` is `took`, which is not a property type",
+      )
+      expect(String(unknown.structured["reason"])).toContain("`int` (a digit run)")
+      expect(String(unknown.structured["reason"])).toContain(
+        "`ref` (a child's id; `under` names the parent)",
+      )
+      expect(String(unknown.structured["reason"])).not.toContain("would leave")
+
+      const missing = await call(client, "add_node", {
+        file: "_olai/Properties.olai",
+        title: "musts",
+      })
+      expect(missing.isError).toBe(true)
+      expect(missing.structured).toMatchObject({ kind: "usage" })
+      expect(String(missing.structured["reason"])).toContain("does not say its `type`")
+      expect(String(missing.structured["reason"])).toContain("`text` (anything)")
+      expect(String(missing.structured["reason"])).toContain(
+        "`ref` (a child's id; `under` names the parent)",
+      )
     },
   )
 })


### PR DESCRIPTION
## The law

A live write that would put a bad `type` on a `_olai/Properties.olai` declaration is refused **naming the legal kinds and each one's required shape**, in the same voice `set_prop` already uses for a value that does not fit. The gate already knew the vocabulary; it used to refuse blind.

`under` on a `ref` is named in that sentence. It is not newly required: absent `under`, the variants are the declaration's own children, as [format.md](docs/format.md#typed-properties) already says. A declaration missing its `type` entirely is the missing-piece refusal, and it names the same list.

General validation messages are untouched. A write that would leave `lanes.olai` invalid still says so.

## What changed

- `@olai/format`: `BOOTSTRAP`'s `type` sentence lists each kind with its shape (`text` anything, `date` an ISO day or instant, `int` a digit run, `path`/`doc` optional `base`, `ref` a child's id and `under` names the parent, `node` any node id). `wrongDeclaration` uses that sentence for both a word the table does not know and a declaration that does not say its `type` at all.
- `@olai/ops`: the planner raises that sentence as a `usage` refusal one moment before the validator would raise it as a finding — `add_node`, `set_prop`, `update`, `apply`, `create_outline`'s seed. Scoped to the declarations file. The generic write gate (`would leave the file invalid`) is no longer the sentence an agent reads for these two mistakes. Every other declaration mistake — a duplicate key, a shadowed or reserved title, a bootstrap word on a variant — now refuses at plan time as `usage` the same way, not only the two type shapes.
- Docs: the typed-properties two-doors example includes the declaration refusal; the validation rules name the same sentence.
- Tests: one per refusal shape (unknown type, missing type) at the format floor, the plan seam, the ops write gate, and the MCP tool surface. A `ref` without `under` still plans.

## Evidence

Refusal transcript from a real `add_node` through the ops write gate (and the same call through the MCP tool surface), before and after.

**Unknown type** — `add_node {file: "_olai/Properties.olai", title: "took", props: {type: "took"}}`

Before:

```
`add_node` was refused (validation): `capture: took` would leave `_olai/Properties.olai` invalid, so nothing was written
```

After:

```
`add_node` was refused (usage): `type` is `took`, which is not a property type — write `text` (anything), `date` (an ISO day or instant), `int` (a digit run), `path` (no whitespace; optional `base`), `doc` (a served `.md`; optional `base`), `ref` (a child's id; `under` names the parent), `node` (any node id).
```

**Missing type** — `add_node {file: "_olai/Properties.olai", title: "musts"}`

Before:

```
`add_node` was refused (validation): `capture: musts` would leave `_olai/Properties.olai` invalid, so nothing was written
```

After:

```
`add_node` was refused (usage): `musts` declares a property key but does not say its `type` — write `text` (anything), `date` (an ISO day or instant), `int` (a digit run), `path` (no whitespace; optional `base`), `doc` (a served `.md`; optional `base`), `ref` (a child's id; `under` names the parent), `node` (any node id).
```

## Local suites

- typecheck — green (`@olai/format`, `@olai/ops`, `@olai/server`).
- unit, the touched features: typing / validate / plan / ops / MCP tools — green.

## Deferrals

No deferrals.