### PR TITLE
Shard unit tests across Linux workers

### DIFF
--- a/justfile
+++ b/justfile
@@ -140,21 +140,14 @@ typecheck: install
 # one commit having minted none — and it is gone with the loop: the quiet window
 # is the server's now (`@olai/ops`' `loop.ts`), so what used to need a browser
 # resolution is an ordinary unit test one package down.
+#
+# Odu may split this leaf across SIX Linux slots. Bun has no native shard flag,
+# so the script partitions the tracked test files deterministically; without
+# Odu's shard variables it retains the ordinary discovery-based `just test`
+# behaviour (including untracked tests during development).
+[metadata("odu:shard=6")]
 test: install
-    {{ nix_shell }} bun test
-    {{ nix_shell }} bun test --conditions browser \
-      ./packages/web/src/client/settled.browsertest.ts \
-      ./packages/web/src/client/fold/refiling.browsertest.ts \
-      ./packages/web/src/client/names.browsertest.ts \
-      ./packages/web/src/client/doors.browsertest.ts \
-      ./packages/web/src/client/licences.browsertest.ts \
-      ./packages/web/src/client/Tree.browsertest.ts \
-      ./packages/web/src/client/directory.browsertest.ts \
-      ./packages/web/src/client/chat/last.browsertest.ts \
-      ./packages/web/src/client/chat/attention/asked.browsertest.ts \
-      ./packages/web/src/client/chat/attention/elsewhere.browsertest.ts \
-      ./packages/web/src/client/chat/declared.browsertest.ts \
-      ./packages/plugins/kolu/src/appliance/props/held.browsertest.ts
+    {{ nix_shell }} bash scripts/test-shard.sh
 
 # The same suite, TO A LOG — for an agent, or for anyone who wants to read the
 # failures more than once.

--- a/nix/odu.nix
+++ b/nix/odu.nix
@@ -12,9 +12,8 @@
 #
 # THE PIN TRACKS MASTER at the exact revision this tree compiled against.
 # `just update-pins` walks it forward; `npins/sources.json` records the tested
-# revision in this diff. This branch temporarily pins the exact revision from
-# juspay/odu#101, which lets independent sharded leaves share burst capacity;
-# return to master after that prerequisite merges.
+# revision in this diff. The pinned master includes juspay/odu#101, which lets
+# independent sharded leaves share burst capacity.
 #
 # WHY THE SCRIPT IS KOLU'S. The copier is generic — `<src> <dest>` pairs, `cp
 # -rL` so a hydrated source's own imports resolve up into the root

--- a/nix/odu.nix
+++ b/nix/odu.nix
@@ -12,8 +12,9 @@
 #
 # THE PIN TRACKS MASTER at the exact revision this tree compiled against.
 # `just update-pins` walks it forward; `npins/sources.json` records the tested
-# revision in this diff. The current revision includes the sharded-recipe design
-# merged in juspay/odu#100.
+# revision in this diff. This branch temporarily pins the exact revision from
+# juspay/odu#101, which lets independent sharded leaves share burst capacity;
+# return to master after that prerequisite merges.
 #
 # WHY THE SCRIPT IS KOLU'S. The copier is generic — `<src> <dest>` pairs, `cp
 # -rL` so a hydrated source's own imports resolve up into the root

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,8 +61,8 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "c3a894c770fd8675c048c491cf4e3ddb6da11aef",
-      "url": "https://github.com/juspay/odu/archive/c3a894c770fd8675c048c491cf4e3ddb6da11aef.tar.gz",
+      "revision": "f5694f370923698ce240a67b258bc66b238b658b",
+      "url": "https://github.com/juspay/odu/archive/f5694f370923698ce240a67b258bc66b238b658b.tar.gz",
       "hash": "sha256-Up9rr5rdmv+YRnIC96qyBeB7aLwCMgHcpyyJtA5TASA="
     },
     "osfacts": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "aed7e2a05adeee02dca0d223c283670c11530d81",
-      "url": "https://github.com/juspay/odu/archive/aed7e2a05adeee02dca0d223c283670c11530d81.tar.gz",
-      "hash": "sha256-+kFunCj8phyFqzBAATitvqIBmbM07JaMUgVcICabjuY="
+      "revision": "c3a894c770fd8675c048c491cf4e3ddb6da11aef",
+      "url": "https://github.com/juspay/odu/archive/c3a894c770fd8675c048c491cf4e3ddb6da11aef.tar.gz",
+      "hash": "sha256-Up9rr5rdmv+YRnIC96qyBeB7aLwCMgHcpyyJtA5TASA="
     },
     "osfacts": {
       "type": "Git",

--- a/scripts/test-shard.sh
+++ b/scripts/test-shard.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+browser_files=(
+  ./packages/web/src/client/settled.browsertest.ts
+  ./packages/web/src/client/fold/refiling.browsertest.ts
+  ./packages/web/src/client/names.browsertest.ts
+  ./packages/web/src/client/doors.browsertest.ts
+  ./packages/web/src/client/licences.browsertest.ts
+  ./packages/web/src/client/Tree.browsertest.ts
+  ./packages/web/src/client/directory.browsertest.ts
+  ./packages/web/src/client/chat/last.browsertest.ts
+  ./packages/web/src/client/chat/attention/asked.browsertest.ts
+  ./packages/web/src/client/chat/attention/elsewhere.browsertest.ts
+  ./packages/web/src/client/chat/declared.browsertest.ts
+  ./packages/plugins/kolu/src/appliance/props/held.browsertest.ts
+)
+
+if [[ -z "${ODU_SHARD_INDEX+x}" && -z "${ODU_SHARD_TOTAL+x}" ]]; then
+  bun test
+  bun test --conditions browser "${browser_files[@]}"
+  exit
+fi
+
+if [[ -z "${ODU_SHARD_INDEX+x}" || -z "${ODU_SHARD_TOTAL+x}" ]]; then
+  echo "ODU_SHARD_INDEX and ODU_SHARD_TOTAL must be set together" >&2
+  exit 2
+fi
+
+if [[ ! "$ODU_SHARD_INDEX" =~ ^[0-9]+$ || ! "$ODU_SHARD_TOTAL" =~ ^[1-9][0-9]*$ ]]; then
+  echo "invalid Odu shard: index=$ODU_SHARD_INDEX total=$ODU_SHARD_TOTAL" >&2
+  exit 2
+fi
+
+if ((ODU_SHARD_INDEX >= ODU_SHARD_TOTAL)); then
+  echo "Odu shard index $ODU_SHARD_INDEX is outside total $ODU_SHARD_TOTAL" >&2
+  exit 2
+fi
+
+ordinary_files=()
+position=0
+while IFS= read -r -d '' file; do
+  case "$file" in
+    *.test.js | *.test.jsx | *.test.ts | *.test.tsx | *_test.js | *_test.jsx | *_test.ts | *_test.tsx | *.spec.js | *.spec.jsx | *.spec.ts | *.spec.tsx | *_spec.js | *_spec.jsx | *_spec.ts | *_spec.tsx)
+      if ((position % ODU_SHARD_TOTAL == ODU_SHARD_INDEX)); then
+        ordinary_files+=("./$file")
+      fi
+      ((position += 1))
+      ;;
+  esac
+done < <(LC_ALL=C git ls-files -z | LC_ALL=C sort -z)
+
+selected_browser_files=()
+for position in "${!browser_files[@]}"; do
+  if ((position % ODU_SHARD_TOTAL == ODU_SHARD_INDEX)); then
+    selected_browser_files+=("${browser_files[$position]}")
+  fi
+done
+
+echo "test shard $((ODU_SHARD_INDEX + 1))/$ODU_SHARD_TOTAL: ${#ordinary_files[@]} ordinary + ${#selected_browser_files[@]} browser-conditioned files"
+
+if ((${#ordinary_files[@]})); then
+  bun test "${ordinary_files[@]}"
+fi
+
+if ((${#selected_browser_files[@]})); then
+  bun test --conditions browser "${selected_browser_files[@]}"
+fi


### PR DESCRIPTION
## Why

After e2e was sharded, `test` became the next long CI leaf: 118.402s on the preceding Linux run. A six-host fleet should accelerate both independent leaves instead of partitioning workers between them.

## What changed

- mark `test` as a six-way Odu shard
- deterministically round-robin tracked Bun test files between slices
- split the curated browser-conditioned suite the same way
- retain ordinary Bun discovery when `just test` runs without Odu, so development still includes untracked tests
- pin the exact prerequisite from juspay/odu#101, which shares each leased worker across independent sharded leaves using isolated lanes

## Measurements

Measured with warm `just ci` runs on the same six-host Linux fleet; no test workload ran locally.

| | Before (`28be159`) | Exclusive allocation (`dfe66b94`) | Shared fleet (`a974c5d`) |
|---|---:|---:|---:|
| unit leaf | 118.402s (1 slice) | 56.636s (2 slices) | 43.760s (6 slices) |
| e2e leaf | 93.373s (6 slices) | 96.833s (5 slices) | 81.486s (6 slices) |
| full CI wall time | 151.873s | 146.675s | 98.143s |

Compared with the baseline, unit is 2.71x faster (63.0% less time), e2e is 12.7% faster, and full CI is 35.4% faster. Sharing the same five optional workers between both roots also cuts 33.1% from the intermediate exclusive-allocation wall time.

Coverage is unchanged: the six unit slices ran all 5,401 ordinary tests across 389 files plus all 92 browser-conditioned tests across 12 files, exactly once. E2e ran all 1,083 scenarios / 9,838 steps.

## Verification

`just ci` passed twice on remote Linux: 49 nodes, 0 failures/errors/skips/cancellations. The warm run took 98.143s. The UI and persisted run include every worker prerequisite, such as `test[2-of-6]::_ci-setup`, `test[2-of-6]::install`, and the corresponding setup/install/nix nodes for all e2e workers. GitHub receives only the logical CI contexts, not worker implementation details.

Merge order: juspay/odu#101 first, then update this temporary exact pin to the merged Odu master revision.