### PR TITLE
The timing chip's hover tells the whole story the record knows

### DIFF
--- a/packages/tests/step_definitions/outline_tree_steps.ts
+++ b/packages/tests/step_definitions/outline_tree_steps.ts
@@ -34,6 +34,7 @@ import {
   OUTLINE_TREE,
   POLL_TIMEOUT,
   TAG,
+  TIP,
   TOGGLE,
   TOOK,
   ZOOM,
@@ -312,14 +313,26 @@ Then(
       async () => /^\d+$/.test((await chip.getAttribute("data-took")) ?? ""),
       `the node "${id}" wears a settled took chip (data-took of whole seconds)`,
     );
-    // And the hover says the exact figure, in words, off the same attr —
-    // whole seconds while it is under a minute, which every scenario here
-    // keeps its span, so `took 7s` is the shape the tooltip is held to.
+    // And the HOVER, which is the app's own tip now (the platform's `title`
+    // ran off the window's right edge — web/src/client/Tip.tsx says why the
+    // move). Every scenario here settles one round inside the minute, so the
+    // tip's one line is the figure off the same attr plus the window the
+    // record carried: `took 7s — the one round: <started> → <settled>`.
     const seconds = parseInt((await chip.getAttribute("data-took")) ?? "-1", 10);
     assert.ok(seconds >= 0 && seconds < 60, `"${id}"'s took attr is ${seconds}s`);
+    await chip.hover();
     await this.waitUntil(
-      async () => (await chip.getAttribute("title")) === `took ${seconds}s`,
-      `the node "${id}"'s chip hovers the exact figure ("took ${seconds}s")`,
+      async () => {
+        const said = await this.page
+          .locator(TIP)
+          .innerText()
+          .catch(() => "");
+        return (
+          said.startsWith(`took ${seconds}s — the one round: `) &&
+          said.includes(" → ")
+        );
+      },
+      `the node "${id}"'s chip hovers the whole story ("took ${seconds}s — the one round: … → …")`,
     );
   },
 );

--- a/packages/tests/step_definitions/outline_tree_steps.ts
+++ b/packages/tests/step_definitions/outline_tree_steps.ts
@@ -320,16 +320,27 @@ Then(
     // record carried: `took 7s — the one round: <started> → <settled>`.
     const seconds = parseInt((await chip.getAttribute("data-took")) ?? "-1", 10);
     assert.ok(seconds >= 0 && seconds < 60, `"${id}"'s took attr is ${seconds}s`);
-    await chip.hover();
     await this.waitUntil(
       async () => {
+        // The hover is RE-ASKED on every try, not trusted from before the
+        // wait: a scroll — a fragment's reveal, an agent landing under the
+        // pointer — retracts an opened tip by design (Tip.tsx: the pane
+        // scrolling IS the leave), and no event says so. The gesture must
+        // live inside the poll, the way the saatchi walk's retry did.
+        await chip.hover();
+        // EXACTLY one tip, and the story in it — the doubled-tooltip catch
+        // navigation_steps.ts keeps: every TEXT assertion passed while two
+        // copies of one sentence were on screen.
         const said = await this.page
           .locator(TIP)
-          .innerText()
-          .catch(() => "");
+          .allInnerTexts()
+          .catch(() => [] as string[]);
+        const [one] = said;
         return (
-          said.startsWith(`took ${seconds}s — the one round: `) &&
-          said.includes(" → ")
+          said.length === 1 &&
+          one !== undefined &&
+          one.startsWith(`took ${seconds}s — the one round: `) &&
+          one.includes(" → ")
         );
       },
       `the node "${id}"'s chip hovers the whole story ("took ${seconds}s — the one round: … → …")`,

--- a/packages/tests/step_definitions/outline_tree_steps.ts
+++ b/packages/tests/step_definitions/outline_tree_steps.ts
@@ -325,8 +325,11 @@ Then(
         // The hover is RE-ASKED on every try, not trusted from before the
         // wait: a scroll — a fragment's reveal, an agent landing under the
         // pointer — retracts an opened tip by design (Tip.tsx: the pane
-        // scrolling IS the leave), and no event says so. The gesture must
-        // live inside the poll, the way the saatchi walk's retry did.
+        // scrolling IS the leave), and no event says so. And the pointer
+        // is moved AWAY first: a tip opens on `mouseenter` alone, and a
+        // hover() over the point the pointer already rests fires none —
+        // without the away the retry asks nothing and can never recover.
+        await this.page.mouse.move(40, 40);
         await chip.hover();
         // EXACTLY one tip, and the story in it — the doubled-tooltip catch
         // navigation_steps.ts keeps: every TEXT assertion passed while two

--- a/packages/web/src/client/Tip.tsx
+++ b/packages/web/src/client/Tip.tsx
@@ -30,12 +30,12 @@
  * is a fact about the text and the window rather than one we can be told.
  */
 
-import { createSignal, type JSX, onCleanup, onMount, Show } from "solid-js"
+import { createEffect, createSignal, type JSX, onCleanup, onMount, Show } from "solid-js"
 import { Portal } from "solid-js/web"
 
 import { LAYER } from "./layer.ts"
 import { TESTID } from "./testids.ts"
-import { clampedLeft, clampedTop, hideTip, showTip, takeTip, tipShowing } from "./tip.ts"
+import { clampedLeft, clampedTop, hideTip, MARGIN, showTip, takeTip, tipShowing } from "./tip.ts"
 
 interface At {
   readonly left: number
@@ -89,9 +89,29 @@ export function Tip(props: {
   onCleanup(hide)
 
   const place = (tip: HTMLDivElement): void => {
+    const want = at()
+    if (want === undefined) return
+    // Read the TRUE box by parking it at the window's edge for the read:
+    // where the tip first draws — under a control that hugs the window's
+    // right edge — the box's own room is only what was left of the window
+    // past it, and the box wraps to THAT floor before the clamp ever
+    // slides it (the wrap never un-winds). Parked at the edge, the read is
+    // the wide box the words ask for, and it is THAT box the clamp may
+    // have to move — never a floor-standed one.
+    tip.style.left = "0px"
     const box = tip.getBoundingClientRect()
-    const left = clampedLeft(box.left, box.width, window.innerWidth)
-    if (left !== box.left) setAt((was) => was === undefined ? was : { ...was, left })
+    const left = clampedLeft(want.left, box.width, window.innerWidth)
+    // And the window's floor is the second clamp of the same clamp: a
+    // multi-line story hung under the LAST row of a page falls past the
+    // scrollable bottom entirely — flip the tip over its anchor rather
+    // than half-paint it.
+    const top = box.height + MARGIN + want.top > window.innerHeight
+      ? Math.max(MARGIN, window.innerHeight - MARGIN - box.height)
+      : want.top
+    if (left !== want.left || top !== want.top)
+      setAt((was) => (was === undefined ? was : { ...was, left, top }))
+    tip.style.left = `${left}px`
+    tip.style.top = `${top}px`
   }
 
   /** The tip itself, in a portal at the end of the document. Its own component
@@ -111,11 +131,23 @@ export function Tip(props: {
       window.addEventListener("scroll", hide, { capture: true, passive: true })
       onCleanup(() => window.removeEventListener("scroll", hide, true))
     })
+    // The clamp was measured for the text AS DRAWN. A tip that MOVES — the
+    // ⏱ chip's story ticks — can widen past the edge it was measured
+    // against, so a change in the words asks the clamp again; the run's own
+    // effect wrote the new text ahead of this one (creation order), so the
+    // rectangle read here is already the widened one.
+    createEffect(() => {
+      props.text
+      if (tip !== undefined) place(tip)
+    })
 
     return (
       <div
         ref={tip}
-        class={`pointer-events-none fixed ${props.layer ?? LAYER.page} max-w-[min(24rem,calc(100vw-1rem))] rounded-sm border border-rule/70 bg-panel px-2 py-1 text-xs text-ink shadow-sm`}
+        // `whitespace-pre-line` rather than plain wrapping: a story told in
+        // LINES (the ⏱ chip's rounds, one per line) must not collapse into
+        // one run — and a text without newlines is drawn exactly as before.
+        class={`pointer-events-none fixed ${props.layer ?? LAYER.page} max-w-[min(24rem,calc(100vw-1rem))] rounded-sm border border-rule/70 bg-panel px-2 py-1 text-xs whitespace-pre-line text-ink shadow-sm`}
         style={{ left: `${drawn.at.left}px`, top: `${drawn.at.top}px` }}
         data-testid={TESTID.tip}
         role="presentation"

--- a/packages/web/src/client/Tip.tsx
+++ b/packages/web/src/client/Tip.tsx
@@ -97,7 +97,7 @@ export function Tip(props: {
     // past it, and the box wraps to THAT floor before the clamp ever
     // slides it (the wrap never un-winds). Parked at the edge, the read is
     // the wide box the words ask for, and it is THAT box the clamp may
-    // have to move — never a floor-standed one.
+    // have to move — never a width-starved one.
     tip.style.left = "0px"
     const box = tip.getBoundingClientRect()
     const left = clampedLeft(want.left, box.width, window.innerWidth)

--- a/packages/web/src/client/Tip.tsx
+++ b/packages/web/src/client/Tip.tsx
@@ -37,12 +37,18 @@ import { LAYER } from "./layer.ts"
 import { TESTID } from "./testids.ts"
 import { clampedLeft, clampedTop, hideTip, liftedTop, showTip, takeTip, tipShowing } from "./tip.ts"
 
+/**
+ * Where the tip ASKS to be — never where it landed: `place` writes the
+ * RESOLVED position onto the drawn tip's style alone and never back into
+ * this, so a re-place on new words re-derives from the anchor's truth
+ * instead of drifting off its own last answer.
+ */
 interface At {
   readonly left: number
   readonly top: number
   /** The bar's bottom edge, or 0 when there is none — the lift
-   *  (`./tip.ts`'s `liftedTop`) may never cross it, so it is carried with
-   *  the ask: a RE-ask on new words must answer with the same floor. */
+   *  (`./tip.ts`'s `liftedTop`) adds its own gap on top, so it is carried
+   *  with the ask: a RE-ask on new words must answer with the same floor. */
   readonly floor: number
 }
 
@@ -50,7 +56,11 @@ export function Tip(props: {
   /** What the tip says. The control it wraps says the same thing in its
    *  `aria-label`, so this is never the only copy. */
   readonly text: string
-  /** The control being explained. */
+  /** The control being explained. It MUST be the wrapper's first element
+   *  child: the tip's rectangle is read off exactly that (the wrapper is
+   *  `display: contents` and has no box of its own). Companions that are
+   *  not the control — an sr-only echo — come AFTER it, as the ⏱ chip's
+   *  copy does. */
   readonly children: JSX.Element
   /**
    * Which of the page's stack this tip rides. Defaults to the page: a tip
@@ -109,8 +119,6 @@ export function Tip(props: {
     // a fact: `./tip.ts`'s table, clampedLeft's sibling — under the last
     // row of a page it is a LIFT, and it never crosses the bar's floor.
     const top = liftedTop(want.top, box.height, window.innerHeight, want.floor)
-    if (left !== want.left || top !== want.top)
-      setAt((was) => (was === undefined ? was : { ...was, left, top }))
     tip.style.left = `${left}px`
     tip.style.top = `${top}px`
   }

--- a/packages/web/src/client/Tip.tsx
+++ b/packages/web/src/client/Tip.tsx
@@ -35,11 +35,15 @@ import { Portal } from "solid-js/web"
 
 import { LAYER } from "./layer.ts"
 import { TESTID } from "./testids.ts"
-import { clampedLeft, clampedTop, hideTip, MARGIN, showTip, takeTip, tipShowing } from "./tip.ts"
+import { clampedLeft, clampedTop, hideTip, liftedTop, showTip, takeTip, tipShowing } from "./tip.ts"
 
 interface At {
   readonly left: number
   readonly top: number
+  /** The bar's bottom edge, or 0 when there is none — the lift
+   *  (`./tip.ts`'s `liftedTop`) may never cross it, so it is carried with
+   *  the ask: a RE-ask on new words must answer with the same floor. */
+  readonly floor: number
 }
 
 export function Tip(props: {
@@ -79,7 +83,7 @@ export function Tip(props: {
     // right edge.
     const header = document.querySelector(`[data-testid="${TESTID.appHeader}"]`)
     const floor = header?.getBoundingClientRect().bottom ?? 0
-    setAt({ left: box.left, top: clampedTop(box.bottom, floor) })
+    setAt({ left: box.left, top: clampedTop(box.bottom, floor), floor })
     showTip(me)
   }
 
@@ -101,13 +105,10 @@ export function Tip(props: {
     tip.style.left = "0px"
     const box = tip.getBoundingClientRect()
     const left = clampedLeft(want.left, box.width, window.innerWidth)
-    // And the window's floor is the second clamp of the same clamp: a
-    // multi-line story hung under the LAST row of a page falls past the
-    // scrollable bottom entirely — flip the tip over its anchor rather
-    // than half-paint it.
-    const top = box.height + MARGIN + want.top > window.innerHeight
-      ? Math.max(MARGIN, window.innerHeight - MARGIN - box.height)
-      : want.top
+    // The vertical half of the same settling, now that the drawn height is
+    // a fact: `./tip.ts`'s table, clampedLeft's sibling — under the last
+    // row of a page it is a LIFT, and it never crosses the bar's floor.
+    const top = liftedTop(want.top, box.height, window.innerHeight, want.floor)
     if (left !== want.left || top !== want.top)
       setAt((was) => (was === undefined ? was : { ...was, left, top }))
     tip.style.left = `${left}px`

--- a/packages/web/src/client/live/duration/TookChip.tsx
+++ b/packages/web/src/client/live/duration/TookChip.tsx
@@ -97,8 +97,13 @@ function GoingChip(props: { readonly started: string; readonly worked: number | 
         data-started={props.started}
       >
         ⏱ {tickingOf(liveOf(banked(), instantOf(props.started) ?? now(), now()))}
-        <span class="sr-only">{story()}</span>
       </span>
+      {/* BESIDE the chip, never inside it: the e2e asks the chip's
+          innerText as proof the FACE moved, and the story's own words tick
+          on the same clock — folded in, a dead face with a live story
+          would still read as moving. Same document order for a reader with
+          no eyes; the tip's wrapper adds no box. */}
+      <span class="sr-only">{story()}</span>
     </Tip>
   )
 }
@@ -158,8 +163,10 @@ export function TookChip(props: {
                 data-took={chip().seconds}
               >
                 ⏱ {wordsOf(chip().seconds)}
-                <span class="sr-only">{story()}</span>
               </span>
+              {/* Beside the chip — the going arm's comment says why the
+                  copy never folds INTO the face. */}
+              <span class="sr-only">{story()}</span>
             </Tip>
           )
         }}

--- a/packages/web/src/client/live/duration/TookChip.tsx
+++ b/packages/web/src/client/live/duration/TookChip.tsx
@@ -1,6 +1,7 @@
 /**
  * The ⏱ chip at a row's far hand: how long the work TOOK, or how long it has
- * been GOING.
+ * been GOING — the face deliberately concise, the HOVER telling the whole
+ * story.
  *
  * THE TWO STATES THE ROW CAN BE IN, drawn differently because they read
  * differently (`projects/olai/prototypes/timing-mock.html`, ruled):
@@ -31,6 +32,15 @@
  * `storedMarker` of the shown record, so a caller-passed status would be one
  * fact spelled twice, and a mirror's target is already followed either way).
  *
+ * THE HOVER IS THIS APP's OWN TIP, never the platform's `title` — the same
+ * move the waiting glyph and the uptime pill made: the chip hugs the row's
+ * RIGHT edge, which is the exact place a platform tooltip runs off the
+ * window (`../../Tip.tsx` is the tip built for it), and the story below is
+ * more than a sentence. The visually-hidden copy says the same words, so
+ * the hover is never the only telling (`./took.ts`'s `liveStoryOf` /
+ * `settledStoryOf` — the rounds the record still windows, in order, the
+ * bank where it can only sum them).
+ *
  * ONE TRUTHINESS PIT, pin-sharp: a row set doing and settled inside the same
  * second has a span of `0` — a real one, and the prototype says the chip
  * wears it ("a `0s` does appear — honest places read zero"). `<Match
@@ -51,7 +61,8 @@ import { Match, Switch } from "solid-js"
 
 import { instantOf } from "../../clock.ts"
 import { TESTID } from "../../testids.ts"
-import { createNow, exactOf, liveOf, tickingOf, wordsOf } from "./took.ts"
+import { Tip } from "../../Tip.tsx"
+import { createNow, liveOf, liveStoryOf, settledStoryOf, tickingOf, wordsOf } from "./took.ts"
 
 /** The quiet register both halves of the chip share — the ¶-counter's own:
  *  mono, reading-size, muted. */
@@ -76,18 +87,19 @@ const GOING = `${CHIP} text-accent bg-accent/10 tabular-nums`
 function GoingChip(props: { readonly started: string; readonly worked: number | undefined }) {
   const now = createNow(() => props.started)
   const banked = () => props.worked ?? 0
+  const story = () => liveStoryOf(props.worked, props.started, now()).join("\n")
   return (
-    <span
-      class={GOING}
-      data-testid={TESTID.took}
-      data-status="doing"
-      data-started={props.started}
-      title={banked() > 0
-        ? `${exactOf(banked())} already banked — under way again since ${props.started}`
-        : `under way since ${props.started}`}
-    >
-      ⏱ {tickingOf(liveOf(banked(), instantOf(props.started) ?? now(), now()))}
-    </span>
+    <Tip text={story()}>
+      <span
+        class={GOING}
+        data-testid={TESTID.took}
+        data-status="doing"
+        data-started={props.started}
+      >
+        ⏱ {tickingOf(liveOf(banked(), instantOf(props.started) ?? now(), now()))}
+        <span class="sr-only">{story()}</span>
+      </span>
+    </Tip>
   )
 }
 
@@ -121,17 +133,31 @@ export function TookChip(props: {
             landing under this page moves the seconds UNDER the wrapper — a
             destructured read would be this client's own promise (the page
             follows the files without a reload) quietly dropped. */}
-        {(chip) => (
-          <span
-            class={SETTLED}
-            data-testid={TESTID.took}
-            data-status={storedMarker(props.node)}
-            data-took={chip().seconds}
-            title={`took ${exactOf(chip().seconds)}`}
-          >
-            ⏱ {wordsOf(chip().seconds)}
-          </span>
-        )}
+        {(chip) => {
+          const story = () => {
+            const mark = storedMarker(props.node)
+            return settledStoryOf({
+              took: chip().seconds,
+              banked: props.node.worked,
+              started: props.node.started,
+              settled:
+                (mark === "done" || mark === "cancelled" ? props.node[mark] : undefined) ?? true,
+            }).join("\n")
+          }
+          return (
+            <Tip text={story()}>
+              <span
+                class={SETTLED}
+                data-testid={TESTID.took}
+                data-status={storedMarker(props.node)}
+                data-took={chip().seconds}
+              >
+                ⏱ {wordsOf(chip().seconds)}
+                <span class="sr-only">{story()}</span>
+              </span>
+            </Tip>
+          )
+        }}
       </Match>
     </Switch>
   )

--- a/packages/web/src/client/live/duration/TookChip.tsx
+++ b/packages/web/src/client/live/duration/TookChip.tsx
@@ -62,7 +62,7 @@ import { Match, Switch } from "solid-js"
 import { instantOf } from "../../clock.ts"
 import { TESTID } from "../../testids.ts"
 import { Tip } from "../../Tip.tsx"
-import { createNow, liveOf, liveStoryOf, settledStoryOf, tickingOf, wordsOf } from "./took.ts"
+import { createNow, liveOf, liveStoryOf, roundOf, settledStoryOf, tickingOf, wordsOf } from "./took.ts"
 
 /** The quiet register both halves of the chip share — the ¶-counter's own:
  *  mono, reading-size, muted. */
@@ -139,9 +139,14 @@ export function TookChip(props: {
             return settledStoryOf({
               took: chip().seconds,
               banked: props.node.worked,
-              started: props.node.started,
-              settled:
-                (mark === "done" || mark === "cancelled" ? props.node[mark] : undefined) ?? true,
+              // The record's own shape is read once, at this edge — the
+              // undated `true`, a buried stamp, an unreadable end all land
+              // as NO round (`./took.ts`'s roundOf), never as a word in a
+              // sentence.
+              round: roundOf(
+                props.node.started,
+                mark === "done" || mark === "cancelled" ? props.node[mark] : undefined,
+              ),
             }).join("\n")
           }
           return (

--- a/packages/web/src/client/live/duration/took.test.ts
+++ b/packages/web/src/client/live/duration/took.test.ts
@@ -12,7 +12,9 @@
  * What is NOT here: whether there is a span to say at all. That is derived
  * with the set (@olai/format's `tookOf`, whose cases — the jump, the running
  * row, the instant-free settle, the bank — are its own test), and this
- * file's ladders are handed a number.
+ * file's ladders are handed a number. What IS here is that answer's
+ * story-side half: `roundOf`, the one place the record's raw marks become
+ * a round the story can tell — or none.
  */
 
 import { describe, expect, test } from "bun:test"
@@ -22,6 +24,7 @@ import {
   exactOf,
   liveOf,
   liveStoryOf,
+  roundOf,
   settledStoryOf,
   tickingOf,
   wordsOf,
@@ -154,19 +157,55 @@ describe("the live chip's story", () => {
   })
 })
 
-describe("the settled chip's story", () => {
+describe("the round the record still windows", () => {
   const STARTED = "2026-08-29T09:52:00-04:00"
   const SETTLED = "2026-08-29T12:26:44-04:00"
 
+  test("both ends read: the pair, and the span between them", () => {
+    expect(roundOf(STARTED, SETTLED))
+      .toEqual({ started: STARTED, settled: SETTLED, span: 9284 })
+    // Ends out of order are the settle's own clamp: a real zero, never a
+    // negative the bank could not have counted.
+    expect(roundOf(SETTLED, STARTED))
+      .toEqual({ started: SETTLED, settled: STARTED, span: 0 })
+  })
+
+  test("no round is said as no round — the three honest absences", () => {
+    // The stamp was buried.
+    expect(roundOf(undefined, SETTLED)).toBeUndefined()
+    // The close was never an instant: work finished before olai stamped
+    // anything settles to `true`, and never marked at all settles to
+    // nothing.
+    expect(roundOf(STARTED, true)).toBeUndefined()
+    expect(roundOf(STARTED, undefined)).toBeUndefined()
+    // A hand wrote one of the ends.
+    expect(roundOf("tuesday-ish", SETTLED)).toBeUndefined()
+  })
+})
+
+describe("the settled chip's story", () => {
+  const STARTED = "2026-08-29T09:52:00-04:00"
+  const SETTLED = "2026-08-29T12:26:44-04:00"
+  // 2h 34m 44s between the two instants — roundOf's figure, handed in the
+  // way the chip hands it.
+  const ROUND = { started: STARTED, settled: SETTLED, span: 9284 }
+
   test("the single round: took, and the window that is also the wall", () => {
-    expect(settledStoryOf({ took: 9284, banked: undefined, started: STARTED, settled: SETTLED }))
+    expect(settledStoryOf({ took: 9284, banked: undefined, round: ROUND }))
       .toEqual([
         "took 2h 34m 44s — round 1: 2026-08-29T09:52:00-04:00 → 2026-08-29T12:26:44-04:00",
       ])
   })
 
+  test("neither a bank nor a round says the figure and no more", () => {
+    // A story the chip itself could never have drawn — its `took` derives
+    // from exactly those two — but the function invents no window for it.
+    expect(settledStoryOf({ took: 7, banked: undefined, round: undefined }))
+      .toEqual(["took 7s"])
+  })
+
   test("one banked round reads the same shape — the window answers the wall", () => {
-    expect(settledStoryOf({ took: 9284, banked: 9284, started: STARTED, settled: SETTLED }))
+    expect(settledStoryOf({ took: 9284, banked: 9284, round: ROUND }))
       .toEqual([
         "took 2h 34m 44s — the one round: 2026-08-29T09:52:00-04:00 → 2026-08-29T12:26:44-04:00",
       ])
@@ -179,8 +218,11 @@ describe("the settled chip's story", () => {
       settledStoryOf({
         took: 4869,
         banked: 4869,
-        started: "2026-08-30T12:02:37-04:00",
-        settled: "2026-08-30T12:32:23-04:00",
+        round: {
+          started: "2026-08-30T12:02:37-04:00",
+          settled: "2026-08-30T12:32:23-04:00",
+          span: 1786, // 29m 46s — and the lump is the remaining 51m 23s.
+        },
       }),
     ).toEqual([
       "took 1h 21m 9s — the pauses between the rounds never counted",
@@ -190,18 +232,16 @@ describe("the settled chip's story", () => {
   })
 
   test("a bank whose windows are all gone says the sum, never invents one", () => {
-    expect(settledStoryOf({ took: 4869, banked: 4869, started: undefined, settled: SETTLED }))
-      .toEqual([
-        "took 1h 21m 9s — rounds banked where each closed, the pauses between them never counted",
-      ])
-    // …and the settle may hold `true`: the close was never an instant.
-    expect(settledStoryOf({ took: 4869, banked: 4869, started: STARTED, settled: true }))
+    // The stamp buried, or the close never an instant — either reading of
+    // the record arrives here as the same `undefined` (roundOf's cases are
+    // its own table above).
+    expect(settledStoryOf({ took: 4869, banked: 4869, round: undefined }))
       .toEqual([
         "took 1h 21m 9s — rounds banked where each closed, the pauses between them never counted",
       ])
     // …but a hand-written ZERO bank with no window is even that claim shy of
     // what it can prove, so the tip holds to the one derived figure.
-    expect(settledStoryOf({ took: 0, banked: 0, started: undefined, settled: SETTLED }))
+    expect(settledStoryOf({ took: 0, banked: 0, round: undefined }))
       .toEqual(["took 0s"])
   })
 
@@ -209,16 +249,17 @@ describe("the settled chip's story", () => {
   // lump is floored at zero, so the tip reads as the one-round shape and
   // never a negative figure.
   test("a record whose window outruns its bank claims no lump", () => {
-    expect(settledStoryOf({ took: 600, banked: 300, started: STARTED, settled: SETTLED }))
+    expect(settledStoryOf({ took: 600, banked: 300, round: ROUND }))
       .toEqual([
         "took 10m — the one round: 2026-08-29T09:52:00-04:00 → 2026-08-29T12:26:44-04:00",
       ])
   })
 
   test("an honest zero is a story too", () => {
-    expect(settledStoryOf({ took: 0, banked: 0, started: STARTED, settled: STARTED }))
-      .toEqual([
-        "took 0s — the one round: 2026-08-29T09:52:00-04:00 → 2026-08-29T09:52:00-04:00",
-      ])
+    expect(
+      settledStoryOf({ took: 0, banked: 0, round: { started: STARTED, settled: STARTED, span: 0 } }),
+    ).toEqual([
+      "took 0s — the one round: 2026-08-29T09:52:00-04:00 → 2026-08-29T09:52:00-04:00",
+    ])
   })
 })

--- a/packages/web/src/client/live/duration/took.test.ts
+++ b/packages/web/src/client/live/duration/took.test.ts
@@ -18,7 +18,14 @@
 import { describe, expect, test } from "bun:test"
 
 import { DAY, HOUR, MINUTE, SECOND } from "../../clock.ts"
-import { exactOf, liveOf, tickingOf, wordsOf } from "./took.ts"
+import {
+  exactOf,
+  liveOf,
+  liveStoryOf,
+  settledStoryOf,
+  tickingOf,
+  wordsOf,
+} from "./took.ts"
 
 describe("the settled words", () => {
   test("coarse, and coarser as the span grows", () => {
@@ -99,5 +106,119 @@ describe("the banked sum", () => {
     // The wire's instant out-running the browser is a skew to clamp, not a
     // debt the counted rounds should repay.
     expect(liveOf(600, AT, AT - 30 * SECOND)).toBe(600 * SECOND)
+  })
+})
+
+describe("the live chip's story", () => {
+  const AT = Date.parse("2026-08-29T09:50:00-04:00")
+  const STARTED = "2026-08-29T09:50:00-04:00"
+
+  test("a single round reads naturally — close to the tip's old words", () => {
+    expect(liveStoryOf(undefined, STARTED, AT + 47 * SECOND))
+      .toEqual(["round 1, under way since 2026-08-29T09:50:00-04:00"])
+    // A bank of zero reads the same: a same-second round closed is no
+    // earlier story to tell.
+    expect(liveStoryOf(0, STARTED, AT + 47 * SECOND))
+      .toEqual(["round 1, under way since 2026-08-29T09:50:00-04:00"])
+  })
+
+  test("a banked row enumerates the rounds the bank distinguishes, in order", () => {
+    expect(liveStoryOf(600, STARTED, AT + 252 * SECOND)).toEqual([
+      "10m already banked over the rounds before this one",
+      "this round under way again since 2026-08-29T09:50:00-04:00 — 4m 12s so far",
+      "14m 12s worked in all — the pauses between the rounds never counted",
+    ])
+  })
+
+  // The bank's own rounding, the settle's: the tip claims the figure the
+  // settle will bank, never the floor of it the face shows for one more
+  // second.
+  test("the live span rounds the way the bank does", () => {
+    expect(liveStoryOf(600, STARTED, AT + (240 * SECOND + 700)))
+      .toContain("this round under way again since 2026-08-29T09:50:00-04:00 — 4m 1s so far")
+  })
+
+  test("a start ahead of this clock reads an honest zero of it", () => {
+    expect(liveStoryOf(600, STARTED, AT - 30 * SECOND)).toEqual([
+      "10m already banked over the rounds before this one",
+      "this round under way again since 2026-08-29T09:50:00-04:00 — 0s so far",
+      "10m worked in all — the pauses between the rounds never counted",
+    ])
+  })
+
+  // The chip's arm matched on a parseable start before this ran, so this is
+  // belt for a hand-written record: the words, and no invented span.
+  test("an unreadable instant is said, never subtracted", () => {
+    expect(liveStoryOf(600, "next monday-ish", AT))
+      .toEqual(["round 1, under way since next monday-ish"])
+  })
+})
+
+describe("the settled chip's story", () => {
+  const STARTED = "2026-08-29T09:52:00-04:00"
+  const SETTLED = "2026-08-29T12:26:44-04:00"
+
+  test("the single round: took, and the window that is also the wall", () => {
+    expect(settledStoryOf({ took: 9284, banked: undefined, started: STARTED, settled: SETTLED }))
+      .toEqual([
+        "took 2h 34m 44s — round 1: 2026-08-29T09:52:00-04:00 → 2026-08-29T12:26:44-04:00",
+      ])
+  })
+
+  test("one banked round reads the same shape — the window answers the wall", () => {
+    expect(settledStoryOf({ took: 9284, banked: 9284, started: STARTED, settled: SETTLED }))
+      .toEqual([
+        "took 2h 34m 44s — the one round: 2026-08-29T09:52:00-04:00 → 2026-08-29T12:26:44-04:00",
+      ])
+  })
+
+  test("several rounds split the bank from the windowed one, in order", () => {
+    // `lane-lrd-address` of the roadmap vault, verbatim: the earlier rounds
+    // closed 51m 23s into the bank, the last one windowed by the pair.
+    expect(
+      settledStoryOf({
+        took: 4869,
+        banked: 4869,
+        started: "2026-08-30T12:02:37-04:00",
+        settled: "2026-08-30T12:32:23-04:00",
+      }),
+    ).toEqual([
+      "took 1h 21m 9s — the pauses between the rounds never counted",
+      "the rounds before the last banked 51m 23s of it",
+      "the last ran 29m 46s: 2026-08-30T12:02:37-04:00 → 2026-08-30T12:32:23-04:00",
+    ])
+  })
+
+  test("a bank whose windows are all gone says the sum, never invents one", () => {
+    expect(settledStoryOf({ took: 4869, banked: 4869, started: undefined, settled: SETTLED }))
+      .toEqual([
+        "took 1h 21m 9s — rounds banked where each closed, the pauses between them never counted",
+      ])
+    // …and the settle may hold `true`: the close was never an instant.
+    expect(settledStoryOf({ took: 4869, banked: 4869, started: STARTED, settled: true }))
+      .toEqual([
+        "took 1h 21m 9s — rounds banked where each closed, the pauses between them never counted",
+      ])
+    // …but a hand-written ZERO bank with no window is even that claim shy of
+    // what it can prove, so the tip holds to the one derived figure.
+    expect(settledStoryOf({ took: 0, banked: 0, started: undefined, settled: SETTLED }))
+      .toEqual(["took 0s"])
+  })
+
+  // The windowed round outrunning the bank is a record a hand wrote: the
+  // lump is floored at zero, so the tip reads as the one-round shape and
+  // never a negative figure.
+  test("a record whose window outruns its bank claims no lump", () => {
+    expect(settledStoryOf({ took: 600, banked: 300, started: STARTED, settled: SETTLED }))
+      .toEqual([
+        "took 10m — the one round: 2026-08-29T09:52:00-04:00 → 2026-08-29T12:26:44-04:00",
+      ])
+  })
+
+  test("an honest zero is a story too", () => {
+    expect(settledStoryOf({ took: 0, banked: 0, started: STARTED, settled: STARTED }))
+      .toEqual([
+        "took 0s — the one round: 2026-08-29T09:52:00-04:00 → 2026-08-29T09:52:00-04:00",
+      ])
   })
 })

--- a/packages/web/src/client/live/duration/took.ts
+++ b/packages/web/src/client/live/duration/took.ts
@@ -34,7 +34,7 @@ import type { Accessor } from "solid-js"
 
 import { spanOf } from "@olai/format"
 
-import { createTwoSpeed, HOUR, instantOf, SECOND } from "../../clock.ts"
+import { createTwoSpeed, HOUR, SECOND } from "../../clock.ts"
 
 /**
  * A SETTLED span in the chip's own words — the coarsest that still tell the
@@ -170,21 +170,20 @@ export const createNow = (
  *
  * `started` is the wire's instant, KNOWN parseable — the chip's own arm
  * matched on exactly that before this ever ran, so an unreadable one here
- * says the words and no span rather than nothing at all. The live span and
- * the in-all total use the bank's own rounding ({@link spanOf}'s): the
- * figure the tip claims is the one the settle will bank, never the floor
- * of it the face's own tick is showing for one more second.
+ * says the words and no span rather than nothing at all. The live span
+ * asks {@link spanOf}'s OWN question, `now` standing in for the settling
+ * instant: the figure the tip claims is by construction the one the settle
+ * will bank, never the floor of it the face's own tick is showing for one
+ * more second.
  */
 export const liveStoryOf = (
   bankedSeconds: number | undefined,
   started: string,
   now: number,
 ): ReadonlyArray<string> => {
-  const startedAt = instantOf(started)
-  if (startedAt === null) return [`round 1, under way since ${started}`]
   const banked = bankedSeconds ?? 0
-  const round = Math.max(0, Math.round((now - startedAt) / 1000))
-  if (banked <= 0) return [`round 1, under way since ${started}`]
+  const round = spanOf(started, new Date(now).toISOString())
+  if (round === undefined || banked <= 0) return [`round 1, under way since ${started}`]
   return [
     `${exactOf(banked)} already banked over the rounds before this one`,
     `this round under way again since ${started} — ${exactOf(round)} so far`,
@@ -193,39 +192,74 @@ export const liveStoryOf = (
 }
 
 /**
+ * The one round a settled record still WINDOWS, parsed: both instants and
+ * the span between them — {@link roundOf}'s answer, or `undefined` where no
+ * honest round remains.
+ */
+export interface WindowedRound {
+  readonly started: string
+  readonly settled: string
+  /** Whole seconds between the two ends — {@link spanOf}'s own figure, so
+   *  this window and the bank are always the same arithmetic. */
+  readonly span: number
+}
+
+/**
+ * The record's raw settle shape read ONCE, at the record's edge, into the
+ * round the story can tell — or `undefined`, three honest ways:
+ *
+ *   - the stamp is GONE — a hand or a merge buried `started` under a later
+ *     write, or none was ever stored;
+ *   - the close was never an instant: the settling mark holds the undated
+ *     `true` of work finished before olai stamped anything — or there is no
+ *     settling mark at all;
+ *   - an end will not read as an instant — a record someone wrote by hand.
+ *
+ * Each is a refusal to invent a window, and the story downstream never has
+ * to name a shape the record cannot be in. Ends OUT OF ORDER are not a
+ * fourth: {@link spanOf} clamps them to the zero the settle itself would
+ * have counted, and the round stands.
+ */
+export const roundOf = (
+  started: string | undefined,
+  settled: string | true | undefined,
+): WindowedRound | undefined => {
+  if (started === undefined || typeof settled !== "string") return undefined
+  const span = spanOf(started, settled)
+  return span === undefined ? undefined : { started, settled, span }
+}
+
+/**
  * A SETTLED chip's tip: `took` first — the total is the figure the chip's
  * face already coarsens, and it heads the story the way it headed the bare
  * tip before — then the split the bank makes possible.
  *
- * `settled` is the settling mark's own value, which can be the undated
- * `true` of work finished before olai stamped anything: then the close is
- * no instant and there is no window to show even when a stamp survives.
- * When the bank outruns the one windowed round there is a LUMP to say —
- * `worked` minus it — and a hand-written record can outrun the bank the
- * other way too, so the lump is asked with a floor of zero and no
- * reconciliation is ever claimed.
+ * `round` arrives PARSED ({@link roundOf}) — the window the record still
+ * names, or `undefined` where no honest round remains. When the bank
+ * outruns the one windowed round there is a LUMP to say — `worked` minus
+ * the window — and a hand-written record can outrun the bank the other way
+ * too, so the lump is asked with a floor of zero and no reconciliation is
+ * ever claimed. A total with NEITHER a bank nor a round is one the chip
+ * could never have drawn (its `took` derives from exactly those), so that
+ * arm says the figure and no more.
  */
 export const settledStoryOf = (args: {
   /** The derived total, whole seconds — `tookOf`'s own answer. */
   readonly took: number
   /** The record's own `worked` — absent when no round has ever closed. */
   readonly banked: number | undefined
-  /** The record's own `started` — the window's only living end. */
-  readonly started: string | undefined
-  /** The settling instant, or `true` on a settle before instants. */
-  readonly settled: string | true
+  /** The round the record still windows, parsed — or gone. */
+  readonly round: WindowedRound | undefined
 }): ReadonlyArray<string> => {
-  const { took, banked, started, settled } = args
-  const window =
-    started !== undefined && typeof settled === "string"
-      ? spanOf(started, settled)
-      : undefined
+  const { took, banked, round } = args
   if (banked === undefined) {
     // The slimmer arm of `tookOf` — the span IS the one window, and the
     // chip only drew because there was one to take.
-    return [`took ${exactOf(took)} — round 1: ${started} → ${settled}`]
+    return round === undefined
+      ? [`took ${exactOf(took)}`]
+      : [`took ${exactOf(took)} — round 1: ${round.started} → ${round.settled}`]
   }
-  if (window === undefined) {
+  if (round === undefined) {
     // Every round's window is gone (the stamp was buried, or the close
     // was never an instant): the bank is all of it, and the tip says so
     // rather than adding a figure the record cannot back. A hand-written
@@ -236,14 +270,14 @@ export const settledStoryOf = (args: {
       `took ${exactOf(took)} — rounds banked where each closed, the pauses between them never counted`,
     ]
   }
-  const lump = Math.max(0, banked - window)
+  const lump = Math.max(0, banked - round.span)
   if (lump === 0) {
     // The one banked round: its window and the wall are one subtraction.
-    return [`took ${exactOf(took)} — the one round: ${started} → ${settled}`]
+    return [`took ${exactOf(took)} — the one round: ${round.started} → ${round.settled}`]
   }
   return [
     `took ${exactOf(took)} — the pauses between the rounds never counted`,
     `the rounds before the last banked ${exactOf(lump)} of it`,
-    `the last ran ${exactOf(window)}: ${started} → ${settled}`,
+    `the last ran ${exactOf(round.span)}: ${round.started} → ${round.settled}`,
   ]
 }

--- a/packages/web/src/client/live/duration/took.ts
+++ b/packages/web/src/client/live/duration/took.ts
@@ -78,7 +78,7 @@ export const exactOf = (seconds: number): string => {
   const minutes = Math.floor(s / 60)
   const hours = Math.floor(minutes / 60)
   if (hours >= 24) parts.push(`${Math.floor(hours / 24)}d`)
-  if (hours % 24 !== 0 || (hours >= 1 && hours < 24)) parts.push(`${hours % 24}h`)
+  if (hours % 24 !== 0) parts.push(`${hours % 24}h`)
   if (minutes % 60 !== 0 || hours === 0) parts.push(`${minutes % 60}m`)
   if (s % 60 !== 0 || minutes === 0) parts.push(`${s % 60}s`)
   return parts.join(" ")
@@ -219,6 +219,11 @@ export interface WindowedRound {
  * to name a shape the record cannot be in. Ends OUT OF ORDER are not a
  * fourth: {@link spanOf} clamps them to the zero the settle itself would
  * have counted, and the round stands.
+ *
+ * It sits here because the story is its only teller today; the day a
+ * second reader wants the window — a server render, an MCP answer — the
+ * record's shape is @olai/format's to read, and this is `tookOf`'s
+ * sibling there.
  */
 export const roundOf = (
   started: string | undefined,

--- a/packages/web/src/client/live/duration/took.ts
+++ b/packages/web/src/client/live/duration/took.ts
@@ -22,11 +22,19 @@
  * settled" is spelled at a frame rate, and the two readers cannot drift.
  * What IS here is the running figure's one addition ({@link liveOf}):
  * banked plus live, the sum the closed rounds make possible.
+ *
+ * And the HOVER's sentences: the chip's face stays as concise as it was,
+ * so the whole story of the work's timing is told on the tip
+ * ({@link liveStoryOf} / {@link settledStoryOf}) — the rounds the record
+ * can still enumerate, in order, and the bank where it can only sum them.
+ * The breakdown is pure like the ladders, with `now` an argument.
  */
 
 import type { Accessor } from "solid-js"
 
-import { createTwoSpeed, HOUR, SECOND } from "../../clock.ts"
+import { spanOf } from "@olai/format"
+
+import { createTwoSpeed, HOUR, instantOf, SECOND } from "../../clock.ts"
 
 /**
  * A SETTLED span in the chip's own words — the coarsest that still tell the
@@ -130,3 +138,112 @@ export const liveOf = (
 export const createNow = (
   started: Accessor<string | number | undefined | null>,
 ): Accessor<number> => createTwoSpeed(started, HOUR)
+
+// ── the hover: the whole story the record can tell ─────────────────────
+
+/**
+ * What the record CAN enumerate, and what it can only sum.
+ *
+ * A round opens when `set_doing` stamps `started` and closes where its
+ * `doing` comes off — settled, queued, or un-started — banking its span
+ * into `worked` (@olai/ops's plan). The record therefore holds AT MOST one
+ * round still windowed — the current one, or the one a settle just closed
+ * (the stamp survives exactly so the pair with the settling instant stays
+ * honest) — plus the SUM of every round before it. The earlier windows are
+ * gone: restamping `started` on the next start is what made the pause
+ * between rounds nobody's work, and it is also why round 2's opening
+ * overwrote round 1's.
+ *
+ * So the rounds line up here the way the BANK knows them, never with
+ * numbers a sum cannot vouch for: the rounds before the windowed one
+ * arrive as one banked figure, the windowed one with its own span and its
+ * instants. Where a round IS the whole story it is numbered, and its
+ * window is also the WALL — first start to last settle, or to now while
+ * running — because that span and the wall are the same subtraction when
+ * exactly one round has ever run. Where several rounds ran, the wall's
+ * first end left the record with the rest of the windows, and the tip
+ * says the bank rather than inventing a start.
+ */
+
+/**
+ * A DOING chip's tip: the rounds so far, in order, and the work in all.
+ *
+ * `started` is the wire's instant, KNOWN parseable — the chip's own arm
+ * matched on exactly that before this ever ran, so an unreadable one here
+ * says the words and no span rather than nothing at all. The live span and
+ * the in-all total use the bank's own rounding ({@link spanOf}'s): the
+ * figure the tip claims is the one the settle will bank, never the floor
+ * of it the face's own tick is showing for one more second.
+ */
+export const liveStoryOf = (
+  bankedSeconds: number | undefined,
+  started: string,
+  now: number,
+): ReadonlyArray<string> => {
+  const startedAt = instantOf(started)
+  if (startedAt === null) return [`round 1, under way since ${started}`]
+  const banked = bankedSeconds ?? 0
+  const round = Math.max(0, Math.round((now - startedAt) / 1000))
+  if (banked <= 0) return [`round 1, under way since ${started}`]
+  return [
+    `${exactOf(banked)} already banked over the rounds before this one`,
+    `this round under way again since ${started} — ${exactOf(round)} so far`,
+    `${exactOf(banked + round)} worked in all — the pauses between the rounds never counted`,
+  ]
+}
+
+/**
+ * A SETTLED chip's tip: `took` first — the total is the figure the chip's
+ * face already coarsens, and it heads the story the way it headed the bare
+ * tip before — then the split the bank makes possible.
+ *
+ * `settled` is the settling mark's own value, which can be the undated
+ * `true` of work finished before olai stamped anything: then the close is
+ * no instant and there is no window to show even when a stamp survives.
+ * When the bank outruns the one windowed round there is a LUMP to say —
+ * `worked` minus it — and a hand-written record can outrun the bank the
+ * other way too, so the lump is asked with a floor of zero and no
+ * reconciliation is ever claimed.
+ */
+export const settledStoryOf = (args: {
+  /** The derived total, whole seconds — `tookOf`'s own answer. */
+  readonly took: number
+  /** The record's own `worked` — absent when no round has ever closed. */
+  readonly banked: number | undefined
+  /** The record's own `started` — the window's only living end. */
+  readonly started: string | undefined
+  /** The settling instant, or `true` on a settle before instants. */
+  readonly settled: string | true
+}): ReadonlyArray<string> => {
+  const { took, banked, started, settled } = args
+  const window =
+    started !== undefined && typeof settled === "string"
+      ? spanOf(started, settled)
+      : undefined
+  if (banked === undefined) {
+    // The slimmer arm of `tookOf` — the span IS the one window, and the
+    // chip only drew because there was one to take.
+    return [`took ${exactOf(took)} — round 1: ${started} → ${settled}`]
+  }
+  if (window === undefined) {
+    // Every round's window is gone (the stamp was buried, or the close
+    // was never an instant): the bank is all of it, and the tip says so
+    // rather than adding a figure the record cannot back. A hand-written
+    // record can carry a ZERO bank, where even that claim is more than the
+    // record supports — and the derived total alone is what it has.
+    if (banked <= 0) return [`took ${exactOf(took)}`]
+    return [
+      `took ${exactOf(took)} — rounds banked where each closed, the pauses between them never counted`,
+    ]
+  }
+  const lump = Math.max(0, banked - window)
+  if (lump === 0) {
+    // The one banked round: its window and the wall are one subtraction.
+    return [`took ${exactOf(took)} — the one round: ${started} → ${settled}`]
+  }
+  return [
+    `took ${exactOf(took)} — the pauses between the rounds never counted`,
+    `the rounds before the last banked ${exactOf(lump)} of it`,
+    `the last ran ${exactOf(window)}: ${started} → ${settled}`,
+  ]
+}

--- a/packages/web/src/client/tip.test.ts
+++ b/packages/web/src/client/tip.test.ts
@@ -51,11 +51,18 @@ test("even a one-line tip in the last pixels is lifted the few it needs", () => 
 
 // The bar hides nothing: the anchor sits INSIDE the header (the bar's
 // bottom edge is the floor), and a story taller than the room beneath it
-// is lifted no further than the floor — never under the bar itself, where
-// the coral rule would cut the first line. The extra hangs off the bottom,
-// which is exactly what a reader sees and can scroll out of.
+// is lifted no further than the floor plus the ask's own gap — never
+// under the bar itself, where the coral rule would cut the first line.
+// The extra hangs off the bottom, which is exactly what a reader sees and
+// can scroll out of.
 test("a lift never crosses the bar's floor", () => {
-  expect(liftedTop(48, 730, 760, 40)).toBe(40)
+  expect(liftedTop(48, 730, 760, 40)).toBe(40 + 4)
+})
+
+// No bar at all — a patient's page down the tree: the pin is the same
+// margin the sides keep, because zero is no floor to stand on.
+test("with no bar, the top pin is the margin itself", () => {
+  expect(liftedTop(100, 780, 760, 0)).toBe(8)
 })
 
 // ── one tip, ever ──────────────────────────────────────────────────────

--- a/packages/web/src/client/tip.test.ts
+++ b/packages/web/src/client/tip.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 
-import { clampedLeft, hideTip, showTip, takeTip, tipShowing } from "./tip.ts"
+import { clampedLeft, hideTip, liftedTop, showTip, takeTip, tipShowing } from "./tip.ts"
 
 // The ordinary case: a tip starts where the thing it is about starts.
 test("a tip that fits is drawn under its anchor", () => {
@@ -25,6 +25,37 @@ test("a tip wider than the window is pinned to the left margin", () => {
 // indented row, a window resized under an open tip.
 test("a tip never starts left of the margin", () => {
   expect(clampedLeft(0, 100, 1280)).toBe(8)
+})
+
+// ── the window's bottom, asked after the draw ──────────────────────────
+
+// A tip that fits where it was asked is left alone — most tips: the asked
+// top, the drawn height, and the window never argue.
+test("a tip with room below it stays where it was hung", () => {
+  expect(liftedTop(100, 28, 800, 40)).toBe(100)
+})
+
+// A LONG tip hung under the page's last row runs past the window's bottom
+// — the story tips did that as drawn. It is lifted until its bottom sits
+// at the window's margin: the words may ride over the anchor (the tip
+// never answers the pointer), but nothing hangs off the screen.
+test("a tip running past the window's bottom is lifted onto the margin", () => {
+  expect(liftedTop(400, 400, 760, 40)).toBe(760 - 400 - 8)
+})
+
+// One short line in the window's last pixels triggers the same lift — the
+// clamp knows nothing about callers, only heights.
+test("even a one-line tip in the last pixels is lifted the few it needs", () => {
+  expect(liftedTop(740, 28, 760, 40)).toBe(760 - 28 - 8)
+})
+
+// The bar hides nothing: the anchor sits INSIDE the header (the bar's
+// bottom edge is the floor), and a story taller than the room beneath it
+// is lifted no further than the floor — never under the bar itself, where
+// the coral rule would cut the first line. The extra hangs off the bottom,
+// which is exactly what a reader sees and can scroll out of.
+test("a lift never crosses the bar's floor", () => {
+  expect(liftedTop(48, 730, 760, 40)).toBe(40)
 })
 
 // ── one tip, ever ──────────────────────────────────────────────────────

--- a/packages/web/src/client/tip.ts
+++ b/packages/web/src/client/tip.ts
@@ -17,7 +17,7 @@
 import { createSignal } from "solid-js"
 
 /** How close to the window's edge a tip may come. */
-const MARGIN = 8
+export const MARGIN = 8
 
 /** How far below the anchor — or the header, if the anchor sits inside it —
  *  a tip starts. */

--- a/packages/web/src/client/tip.ts
+++ b/packages/web/src/client/tip.ts
@@ -53,6 +53,33 @@ export const clampedLeft = (
 export const clampedTop = (anchorBottom: number, floor: number): number =>
   Math.max(anchorBottom, floor) + TIP_GAP
 
+/**
+ * The top edge to RE-place a tip at once it has drawn and its height is a
+ * fact ({@link clampedTop} answers the ask before the height is known):
+ * the asked top, unless that would run the tip's bottom past the window's
+ * bottom margin — then it is LIFTED until the bottom sits at the margin.
+ *
+ * The lift never crosses the floor {@link clampedTop} enforced at the ask:
+ * an anchor inside the header asks below the bar's bottom edge, because the
+ * bar and its coral rule stack ABOVE the page layer — a tip lifted past
+ * that edge would be painted through, not merely covered. A tip taller
+ * than the room between the floor and the margin keeps the floor and
+ * overflows: no lift can help it, and pinning it would lie about both.
+ *
+ * This is arithmetic of one axis — a bottom cannot be clamped before the
+ * height exists, and the height is the caller's to read off the drawn box,
+ * the same fact-of-the-text-sharing {@link clampedLeft} declares.
+ */
+export const liftedTop = (
+  top: number,
+  tipHeight: number,
+  viewportHeight: number,
+  floor: number,
+): number =>
+  top + tipHeight + MARGIN > viewportHeight
+    ? Math.max(floor, viewportHeight - tipHeight - MARGIN)
+    : top
+
 // ── one tip, ever ──────────────────────────────────────────────────────
 
 /**

--- a/packages/web/src/client/tip.ts
+++ b/packages/web/src/client/tip.ts
@@ -17,7 +17,7 @@
 import { createSignal } from "solid-js"
 
 /** How close to the window's edge a tip may come. */
-export const MARGIN = 8
+const MARGIN = 8
 
 /** How far below the anchor — or the header, if the anchor sits inside it —
  *  a tip starts. */
@@ -59,12 +59,12 @@ export const clampedTop = (anchorBottom: number, floor: number): number =>
  * the asked top, unless that would run the tip's bottom past the window's
  * bottom margin — then it is LIFTED until the bottom sits at the margin.
  *
- * The lift never crosses the floor {@link clampedTop} enforced at the ask:
- * an anchor inside the header asks below the bar's bottom edge, because the
- * bar and its coral rule stack ABOVE the page layer — a tip lifted past
- * that edge would be painted through, not merely covered. A tip taller
- * than the room between the floor and the margin keeps the floor and
- * overflows: no lift can help it, and pinning it would lie about both.
+ * The lift never parks above the bar's floor PLUS the gap the ask itself
+ * was given ({@link clampedTop}'s spacing is the least a re-placement owes
+ * it), nor above the same top margin the sides keep. A tip taller than the
+ * room between that pin and the bottom margin keeps the pin and
+ * overflows: no lift can help it, and parking higher would lie about
+ * both ends.
  *
  * This is arithmetic of one axis — a bottom cannot be clamped before the
  * height exists, and the height is the caller's to read off the drawn box,
@@ -75,10 +75,14 @@ export const liftedTop = (
   tipHeight: number,
   viewportHeight: number,
   floor: number,
-): number =>
-  top + tipHeight + MARGIN > viewportHeight
-    ? Math.max(floor, viewportHeight - tipHeight - MARGIN)
+): number => {
+  // Bar below or no bar at all: without one the floor arg is zero, and
+  // the margin is the pin.
+  const pin = Math.max(floor + TIP_GAP, MARGIN)
+  return top + tipHeight + MARGIN > viewportHeight
+    ? Math.max(pin, viewportHeight - tipHeight - MARGIN)
     : top
+}
 
 // ── one tip, ever ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What this is

The ⏱ chip's face stays what #430/#435 pinned — a concise ticking register
while doing, a coarse settle afterwards. The **hover** now tells the whole
story the record knows how to back: the rounds in order with their spans,
the `worked` total, where the pauses never counted anyway.

## Design decisions

- **The hover is the app's own `<Tip>`, never the platform's `title`.** The
  chip hugs the row's right edge — the exact place a platform tooltip runs
  off the window, which is why that species exists (`Tip.tsx`) — and the
  story is more than a sentence. The same words ride a `<span
  class="sr-only">` BESIDE the chip, inside the tip's boxless wrapper (the
  uptime pill's precedent: hover is never the only telling) — and beside
  rather than inside because the e2e asks the chip's `innerText` as proof
  the FACE ticked, and the copy's own words tick on the same clock.
- **The story is filed from the bank, never invented.** The record (#435's
  counting) holds: `started` restamped on EVERY start, `worked` the sum of
  closed rounds, the settling instant. So at most ONE round is ever still
  windowed — the current one, or the one the settle just closed — plus ONE
  banked lump. Rounds before the last have no windows to enumerate and the
  tip says the lump rather than making one up. Five shapes fall out, in
  `took.ts`'s `liveStoryOf` / `settledStoryOf` with unit tables:
  - live, no bank: the round's start (near the brief's words);
  - live, banked: banked figure · this round under way with its span · in
    all, the pauses never counted;
  - settled, one round windowed: the `S → E` pair — which on a single-round
    record IS the wall, said without extra ceremony (first start to last
    settle is the same subtraction);
  - settled, lump + window: three lines, lump then the last window;
  - settled, windows all gone (the stamp buried, or the close never an
    instant): the banked sum alone; a zero bank there is just `took X`.
- **The record's raw settle shape is read ONCE, at the story's edge.**
  `roundOf(started, settled)` is the one place the mark's undated `true`, a
  buried stamp, and an unreadable end all become "no round"; every caller
  downstream holds a parsed `WindowedRound` — both instants and `spanOf`'s
  own span between them — and no sentence can ever carry the literal `true`
  or `undefined`.
- **Spans quote the bank's own arithmetic by construction**: the live span
  asks `spanOf`'s own question with `now` in the settling instant's place —
  the figure the settle will bank, never the face's floor of it for one
  more second.
- **What the EVIDENCE added to `Tip` — every upgrade is general, none
  chip-special.** Four changes, all inside Tip's own arithmetic and
  styling, no prop, no knob, no branch on who asked:
  (1) `whitespace-pre-line`, so a multi-line text does not collapse into
  one run — a text without newlines draws exactly as before;
  (2) a change in the tip's text re-asks the clamp (any ticking caller's
  words can widen past the measured edge);
  (3) `place()` parks the box at the window's edge to measure — a control
  hugging that edge starves a fresh fixed box of room, and it wraps at
  THAT floor before any clamp is asked;
  (4) the window's bottom is `liftedTop` in `tip.ts`, `clampedLeft`'s
  sibling: a tip whose hung position would run its bottom past the
  window's margin is lifted onto the margin, and the lift NEVER crosses
  the header's floor — an anchor inside the bar keeps the tip under the
  bar's bottom edge, where the coral rule cannot paint through it. Every
  tip takes the lift — a ONE-LINE tip anchored in a window's last pixels
  included; only the story-tall ones make the distance visible.
- **The e2e's own pin moved**: `outline_tree_steps.ts`'s settled-chip step
  re-asks the hover INSIDE its poll, pointer cleared from the point first —
  a tip opens on `mouseenter` alone, so a `hover()` where it already rests
  fires nothing, and a scroll retracts a tip by design without telling.
  Then it wants EXACTLY one tip in the document — the count
  `navigation_steps.ts` keeps as the doubled-tooltip catch — with both the
  figure and the record's window pair in it. The old pin read the
  platform's `title` attribute, whose asking never needed the gesture at
  all.

## Deferrals

- **The wall span is the brief's third figure, and the record cannot
  derive it.** `started` restamps on EVERY start — that restamping is
  exactly what makes the pause between rounds never a figure — so a
  multi-round record holds no first start. Deriving the wall would take
  one more stamp a settle refuses to pay for today:
  `first-started`-alongside-`started`, written on the FIRST start of a
  fresh record and never again. That is a record-shape decision the
  roadmap should take with its eyes open; the chip tells the two figures
  the record already backs, and says the bank where it cannot enumerate.
- `roundOf` sits next to its only teller (`took.ts`). The record's settle
  shape is @olai/format's to read, so the day a SECOND reader wants the
  windowed round — a server render, an MCP answer — it moves there,
  sibling to `tookOf`. Recorded in its docstring.

## Evidence

Shots against the working set's own vault records (a throwaway copy of
`oss.olai/projects/olai/roadmap`, never the live vault), one record per
story, one hover, one witness — plus the one shape verbs can only leave
indirectly, minted into the copy: `ev-buried`, `worked` with no window,
the shape an undone-settle-then-resettle leaves. The records:
`lane-tch-implement` (doing, single round), `ev-rounds` (doing, bank +
live round), `lane-lrd-implement` (settled, the one banked round),
`lane-lrd-address` (settled, several rounds against the one window), and
`ev-buried`.

![live-single-round](https://github.com/user-attachments/assets/78415ff1-141e-4523-ac25-ff5452971e0b)

![live-banked-rounds](https://github.com/user-attachments/assets/635b8da3-1dcf-4959-bebc-c18e4eb745ce)

![settled-one-round](https://github.com/user-attachments/assets/d409b0a6-c818-4c37-b0d0-e5f645da841d)

![settled-banked-rounds](https://github.com/user-attachments/assets/97db2e42-98d4-449d-b7d6-4f7297882baf)

![settled-buried-windows](https://github.com/user-attachments/assets/be8164f2-d5cf-4599-bbc6-eb0e1b3dd887)

<details><summary>The saatchi section (throwaway by convention)</summary>

```ts
/**
 * The timing chip's hover: the recorded record's whole story, photographed.
 *
 * Data (`.saatchi/data/roadmap/features.olai`): the WORKING TREE's own
 * roadmap copy, plus two lines minted into that copy only —
 * `ev-rounds`, a record an hour behind one closed 5m round with the second
 * live, and `ev-buried`, the shape verbs leave after an undone settle lands
 * again with nothing between: the bank stays, every window is gone.
 * Every other record is the roadmap's own: `lane-tch-implement` (doing,
 * single round), `lane-lrd-implement` (settled, the one banked round),
 * `lane-lrd-address` (settled, several rounds against one window).
 *
 * Each shot re-opens the roadmap's outline cold at the record's own
 * fragment — a row folded under a done lane is revealed when a link asks
 * for it, the app answering the ask — and settles on the chip itself,
 * which is the row reporting the record. One hover, one witness.
 */
import type { Saatchi } from "saatchi"

const TOOK = '[data-testid="took"]'
const TIP = '[data-testid="tip"]'

export default async ({ page, shot }: Saatchi) => {
  page.on("console", (m) => console.log("browser:", m.type(), m.text().slice(0, 200)))
  page.on("pageerror", (e) => console.log("pageerror:", String(e).slice(0, 300)))
  const story = async (id: string, name: string) => {
    // The section's page arrives at the served origin; the outline's
    // address is absolute against THAT, never a bare path — the context
    // carries no baseURL of its own. The id lands as the page's own
    // fragment on purpose: a row folded under a done lane is REVEALED when
    // a link asks for it — that is the app answering the ask, not this
    // section unhiding anything by hand.
    console.log(`stage ${name}: goto`)
    await page.goto(new URL(`/roadmap/features.olai#${id}`, page.url()).href)
    const row = page.locator(`[data-testid="node"][data-node-id="${id}"]`).first()
    await row.waitFor({ state: "attached" })
    // Center first, hover after — a hovers-only approach scrolls the ROW to
    // the pane's edge, which is exactly where a story-tall tip goes out
    // from under the pointer. The app's own scroll rule takes the tip with
    // the scroll; that is why the waiting time is on the chip, not on it.
    await row.evaluate((el) => el.scrollIntoView({ block: "center" }))
    const chip = row.locator(TOOK).first()
    await chip.waitFor({ state: "visible" })
    console.log(`stage ${name}: chip`)
    await chip.hover()
    try {
      await page.locator(TIP).waitFor({ state: "visible", timeout: 6000 })
    } catch {
      console.log(
        `stage ${name}: first visit missed the tip, second visit —`,
        await chip.evaluate((el: Element) =>
          `hover=${el.matches(":hover")} rect=${JSON.stringify(el.getBoundingClientRect())}`),
        "tips on page:", await page.locator(TIP).count(),
      )
      await page.mouse.move(40, 40)
      await chip.hover()
      await page.locator(TIP).waitFor({ state: "visible" })
    }
    await shot(name)
  }

  await story("lane-tch-implement", "live-single-round")
  await story("ev-rounds", "live-banked-rounds")
  await story("lane-lrd-implement", "settled-one-round")
  await story("lane-lrd-address", "settled-banked-rounds")
  await story("ev-buried", "settled-buried-windows")
}
```

</details>

Local gates at head `b9eb9c75` (no master drift): `just typecheck`; the
full unit suite (4718 pass / 0 fail); `native_timing.feature` with
`OLAI_BIN` on the nix binary (6 scenarios, 80 steps, all passed).
