### PR TITLE
The pinned odu moves to 210b1710, which admits an MCP-spawned run dies with its host

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "2e7b30f6519a34f8cfc01ea334bff94d27f3a83a",
-      "url": "https://github.com/juspay/odu/archive/2e7b30f6519a34f8cfc01ea334bff94d27f3a83a.tar.gz",
-      "hash": "sha256-cZ3ZGR7YpK0OB0woY60Q5/I/KDjKkBClc80G3N5sN24="
+      "revision": "210b17101439e26d530a395e3d764caa4deee6ef",
+      "url": "https://github.com/juspay/odu/archive/210b17101439e26d530a395e3d764caa4deee6ef.tar.gz",
+      "hash": "sha256-9h9VCuv+jx5fx6RD9B1KIbylOl2bkhWNuFNIcjC3Eu0="
     },
     "osfacts": {
       "type": "Git",


### PR DESCRIPTION
The odu pin in `npins/sources.json` moves from `2e7b30f6` to `210b1710`.

That is juspay/odu master at [juspay/odu#98](https://github.com/juspay/odu/pull/98) ("Admit it: an MCP-spawned run dies with its host — and every face SAYS so"). The pin's dependency check (`just odu-deps`) agrees with `@odu/run-client` as-is; nothing else moved.

## Deferrals

No deferrals.