### PR TITLE
The ACP pipe drops leftover stdout instead of throwing Controller is already closed

### DIFF
--- a/packages/chat/src/pipes.test.ts
+++ b/packages/chat/src/pipes.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The ACP pipe's close is load-bearing for every live subprocess, and the
+ * one place a dying child's leftover stdout used to throw
+ * `Controller is already closed` into the test (and into a stopped
+ * conversation). `deliveries.test.ts` is where that showed under full-suite
+ * load; this file is the cause, without a subprocess.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { EventEmitter } from "node:events"
+import type { Readable, Writable } from "node:stream"
+
+import { streamOver } from "./pipes.ts"
+
+/** Enough of a child's stdio for {@link streamOver}: stdout as an emitter
+ *  we can fire `data`/`end`/`error` on in any order, stdin as a sink. */
+const fake = (): { stdout: EventEmitter } => {
+  const stdout = new EventEmitter()
+  const stdin = {
+    write: (_chunk: unknown, cb?: (err?: Error | null) => void) => {
+      cb?.(null)
+      return true
+    },
+    end: () => {},
+    destroy: () => {},
+  }
+  streamOver({
+    stdin: stdin as Writable,
+    stdout: stdout as unknown as Readable,
+  })
+  return { stdout }
+}
+
+describe("a child's stdout after the controller has closed", () => {
+  test("a chunk before end still lands, and does not throw", () => {
+    const { stdout } = fake()
+    expect(() => stdout.emit("data", Buffer.from('{"jsonrpc":"2.0","id":1,"result":{}}\n'))).not.toThrow()
+    stdout.emit("end")
+  })
+
+  test("a chunk after end does not throw", () => {
+    const { stdout } = fake()
+    stdout.emit("end")
+    expect(() => stdout.emit("data", Buffer.from('{"jsonrpc":"2.0"}\n'))).not.toThrow()
+  })
+
+  test("a chunk after error does not throw", () => {
+    const { stdout } = fake()
+    stdout.emit("error", new Error("the pipe broke"))
+    expect(() => stdout.emit("data", Buffer.from('{"jsonrpc":"2.0"}\n'))).not.toThrow()
+  })
+
+  test("end then error is close twice, and that is harmless", () => {
+    const { stdout } = fake()
+    stdout.emit("end")
+    expect(() => stdout.emit("error", new Error("and then it broke"))).not.toThrow()
+  })
+})

--- a/packages/chat/src/pipes.ts
+++ b/packages/chat/src/pipes.ts
@@ -34,20 +34,49 @@ export const streamOver = (stdio: {
     throw new Error("the subprocess was spawned without pipes")
   }
 
+  // Stashed so `cancel` (`connection.close` then `child.stop`) can mark
+  // the controller closed the same way `end` does, before leftover stdout
+  // arrives.
+  let stop: (() => void) | undefined
   const readable = new ReadableStream<Uint8Array>({
     start(controller) {
-      // Both ends of the pipe close the same way, and a process exiting can
-      // deliver `end` AND `error` — so closing twice has to be harmless.
-      const close = () => {
+      // A process exiting can deliver `end` AND `error`, and a consumer
+      // cancel closes the controller while leftover stdout is still in
+      // flight. Close twice is already caught; enqueue AFTER close is the
+      // throw `Invalid state: Controller is already closed` — the
+      // load-dependent flake `deliveries.test.ts` showed under a full
+      // suite. Drop the chunk; the conversation is already gone.
+      let closed = false
+      const onData = (chunk: Buffer) => {
+        if (closed) return
+        try {
+          controller.enqueue(new Uint8Array(chunk))
+        } catch {
+          stop?.()
+        }
+      }
+      const onClose = () => {
+        stop?.()
         try {
           controller.close()
         } catch {
           // already closed
         }
       }
-      stdout.on("data", (chunk: Buffer) => controller.enqueue(new Uint8Array(chunk)))
-      stdout.on("end", close)
-      stdout.on("error", close)
+      stop = () => {
+        if (closed) return
+        closed = true
+        stdout.removeListener("data", onData)
+        stdout.removeListener("end", onClose)
+        // `error` stays: Node throws an unhandled `error` event, and a
+        // process exiting can still deliver one after `end`.
+      }
+      stdout.on("data", onData)
+      stdout.on("end", onClose)
+      stdout.on("error", onClose)
+    },
+    cancel() {
+      stop?.()
     },
   })
 


### PR DESCRIPTION
Shakeout lane: re-run full CI on the kolu-ci pool until two consecutive greens at the final head (≥4 runs total), and fold in the held `deliveries.test.ts` flake. No reviewer on this lane — CI is the gate; the orchestrator merges.

Loop closed: four sequential odu runs, last three at this head, last two consecutive green.

## Shakeout runs

Full CI via odu, `--platform x86_64-linux`, one run at a time, kolu-ci pool. Logs under `.ci/shakeout/run-N.log`.

| run | sha | host | verdict | notes |
|---|---|---|---|---|
| 1 | `e5d6171` (master, pre-fix) | kolu-ci-5 | **green** 11/11 | `test` 5048 pass / 0 fail; e2e 1038 passed. Deliveries flake did not fire. |
| 2 | `bcf72e72` (this head) | kolu-ci-9 | **green** 11/11 | first run at the fix |
| 3 | `bcf72e72` | kolu-ci-5 | **green** 11/11 | |
| 4 | `bcf72e72` | kolu-ci-9 | **green** 11/11 | `test` 5052 pass / 0 fail (the four new `pipes.test.ts` cases); e2e 1038 passed |

Runs 3 and 4 are the two consecutive greens at the final head.

## `packages/chat/src/deliveries.test.ts` — `Controller is already closed`

### Failure as observed

Verbatim, from the pin written against the unfixed `streamOver` (and matching #454's string under full-suite load):

```
error: expect(received).not.toThrow()

Error name: "TypeError"
Error message: "Invalid state: Controller is already closed"

(fail) a child's stdout after the controller has closed > a chunk after end does not throw
(fail) a child's stdout after the controller has closed > a chunk after error does not throw
```

Sightings: #453's author, 3 pass / 1 fail over 4 runs on master at `12b3b6ad`, 7 pass / 2 fail over 9 on its branch — same two cases, same stream error. #454's author, 2026-09-01, under full-suite load, green on re-run. #455 lost a 4957/1 identity to a `tail -4`. CI's `test` recipe has been green at every head this week.

**Run 1** of this shakeout did **not** surface it — consistent with that last fact. The pin does, every time, without a subprocess.

### Cause

It is the **product**, not the test. `packages/chat/src/pipes.ts` turns a child's stdout into a Web `ReadableStream`. The existing comment already knew a process exiting can deliver `end` AND `error`, so `controller.close()` was wrapped; `controller.enqueue()` on `data` was not.

Two ways the controller is already closed when a chunk arrives:

1. `end` or `error` closed it, then a late `data` (Bun's Node compatibility is why this file exists by hand).
2. The consumer cancelled first — `agent.stop` does `connection.close()` then `child.stop()`. Leftover stdout still in the pipe hits `enqueue`.

That is load-dependent because isolation usually drains the pipe before teardown; a full suite does not. A live conversation whose agent is stopped can throw the same way. The test was telling the truth.

### Fix

`streamOver` now tracks closed, ignores `data` after close, detaches `data`/`end` on stop, and `cancel()` takes the same path. `error` stays attached: Node throws an unhandled `error` event, and a process can still deliver one after `end`. The late chunk is dropped — the conversation is already gone.

Pinned in `pipes.test.ts` without a subprocess: emit `end` (or `error`), then `data`. Red before with the TypeError above; green after. `deliveries.test.ts` 28/28 and `@olai/chat` typecheck clean.

### Runs that saw it

- Historical: #453, #454, (likely) #455 — not this PR's run 1.
- This PR: the pin, red before `bcf72e72`, green after. Shakeout runs 2–4 at the fix were all green; the flake did not recur.

No other flake surfaced in four full-CI runs.

## Design decisions

**The throw belongs in the pipe, not in the doorbell test.** Settled by reproducing `enqueue` after `close` with an EventEmitter in place of a child — the same TypeError, no suite load, no fixture. A timeout bump or a retry in `deliveries.test.ts` would have hidden a product race on the ACP transport every conversation uses.

**Drop the chunk, do not surface it.** After `connection.close()` there is no conversation to hand the bytes to. Turning the late write into `controller.error()` would fail a stop that already succeeded.

## Deferrals

No deferrals.