### PR TITLE
e2e: a row jump waits on the row

### DIFF
--- a/packages/tests/step_definitions/chat_steps.ts
+++ b/packages/tests/step_definitions/chat_steps.ts
@@ -209,8 +209,15 @@ When("I ask the agent {string}", async function (this: OlaiWorld, text: string) 
  * either — and one scenario pins that they do the same thing.
  */
 When("I interrupt the agent with {string}", async function (this: OlaiWorld, text: string) {
+  // THE CONTROL, not the panel's `thinking` attribute. Thinking can land
+  // before `talking.steers` does (the handshake's advertised frame is a later
+  // assignment on the same cell), and filling the box first burns the wait
+  // on the wrong thing — the button is what this gesture presses. The
+  // sibling `I cancel the turn` already waits on its control first.
+  const interrupt = this.page.locator(CHAT_INTERRUPT);
+  await interrupt.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
   await typeInto(this, text);
-  await this.press(this.page.locator(CHAT_INTERRUPT));
+  await this.press(interrupt);
 });
 
 /** The same gesture through the keyboard. Alt+Enter and not a second control:

--- a/packages/tests/step_definitions/chat_steps.ts
+++ b/packages/tests/step_definitions/chat_steps.ts
@@ -209,15 +209,8 @@ When("I ask the agent {string}", async function (this: OlaiWorld, text: string) 
  * either — and one scenario pins that they do the same thing.
  */
 When("I interrupt the agent with {string}", async function (this: OlaiWorld, text: string) {
-  // THE CONTROL, not the panel's `thinking` attribute. Thinking can land
-  // before `talking.steers` does (the handshake's advertised frame is a later
-  // assignment on the same cell), and filling the box first burns the wait
-  // on the wrong thing — the button is what this gesture presses. The
-  // sibling `I cancel the turn` already waits on its control first.
-  const interrupt = this.page.locator(CHAT_INTERRUPT);
-  await interrupt.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
   await typeInto(this, text);
-  await this.press(interrupt);
+  await this.press(this.page.locator(CHAT_INTERRUPT));
 });
 
 /** The same gesture through the keyboard. Alt+Enter and not a second control:

--- a/packages/tests/step_definitions/sticky_header_steps.ts
+++ b/packages/tests/step_definitions/sticky_header_steps.ts
@@ -88,12 +88,18 @@ Then(
 When(
   "a jump lands the row {string} at the top of the window",
   async function (this: OlaiWorld, id: string) {
+    // THE ROW LINE, not two frames after the tree container. `I open the
+    // outline` waits for `outline-tree` and two rAFs; `<Key>`'s children can
+    // still be uncommitted, and the viewport-shortening step above can reflow
+    // the list before they are. A one-shot querySelector in that window is
+    // how the phone twin said `no row line for [data-row-key$="/install"]`
+    // under petit-load (the_header_sticks.feature:93).
+    const row = this.page.locator(rowLineOf(id));
+    await row.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
     const before = await this.page.evaluate(() => scrollY);
-    await this.page.evaluate((sel) => {
-      const el = document.querySelector(sel);
-      if (!el) throw new Error(`no row line for ${sel} — wrong outline or wrong id`);
+    await row.evaluate((el) => {
       el.scrollIntoView({ block: "start" });
-    }, rowLineOf(id));
+    });
     await this.waitUntil(async () => (await this.page.evaluate(() => scrollY)) > before,
       `the window to move after jumping to the row ${JSON.stringify(id)}`);
   },


### PR DESCRIPTION
On merge the orchestrator closes the Inbox flake entry for `the_header_sticks.feature:93` only. **`the_agent.feature:1246` stays open** — the cause was not found, the first diff could not have killed it, and this head no longer claims to.

One sighting each: PR #442's petit run seq 3, aarch64-darwin, parallel workers. Both green on the immediate e2e-only rerun at the same commit. The diff under test was store/ops-only and cannot touch either UI.

## `the_agent.feature:1246` — pulled (pi MUST)

The observed failure was `press` timing out on `[data-testid="chat-interrupt"]`. `this.press` already does `target.waitFor({ state: "visible", timeout: POLL_TIMEOUT })`. The first commit moved that same 15s wait to before `fill`. Arithmetic: before = fill + 15s; after = 15s + fill. A control that stayed undrawn for 15s fails identically.

The stated mechanism (thinking before `talking.steers`) is the boot window. :1246 interrupts on the **second** turn (`"hold"`), after a full thinking→idle round trip. `advertised` has been settled for the length of a conversation. `data-status="thinking"` passing means the button was drawable in that same commit.

**Red hunt, original step, linux, this worktree** (not aarch64-darwin, not the full petit suite):

| Shape | Result |
|---|---|
| `SUITES=5 RUNS=8` (:1246 only, 40 runs) | **40/40** |
| `BUSY=48 RUNS=10` | **10/10** |
| `OLAI_TEST_SLOW=50` ×10 | **10/10** |
| `the_agent.feature` default parallel ×3 | **303/303** (101 each, :1246 included) |

No red. A 15s miss on a second-turn interrupt is a stuck undrawn control or a renderer/harness stall; neither is a step-order race, and no step change here kills one. The Inbox entry for `the_agent.feature:1246` is **not** closed by this PR.

## `the_header_sticks.feature:93` — kept

The jump did a one-shot `querySelector` with no wait. `I open the outline` waits for the `outline-tree` container and two rAFs; `<Key>`'s children can still be uncommitted, and the viewport-shortening step (844→400 on the phone twin) can reflow the list before they are. The Then already waited on the row. The When did not. Darwin + parallel workers is the shape that makes the renderer lose to two rAFs: `waitForFrame` is vsync, not the row.

The jump waits on the row line, then `scrollIntoView`s that locator.

**Pins are hygiene, not a red-then-green kill** (pi SHOULD). Pre-fix original jump, this worktree:

| Shape | Result |
|---|---|
| `OLAI_TEST_SLOW=20` ×15 | **15/15** (no red) |
| `SUITES=5 RUNS=8` | **40/40** (no red) |

Post-fix:

| Shape | Result |
|---|---|
| `the_header_sticks.feature` | **6/6** (again at this head) |
| `OLAI_TEST_SLOW=20` ×15 | **15/15** |
| `BUSY=24` ×8 | **8/8** |

The miss is CI-load / darwin-parallel shaped, one sighting. The pre-fix step is the one-shot `querySelector`; revert it and the CI shape is `no row line for [data-row-key$="/install"]`.

## Design decisions

- **Pull the interrupt half rather than keep a wait-reorder that cannot affect the failure.** Pi's budget arithmetic is right; a second-turn interrupt with `thinking` already asserted is not the boot-window race the first commit named.
- **Locator.evaluate rather than page.evaluate + querySelector** on the jump. Once the row is waited on, scrolling that locator cannot miss it between the wait and the scroll.
- **Pins that never went red are reported as hygiene.** The header mechanism still matches the sighted error; it is not a measured kill on this box.

## Deferrals

- **`the_agent.feature:1246` cause unnamed.** Honest effort on linux (stranger, load, renderer throttle, the feature under default parallel) did not produce the 15s miss. Darwin petit under the full suite is a shape this lane is forbidden to run. The ledger entry stays open.

## NIT (merge commit)

The brief asked for a merge commit of latest master. merge-base == `origin/master` (`e46b2b94`); master has not moved. Substance holds; the letter did not.

Reviewer: the standing flake-class grant. CI once at close after review folds. Merge: AUTO. Close only `the_header_sticks.feature:93`.