### PR TITLE
The adapter pin's npm audit comes out clean: fast-uri and qs move inside their ranges

### DIFF
--- a/acp/package-lock.json
+++ b/acp/package-lock.json
@@ -661,9 +661,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -1114,9 +1114,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/nix/acp-agent.nix
+++ b/nix/acp-agent.nix
@@ -40,7 +40,7 @@ buildNpmPackage {
     filter = path: _type:
       baseNameOf path == "package.json" || baseNameOf path == "package-lock.json";
   };
-  npmDepsHash = "sha256-9JFTvDE4oq13P+I/AMpygqRNIri9Rl3fNOOz5uAfXCQ=";
+  npmDepsHash = "sha256-dCiEbsKRiCWle/OFr1qypIZQ7lrGhxStLli3zlck+GY=";
 
   # acp/ is a shim around its two pinned dependencies: nothing to compile,
   # and no package in the tree has an install script to run.


### PR DESCRIPTION
## The finding

`just run` runs `npm ci --ignore-scripts` inside `acp/` — the pinned chat adapter's tree — and npm reported, on `acp/package-lock.json`:

```
2 vulnerabilities (1 moderate, 1 high)
```

Both transitive dependencies of the pinned adapter tree (`@agentclientprotocol/claude-agent-acp` 0.73.0, bumped in #468). `npm audit` **before**:

| package | severity | path | advisories |
|---|---|---|---|
| fast-uri 3.1.5 | high | `@modelcontextprotocol/sdk` → `ajv` | GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp — host confusion / SSRF in URI normalization |
| qs 6.15.3 | moderate | `@modelcontextprotocol/sdk` → `express` / `body-parser` | GHSA-x5fp-wj9c-mxmx, GHSA-4mjr-xmp4-gh2g — array-limit bypass, DoS via attacker-controlled isBuffer |

`npm audit` **after**, on a fresh `npm ci --ignore-scripts` at this head:

```
found 0 vulnerabilities
```

## What changes

Two packages' `version` / `resolved` / `integrity` lines in `acp/package-lock.json` (6 lines), fast-uri 3.1.5 → **3.1.7** and qs 6.15.3 → **6.16.0** — both patched releases inside the ranges the tree already declares (`ajv` asks `^3.0.1`; `express` asks `^6.14.0`, `body-parser` `^6.15.2`). Plus the `npmDepsHash` in `nix/acp-agent.nix`, which is pinned to the lockfile's tarball set and so moves with it by construction.

Nothing else:

- **The pin does not move.** `@agentclientprotocol/claude-agent-acp` stays 0.73.0, `pi-acp` stays 0.0.33, `@modelcontextprotocol/sdk` stays 1.30.0.
- **No patch is touched**, and all three still apply loudly: the derivation build runs `patch -p1 -F0` on the extracted tree and it passes (`patch` would FATAL on drift). The built store tree was inspected directly: fast-uri 3.1.7, qs 6.16.0, adapter 0.73.0, patch markers present in both patched dists.

## Local suites

- `npm audit` in `acp/` — before/after as above.
- `nix build .#acp-agent` — patches apply at `-F0`; `just nix` builds the packaged binary and its wrapper still bakes both adapters.
- `just typecheck` — every workspace member, Exited with code 0.
- `just test` — 5268 pass / 0 fail across 374 files, plus the 92 browser-condition cases green. `bun test acp/` alone: 77 pass / 0 fail — relevant because the mcp-bridge roundtrips are where the bumped packages (ajv→fast-uri, the MCP SDK tree) actually load and run.
- `just fmt-check` — the one edited `.nix` is clean.

## The chat check

`packages/tests/panel-live.sh` — the driver's own purpose is a pin-tree change — against this worktree's built adapter and a local serve it stands up itself. **24 of its 26 claims PASS**, including the ones this PR's bar names: the panel opens, a conversation opens, a turn is sent **and answered**, queueing, interrupt, cancel, an armed Monitor's clock and its death notice in the harness's own word, a subagent's rail and the shelf its calls are read in.

Claims 25–26 fail, and they are **not this lockfile's** — see Deferrals.

## Design decisions

- **`npm audit fix`, no `--force`.** Both advisories are leaf-level and patched inside declared ranges, so the plain fix reaches zero with no semver-major move — no stop-and-ask earned. Anything beyond that shape would have stopped and asked instead.
- **Where the bumped packages can run.** The claude adapter's own dependency tree is `@agentclientprotocol/sdk` + `@anthropic-ai/claude-agent-sdk` + `zod`: it never loads ajv, express, qs, or fast-uri. They live under the shim's `@modelcontextprotocol/sdk`, which is the pi mcp-bridge's tree (and the unit roundtrips exercise it). The chat check therefore drives the claude panel end-to-end while the SDK side's exercise is the (green) bridge suite — a deliberate split, stated rather than implied.
- **Hash updated by the documented dance** in `nix/acp-agent.nix`'s header: `lib.fakeHash`, build, paste the printed hash.

## Deferrals

- **`panel-live.ts` section 7 can never pass in its own fresh vault, at HEAD, with or without this PR.** The section (added in #471) clicks the sidebar's `agent-unassigned` row; that row draws only when `unassigned().length > 0 || unreachable().length > 0`, and the listing behind it is asked **once, at provider mount** (`packages/web/src/client/agents/answered.tsx` — "the only unprompted round trip in this module"), when the driver's brand-new vault has zero stored conversations. The only re-ask is pressing that very row. Reproduced identically twice; the pkgs this PR moves are unreachable from the panel or the claude adapter, so this is #471's driver meeting its own door, not a regression here. Not fixed in this PR — it is a driver/panel question for the chat lane, named here so it is not lost: either the driver seeds a stored conversation (or presses through a second tab after one exists), or the panel re-asks on a settled turn.
- **The pi leg's live conversation is not re-driven here.** Its bridge path (where the bumped SDK lives) is covered by the unit roundtrips; a live kimi turn was the pin-bump lane's evidence (#422) and is unaffected by two tarballs' content hashes. If a reviewer wants it anyway, that is cheap to commission separately.

## Scope

Lockfile + its FOD hash only. No adapter move, no patch edit, no `npm audit fix --force`-shaped motion — per the brief, any of those would have been a stop-and-ask, and none were needed.