### PR TITLE
e2e: the done-flip waits on the addressed page

### DIFF
--- a/packages/tests/step_definitions/outline_list_steps.ts
+++ b/packages/tests/step_definitions/outline_list_steps.ts
@@ -90,11 +90,17 @@ Then(
   },
 );
 
+/** A row of THIS file — the swap, not any outline-tree still held from the
+ *  page before. Shared by the click and the open so they cannot drift. */
+const treeOf = (world: OlaiWorld, file: string) =>
+  world.page.locator(`${OUTLINE_TREE} ${attr("data-file", file)}`).first();
+
 /** The same click one kind over from "I click the document": the entry in the
  *  tree, pressed from wherever the reader already is. Its sibling below opens
  *  the app first, which is what makes it a `Given`; this one is a gesture on a
  *  page that is already up, and the difference is the whole subject of
- *  `features/the_chrome_holds_still.feature`. */
+ *  `features/the_chrome_holds_still.feature`. The wait after the click is the
+ *  swap, same as the Given — not a rAF. */
 When(
   "I click the outline {string}",
   async function (this: OlaiWorld, file: string) {
@@ -102,7 +108,10 @@ When(
     const link = this.outlineLink(file);
     await link.waitFor({ state: "visible", timeout: HYDRATION_TIMEOUT });
     await link.click();
-    await this.waitForFrame();
+    await treeOf(this, file).waitFor({
+      state: "visible",
+      timeout: POLL_TIMEOUT,
+    });
   },
 );
 
@@ -121,10 +130,10 @@ Given(
     // container matches the previous page. One rAF is vsync, not the swap
     // — darwin + parallel workers loses that window (#445's row-jump), and
     // the next step's Done flip is then the held page's prefs-choice.
-    await this.page
-      .locator(`${OUTLINE_TREE} ${attr("data-file", file)}`)
-      .first()
-      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await treeOf(this, file).waitFor({
+      state: "visible",
+      timeout: POLL_TIMEOUT,
+    });
   },
 );
 

--- a/packages/tests/step_definitions/outline_list_steps.ts
+++ b/packages/tests/step_definitions/outline_list_steps.ts
@@ -115,12 +115,16 @@ Given(
     const link = this.outlineLink(file);
     await link.waitFor({ state: "visible", timeout: HYDRATION_TIMEOUT });
     await link.click();
-    // The tree is the app's answer to the click; waiting for it here means
-    // every later step starts from a rendered outline rather than racing it.
+    // A ROW OF THIS FILE, not any outline-tree. `/` is the first outline
+    // (`Daily/2026-08.olai` in the good corpus); createReading HOLDS that
+    // tree while the named outline is in flight, so waiting for the
+    // container matches the previous page. One rAF is vsync, not the swap
+    // — darwin + parallel workers loses that window (#445's row-jump), and
+    // the next step's Done flip is then the held page's prefs-choice.
     await this.page
-      .locator(OUTLINE_TREE)
+      .locator(`${OUTLINE_TREE} ${attr("data-file", file)}`)
+      .first()
       .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await this.waitForFrame();
   },
 );
 

--- a/packages/tests/step_definitions/preferences_steps.ts
+++ b/packages/tests/step_definitions/preferences_steps.ts
@@ -35,6 +35,7 @@ import {
   APP_HEADER,
   attr,
   HYDRATION_TIMEOUT,
+  PANE,
   POLL_TIMEOUT,
   PREFS_CHOICE,
   PREFS_HINT,
@@ -279,6 +280,32 @@ const pickDone = async (
 const DONE_FLIP = attr("data-testid", TESTID.doneFlip);
 const FOCUSED_PANE = attr("data-pane-focused", "true");
 
+/** The outline a pane's `data-href` names, or nothing — `/` is the first
+ *  outline and does not spell a file; a node permalink does not either. */
+const outlineNamedBy = (href: string | null): string | undefined => {
+  if (href === null || href === "") return undefined;
+  const path = decodeURIComponent(href.split("?")[0] ?? "");
+  if (!path.endsWith(".olai")) return undefined;
+  return path.replace(/^\//, "");
+};
+
+/** The flip of the ADDRESSED page, not a held previous one.
+ *
+ *  `/` lands on the first outline; a later open keeps that tree on screen
+ *  until the named file arrives (`createReading`'s swap). The flip is drawn
+ *  from the held reading, so a wait on any done-flip prefs-choice matches
+ *  the previous page and the press (or the Then) is lost when the swap
+ *  remounts it. */
+const flipOfAddressed = async (page: Page) => {
+  const href = await page
+    .locator(`${PANE}${FOCUSED_PANE}`)
+    .getAttribute("data-href");
+  const named = outlineNamedBy(href);
+  return named === undefined
+    ? page.locator(`${FOCUSED_PANE} ${DONE_FLIP}`)
+    : page.locator(`${FOCUSED_PANE} ${DONE_FLIP}${attr("data-file", named)}`);
+};
+
 /** One segment of the flip beside the FOCUSED pane's filter: this page's own
  *  say. Its value-space is the override map's — `shown` / `hidden` — where
  *  the panel's segments answer in the row's own `visible` / `hidden`
@@ -287,19 +314,16 @@ const flipDone = async (
   page: Page,
   word: "shown" | "hidden",
 ): Promise<void> => {
-  const pick = page
-    .locator(`${FOCUSED_PANE} ${DONE_FLIP}`)
-    .locator(`${PREFS_CHOICE}${attr("data-value", word)}`);
+  const flip = await flipOfAddressed(page);
+  const pick = flip.locator(`${PREFS_CHOICE}${attr("data-value", word)}`);
   await pick.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
   await pick.click();
   // Scored to THE SEGMENT PRESSED: either the press landed (the segment
   // that was not in force now is) or the ask was a deliberate no-op (the
   // in-force side already carries it — at pace the same selector, at no
   // cost — a no-op IS the read a press makes of this strip now.
-  await page
-    .locator(
-      `${FOCUSED_PANE} ${DONE_FLIP} ${PREFS_CHOICE}${attr("data-value", word)}[aria-pressed="true"]`,
-    )
+  await flip
+    .locator(`${PREFS_CHOICE}${attr("data-value", word)}[aria-pressed="true"]`)
     .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
 };
 
@@ -309,10 +333,10 @@ Then(
     if (word !== "shown" && word !== "hidden") {
       throw new Error(`Done is "shown" or "hidden", not "${word}"`);
     }
-    await this.page
+    const flip = await flipOfAddressed(this.page);
+    await flip
       .locator(
-        `${FOCUSED_PANE} ${DONE_FLIP} ` +
-          `${PREFS_CHOICE}${attr("data-value", word)}[aria-pressed="true"]`,
+        `${PREFS_CHOICE}${attr("data-value", word)}[aria-pressed="true"]`,
       )
       .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
   },

--- a/packages/tests/step_definitions/preferences_steps.ts
+++ b/packages/tests/step_definitions/preferences_steps.ts
@@ -343,14 +343,16 @@ Then(
 );
 
 Then("the Done flip is this page's own", async function (this: OlaiWorld) {
-  await this.page
-    .locator(`${FOCUSED_PANE} ${DONE_FLIP}${attr("data-own", "true")}`)
+  const flip = await flipOfAddressed(this.page);
+  await flip
+    .and(this.page.locator(`${DONE_FLIP}${attr("data-own", "true")}`))
     .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
 });
 
 Then("the Done flip is the panel's answer", async function (this: OlaiWorld) {
-  await this.page
-    .locator(`${FOCUSED_PANE} ${DONE_FLIP}:not(${attr("data-own", "true")})`)
+  const flip = await flipOfAddressed(this.page);
+  await flip
+    .and(this.page.locator(`${DONE_FLIP}:not(${attr("data-own", "true")})`))
     .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
 });
 
@@ -409,9 +411,8 @@ When("I show the done nodes", async function (this: OlaiWorld) {
  *  back to the panel, and that is deliberately a door one CLUTTER-free
  *  second near a strip cannot miss (client/filter/DoneFlip.tsx). */
 When("I hand the page's Done pick back to the panel", async function (this: OlaiWorld) {
-  await this.page
-    .locator(`${FOCUSED_PANE} ${DONE_FLIP} ${attr("data-testid", TESTID.doneRelease)}`)
-    .click();
+  const flip = await flipOfAddressed(this.page);
+  await flip.locator(attr("data-testid", TESTID.doneRelease)).click();
 });
 
 /**

--- a/packages/tests/step_definitions/preferences_steps.ts
+++ b/packages/tests/step_definitions/preferences_steps.ts
@@ -18,6 +18,8 @@ import * as assert from "node:assert";
 import { Then, When } from "@cucumber/cucumber";
 import type { Page } from "playwright";
 
+import { fileKind } from "@olai/format";
+
 import {
   ALERT_SOUND_KEY,
   ALERTS_KEY,
@@ -281,12 +283,16 @@ const DONE_FLIP = attr("data-testid", TESTID.doneFlip);
 const FOCUSED_PANE = attr("data-pane-focused", "true");
 
 /** The outline a pane's `data-href` names, or nothing — `/` is the first
- *  outline and does not spell a file; a node permalink does not either. */
+ *  outline and does not spell a file; a node permalink does not either.
+ *  Asked of `fileKind`, not of a spelled suffix: kinds.test.ts is the
+ *  fence, and the registry is the one place that list exists. */
 const outlineNamedBy = (href: string | null): string | undefined => {
   if (href === null || href === "") return undefined;
-  const path = decodeURIComponent(href.split("?")[0] ?? "");
-  if (!path.endsWith(".olai")) return undefined;
-  return path.replace(/^\//, "");
+  const path = decodeURIComponent(href.split("?")[0] ?? "").replace(
+    /^\//,
+    "",
+  );
+  return fileKind(path) === "outline" ? path : undefined;
 };
 
 /** The flip of the ADDRESSED page, not a held previous one.

--- a/packages/web/src/client/filter/DoneFlip.tsx
+++ b/packages/web/src/client/filter/DoneFlip.tsx
@@ -71,6 +71,7 @@ export function DoneFlip(props: { readonly file: string }) {
       aria-label={said()}
       class="inline-flex items-center gap-1"
       data-testid={TESTID.doneFlip}
+      data-file={props.file}
       data-own={own() ? "true" : undefined}
       title={said()}
     >

--- a/packages/web/src/client/testids.ts
+++ b/packages/web/src/client/testids.ts
@@ -1137,8 +1137,10 @@ export const TESTID = {
   filterInput: "filter-input",
   /** The page's own out-vote on done-visibility, beside the filter: a
    *  (filter/) two-segment strip, `data-own` while the page holds an entry
-   *  against the panel's default. Outline pages only — a day, the agenda,
-   *  the trash get the bar without it (settings/done.ts). */
+   *  against the panel's default. `data-file` is the outline it speaks for —
+   *  the held previous page during a swap still wears its own. Outline pages
+   *  only — a day, the agenda, the trash get the bar without it
+   *  (settings/done.ts). */
   doneFlip: "done-flip",
   /** The release door of the flip — the `·` mark, a button while the page
    *  owns its say: the flip's two segments ask, the mark hands the pick


### PR DESCRIPTION
The flake (ledger `dfsqxh2k`, two sightings 2026-08-30 ~14:40 and ~14:50 ET): e2e@aarch64-darwin (ci@petit), two consecutive full-suite runs at 1695e5d2, different scenarios, the same locator — the done-flip prefs-choice, 15s timeout.

## The cause

`I open the outline` starts at `/`, which is the first outline (`Daily/2026-08.olai` in the good corpus). `createReading` **holds** that tree while the named outline is in flight. Waiting for any `outline-tree` therefore matches the previous page. One rAF is vsync, not the swap — the same class as `the_header_sticks.feature:93` (#445). The next step's done-flip prefs-choice is then the **held** page's; the press (or the Then) is lost when the swap remounts the flip for the page the address actually named.

Measured on this worktree, unthrottled, original wait:

| When | Drawn file vs wanted `house.olai` |
|---|---|
| After the container wait, before the rAF | **2/8** still `Daily/2026-08.olai` (href already `/house.olai`) |
| At `flipDone`, after the rAF | **0/20** still Daily |

The 15s miss itself did not reproduce on linux. Pre-fix loops of the affected one-offs:

| Shape | Result |
|---|---|
| `OLAI_TEST_SLOW=20` ×12 `see_the_outline.feature:16` | **12/12** |
| `OLAI_TEST_SLOW=20` ×8 `preferences.feature:93` | **8/8** |
| `SUITES=5 RUNS=4` (see_the_outline + preferences + filter_in_place) | **20/20**, 0 drops |
| `BUSY=32` ×8 `see_the_outline.feature:16` | **8/8** |

The hold window is the cause; darwin + parallel workers is the shape that makes one rAF lose, as #445 named.

The opener waits for a **row of the named file**. The flip wait (When and Then) is keyed on `data-file` of the pane's href — the flip of the addressed page, not a held previous one. No timeout widened.

## Post-fix (same one-offs)

| Shape | Result |
|---|---|
| see_the_outline + preferences + filter_in_place + zoom_and_navigate | **66/66** |
| preferences + zoom_and_navigate (after the Then wait) | **44/44** |
| `OLAI_TEST_SLOW=20` ×8 `see_the_outline.feature:16` | **8/8** |
| `SUITES=5 RUNS=4` (same three features as pre-fix) | **20/20**, 0 drops |

Address round (pi's SHOULD + two NITs): `just typecheck` green (20 packages); preferences + zoom_and_navigate + the_chrome_holds_still **48/48**. Merge latest master: merge-base == `origin/master` (`04750ad2`); master has not moved, so the merge is a no-op.

## Design decisions

- **Wait on the named file's row, not any tree plus a rAF.** The container is already visible from `/`. A row of the opened file is the swap. Same lesson as #445's jump: wait on what the step needs. `I click the outline` waits the same way — it was the last carrier of the rAF shape.
- **Key the flip locator on `data-file`.** The strip already knew which outline it spoke for; publishing it means the gesture cannot match a held previous page's prefs-choice. `/` and a node permalink spell no file in the href and keep the unscoped wait — those are cold loads, not a hold: `I open the node` is `openNode` in `world.ts`, a fresh document (`goto /#id`), so there is no previous tree to hold. The two `data-own` Thens and the release-door When ride `flipOfAddressed` with the rest, so they cannot pass on a held page either.
- **Not a product race in the pick.** The hold is `createReading`'s swap, which is the right product. The test was clicking the page that was still on screen.

## Deferrals

No deferrals.