### PR TITLE
Bridge-owned provision, teardown order and cancellation (12a)

### DIFF
--- a/docs/dynamic-plugins.md
+++ b/docs/dynamic-plugins.md
@@ -161,3 +161,21 @@ Run it from a package that depends on `@olai/plugin-build` (`packages/server` do
 - **Not a report of what the FACE did.** A half whose `apply` throws lands the row on `failed` with its own sentence, on the server. A face that throws while it is being *drawn* does not: the tab's fault boundary contains it the way it contains a shipped plugin's, the console says which plugin it was, and the row goes on saying `running` — because on the server it is. That is the same gap every built plugin has, and closing it wants a field on the roster row's browser reading rather than a console line, so it is written down here rather than built in this lane.
 - **Not persisted enablement.** A `plugins.stop`, or the panel's switch on a definition, lasts as long as the process. What survives a restart is the definition and its approval, which are in the vault.
 - **Not a package.** There is no `olai plugin add`, no npins pin and no out-of-tree build. A definition is two notes in a directory olai is already serving.
+
+## Initialization and stopping
+
+A server half stays `waiting` while its `apply` initializes. Services it offers
+become available to consumers only after initialization succeeds. If it fails,
+its acquired registrations and resources are unwound and the row shows its fault.
+
+The panel's switch and `plugins.stop` can stop a half that is still initializing.
+Stopping interrupts its Effect work, waits for background work and cleanup, and
+then leaves it switched off. Losing a required service also interrupts
+initialization, but leaves the row `waiting`, naming the missing service; when
+that service returns, initialization runs again. Host shutdown closes every
+plugin, including one with no declared needs. Dependent cleanup finishes before
+the provider releases the resources those dependents use.
+
+Cancellation is cooperative: synchronous JavaScript cannot be preempted in this
+process, and uninterruptible acquisitions and finalizers must finish themselves.
+There is no per-plugin initialization timeout.

--- a/docs/running.md
+++ b/docs/running.md
@@ -286,6 +286,10 @@ you set by hand on the command line is a policy you set once and forget:
 
 **Turning a row off takes its dependants with it, and the panel says so.** The chat row stands behind four doors ([plugins/chat.md](plugins/chat.md)), so switching it off leaves every engine, every doorbell and the mirror `waiting` — each row naming the door it is short of. Switch chat back on and they re-start themselves; nothing has to be pressed twice, and a plugin that comes back is holding the same machine-local record it left.
 
+A service can have only one provider. If two plugins offer the same service,
+the second fails with a sentence naming both plugins and the service; the
+existing provider keeps running.
+
 **Stopping also reaches a plugin that is still starting.** The runtime
 interrupts its Effect initialization, waits for dependent cleanup while the
 provider's resources are still available, then releases its resources. A

--- a/docs/running.md
+++ b/docs/running.md
@@ -286,6 +286,15 @@ you set by hand on the command line is a policy you set once and forget:
 
 **Turning a row off takes its dependants with it, and the panel says so.** The chat row stands behind four doors ([plugins/chat.md](plugins/chat.md)), so switching it off leaves every engine, every doorbell and the mirror `waiting` — each row naming the door it is short of. Switch chat back on and they re-start themselves; nothing has to be pressed twice, and a plugin that comes back is holding the same machine-local record it left.
 
+**Stopping also reaches a plugin that is still starting.** The runtime
+interrupts its Effect initialization, waits for dependent cleanup while the
+provider's resources are still available, then releases its resources. A
+required service disappearing leaves the plugin `waiting` with that service
+named; when it returns the plugin starts again. Shutdown closes every plugin,
+including one that declares no dependencies. Cancellation is cooperative:
+synchronous JavaScript and uninterruptible Effect work must finish themselves.
+
+
 ### Machine-local state
 
 Plugins have one machine-local door, `LocalState`. Core stores its opaque document outside the vault at `$XDG_STATE_HOME/olai/<plugin>/<hash>.json` (normally `~/.local/state/olai/<plugin>/<hash>.json`), where `hash` names the served directory's real path. A plugin never opens that path itself. Core keys the door with the plugin's own name and keeps one ordered write chain across plugin flips. A save completes when its file lands; a failed save is both logged and returned to the plugin so the gesture that caused it can say what did not stick without taking the serve down.
@@ -298,7 +307,7 @@ An upgrade reads the previous paths once. The first save migrates `hold/<hash>.<
 
 **A serve with an integration off is not a degraded serve**, and the word is literal: the connection indicator stays green. Nothing is parked and nothing is half-wired — the integration's members are not on the wire at all, its tab half is never mounted so nothing subscribes to them, it hangs no chip in the bar, it probes for nothing, and the kinds it teaches the vault validate as ordinary text ([live-properties.md](live-properties.md)). The outline it would have owned is an ordinary outline. That is exactly the state a machine that never had the tool is already in, which is why it costs nothing to be true — and it is the state `olai surface` and every headless face already run in.
 
-**And it is the same nothing whichever door turned it off.** A row the flag never named and a row somebody switched off at the panel a minute ago are one state, not two: the plugin's registrations are undone as it goes — the words it taught, the doorbell it declared, the members it served, the seats it filled — so what is left behind is absence rather than a disabled copy of anything. The vocabulary in particular follows the fibers rather than the boot: a kind whose plugin you just switched off stops being a kind on the running serve, and its values are read as the plain text any undeclared key already is.
+**And it is the same nothing whichever door turned it off.** A row the flag never named and a row somebody switched off at the panel a minute ago are one state, not two: the plugin's registrations are undone as it goes — the words it taught, the doorbell it declared, the members it served, the seats it filled — so once teardown has finished what is left behind is absence rather than a disabled copy of anything. The vocabulary in particular follows the fibers rather than the boot: a kind whose plugin you just switched off stops being a kind on the running serve, and its values are read as the plain text any undeclared key already is.
 
 **The panel's row says which of seven states a plugin is in**, not just on or off. Running is the ordinary one, and it draws no sentence at all — the switch has already said it. The other six are all total absence and they differ in *why*: it was not asked for; this build ships it off until you name it (which is what `xyne-spaces` is, and the row names the flag value that turns it on); **you switched it off here**, which is the one that undoes itself and the only one a restart alone would clear; it was asked for and its **start failed** — in which case the row quotes what the plugin said, verbatim; it was asked for and is still waiting on something it needs; or — for a plugin the VAULT defines — it is waiting on YOU, which is the one absence whose answer is on this very panel (the source is drawn under the rows and the verb is beside it). Only the failure is a fault, and it is the one nothing else on screen would tell you about: an integration whose start failed draws nothing at all, exactly like one you turned off on purpose. The switch stays drawn on a row that failed, so a plugin whose start died on something you have since fixed can be told to try again.
 

--- a/packages/effect-cordis/README.md
+++ b/packages/effect-cordis/README.md
@@ -45,14 +45,39 @@ closed with that exit — every finalizer it had already installed runs, in reve
 — and the failure is re-thrown into the runtime, which lands it `failed` with its
 siblings running.
 
-What that does NOT buy is interruption *inside* `apply`, and the reason is the
-engine's rather than this package's. A loading fiber holds an `inertia` promise,
-and a revocation that arrives while it is loading does not start the unload — it
-is queued behind the load and runs when the load settles (`fiber.ts`'s
-`_setEpoch` returns early while `inertia` is set). So an `apply` that blocks on
-something slow delays the stop by however long it blocks, and no `Scope` here
-can shorten that: the scope it would unwind is the one the load has not finished
-filling. An `apply` does its slow work on a finalizer-owning fork, not in line.
+Initialization runs on an Effect fiber kept by the bridge. `apply` still awaits
+it, so Cordis marks the plugin ACTIVE only after initialization succeeds. A
+stop, a loader flip, host close, or withdrawal of a required service interrupts
+that work and closes its scope. Interruption alone is not a failure: explicit
+stop reads `off`; dependency withdrawal reads `waiting` with the missing key,
+and the plugin initializes again when that service returns. Cancellation is
+cooperative: it reaches interruptible Effect yields, cannot preempt synchronous
+JavaScript, and waits for uninterruptible acquisition and finalizers.
+
+**`offer(key, provision)`** provides on the calling plugin's fiber, carried in
+its Effect environment. Consumers cannot see the provision until the provider
+is ACTIVE; failed initialization activates none. Cordis owns duplicate refusal
+and identifies the existing provider. The bridge revokes every offer and joins
+dependent cleanup **before** closing any of the provider's resource finalizers,
+including finalizers registered after the offer. During host shutdown it also
+joins departing activations already removed from Cordis's registry.
+
+This ownership has one explicit pin coupling in `src/lifecycle.ts`: the bridge
+removes `ctx.provide`'s disposer from the fiber's `_disposables` and becomes its
+only caller. Leaving it in that set would run revocation concurrently with scope
+close; calling its guarded wrapper twice cannot join the first revocation. The
+ordering tests use the provider's resource from asynchronous dependent cleanup,
+not just the fibers' state words.
+
+**`openHost` / `closeHost(host)`** own the whole registry. Opening is scoped;
+closing is idempotent and waits for loading initializers, background work and
+asynchronous cleanup, including plugins with empty `needs`. The server and tab
+inherit this lifetime through `openPlugins` and `openApp`. Direct mounting
+normally waits for initialization; `mountPlugin(host, plugin, { wait: false })`
+returns the stop handle immediately. Dynamic plugins use that form so a hung
+initializer cannot block the stop command. `hostChanges` emits an initial
+notification and subsequent status transitions, allowing the host to publish
+readiness or failure when initialization finishes later.
 
 **`broadcast(what)` and `waterfall(key)`** — the two dispatch modes. A BROADCAST
 tells every handler, in subscription order, and AWAITS all of them: the caller
@@ -100,8 +125,9 @@ another row names: the second row is woken a turn later, so a caller reading the
 kind registry on the next line reads it a plugin short, silently and for the life
 of the process.
 
-So `settled` waits out MOVEMENT — in bounded passes, warning by name rather than
-hanging — and decides nothing. A row still `waiting` when it returns is waiting
+So `settled` waits out MOVEMENT, with bounded passes between transitions, and
+decides nothing. The bound is not an initialization timeout: a caller still
+waits for each transition until it finishes or is cancelled. A row still `waiting` when it returns is waiting
 on a key nothing in this build offers, which is a legitimate resting state and is
 what `rowReport` is about to say.
 
@@ -109,7 +135,7 @@ what `rowReport` is about to say.
 
 | door | what it carries |
 | --- | --- |
-| `.` | the RUNTIME: a host, `provide`, `mountPlugin`, `settled`, `rowReport`, `definePlugin`, `serviceTag`, `broadcast`, `waterfall`, `detached` |
+| `.` | the RUNTIME: a scoped host, `closeHost`, `hostChanges`, `provide`, `offer`, `mountPlugin`, `settled`, `rowReport`, `definePlugin`, `serviceTag`, `broadcast`, `waterfall`, `detached` |
 | `./loader` | `mountRows` — a declarative bundle, through `@cordisjs/plugin-loader` and `-include` |
 
 The split is not tidiness. The loader reads a file off a disk and resolves module
@@ -122,7 +148,7 @@ matching export named "pathToFileURL"`.
 [`@olai/plugin-api`](../plugin-api/README.md), whose `src/runtime.ts` re-exports
 the runtime list verbatim onto both of its own doors — so a plugin, a tab and a
 composition root all spend the same names from the same place, and what the
-bridge keeps back (`openHost`, `provide`, `settled`) is what could mint a host,
+bridge keeps back (`openHost`, `closeHost`, `provide`, `offer`, `hostChanges`, `settled`) is what could mint a host,
 mint a service, or make a plugin wait on its own siblings. `@olai/bundle` opens
 both doors directly: `./loader` for the graph reason above, and the root door for
 `settled` alone, which it spends beside `mountRows` in one function

--- a/packages/effect-cordis/README.md
+++ b/packages/effect-cordis/README.md
@@ -57,7 +57,9 @@ JavaScript, and waits for uninterruptible acquisition and finalizers.
 **`offer(key, provision)`** provides on the calling plugin's fiber, carried in
 its Effect environment. Consumers cannot see the provision until the provider
 is ACTIVE; failed initialization activates none. Cordis owns duplicate refusal
-and identifies the existing provider. The bridge revokes every offer and joins
+and identifies the existing provider. The bridge recognizes the pinned
+runtime's duplicate error as `OfferConflict`, so the API supplies its own
+sentence without relabeling unrelated lifecycle defects. The bridge revokes every offer and joins
 dependent cleanup **before** closing any of the provider's resource finalizers,
 including finalizers registered after the offer. During host shutdown it also
 joins departing activations already removed from Cordis's registry.
@@ -67,11 +69,16 @@ removes `ctx.provide`'s disposer from the fiber's `_disposables` and becomes its
 only caller. Leaving it in that set would run revocation concurrently with scope
 close; calling its guarded wrapper twice cannot join the first revocation. The
 ordering tests use the provider's resource from asynchronous dependent cleanup,
-not just the fibers' state words.
+not just the fibers' state words. A checked disposer handoff fails immediately
+if the pin stops registering that disposer in the expected set. The activation
+handle owns this ordering and cancellation; plugin configuration and service
+resolution cannot mutate its lifecycle bookkeeping.
 
 **`openHost` / `closeHost(host)`** own the whole registry. Opening is scoped;
 closing is idempotent and waits for loading initializers, background work and
-asynchronous cleanup, including plugins with empty `needs`. The server and tab
+asynchronous cleanup, including plugins with empty `needs`. Cordis implements
+root disposal as a restart, leaving an empty ACTIVE root; the bridge remembers
+closure and refuses subsequent mounts. The server and tab
 inherit this lifetime through `openPlugins` and `openApp`. Direct mounting
 normally waits for initialization; `mountPlugin(host, plugin, { wait: false })`
 returns the stop handle immediately. Dynamic plugins use that form so a hung

--- a/packages/effect-cordis/src/host.ts
+++ b/packages/effect-cordis/src/host.ts
@@ -36,7 +36,7 @@ import { Context as CordisContext, FiberState } from "cordis"
 import type { Fiber } from "cordis"
 import { Context, Effect, Queue, Scope, Stream } from "effect"
 
-import { interrupt } from "./lifecycle.ts"
+import { hostActivations, interrupt } from "./lifecycle.ts"
 import type { Plugin } from "./plugin.ts"
 import type { Provision, ServiceKey } from "./service.ts"
 
@@ -131,10 +131,12 @@ export const closeHost = (host: Host): Effect.Effect<void> => Effect.promise(() 
   let task = closing.get(host)
   if (task === undefined) {
     const ctx = ctxOf(host)
-    ctx.registry.forEach((runtime) => {
-      for (const fiber of runtime.fibers) interrupt(fiber)
+    task = Promise.resolve().then(async () => {
+      const active = hostActivations(ctx)
+      for (const activation of active) activation.interrupt()
+      await ctx.fiber.dispose()
+      await Promise.all(active.map((activation) => activation.drained))
     })
-    task = ctx.fiber.dispose()
     closing.set(host, task)
   }
   return task
@@ -385,7 +387,7 @@ export const namedBy = (
  * six.
  *
  * `off` is a row the loader declined to load and a fiber on its way out alike:
- * both have unwound every registration they made, and a reader has no use for
+ * cleanup is awaited by disposal, not proved by this state word. A reader has no use for
  * the difference. `waiting` is one WORD over `PENDING` (a service it names is not
  * there) and `LOADING` (it has not finished starting), because a row that has not
  * started has not started — the two are told apart by what {@link RowReport}

--- a/packages/effect-cordis/src/host.ts
+++ b/packages/effect-cordis/src/host.ts
@@ -34,8 +34,9 @@
 
 import { Context as CordisContext, FiberState } from "cordis"
 import type { Fiber } from "cordis"
-import { Context, Effect, Scope } from "effect"
+import { Context, Effect, Queue, Scope, Stream } from "effect"
 
+import { interrupt } from "./lifecycle.ts"
 import type { Plugin } from "./plugin.ts"
 import type { Provision, ServiceKey } from "./service.ts"
 
@@ -87,38 +88,57 @@ export const ctxOf = (host: Host): CordisContext => host as unknown as CordisCon
 /**
  * OPEN A HOST, under the services of the fiber that opens it.
  *
- * ## NOT SCOPED — and what that does and does not leave undone
- *
- * A host has no close. What it holds is a registry and the Effect services in
- * force where it was opened; neither is a resource, and both go with the
- * process.
- *
- * ITS PLUGINS DO COME DOWN, and by the reactive half rather than by anything
- * here. {@link provide} is an `acquireRelease` on the CALLER's scope, so a
- * composition root that closes that scope on the way out revokes every service
- * it provided, and revoking one unloads every fiber that named it — which
- * closes each plugin's own scope and runs its finalizers, in reverse. That is
- * the shutdown path in this tree: `@olai/server`'s `main.ts` runs the whole
- * command under `Effect.scoped`, and `runMain` interrupts it on SIGINT and
- * SIGTERM, so the unwind is the ordinary one. `plugin.test.ts`'s replaced-
- * provider bench is the same mechanism, two lines apart.
- *
- * WHAT IS LEFT is a plugin whose `needs` is EMPTY: it depends on nothing that
- * can be revoked, so nothing unloads it but the disposer its mount handed back.
- * There is no such plugin in this tree — every half, in both processes, names at
- * least one service — and the bench beside that one pins the shape so the claim
- * is checkable rather than remembered. A host that closed its own fibers would
- * close that gap and would also be a behaviour change on every shutdown path,
- * which is the loader surface's to make when it owns one.
+ * The enclosing scope closes the host, including plugins with empty needs.
+ * Explicit close is idempotent and awaits asynchronous plugin cleanup.
  */
-export const openHost: Effect.Effect<Host> = Effect.map(
+export const openHost: Effect.Effect<Host, never, Scope.Scope> = Effect.flatMap(
   Effect.context<never>(),
   (services) => {
     const host = new CordisContext() as unknown as { [HELD]: Context.Context<never> }
     host[HELD] = services
-    return host as unknown as Host
+    const ctx = host as unknown as CordisContext
+    // Dispose emits before waiting for apply, including loader-owned disposal.
+    ctx.on("internal/plugin", (fiber) => { if (fiber.uid === null) interrupt(fiber) })
+    ctx.on("internal/service", (name) => {
+      ctx.registry.forEach((runtime) => {
+        for (const fiber of runtime.fibers) {
+          if (name in fiber.inject && fiber.ctx.reflect.get(name) === undefined) interrupt(fiber)
+        }
+      })
+    })
+    return Effect.as(Effect.addFinalizer(() => closeHost(host as unknown as Host)), host as unknown as Host)
   },
 )
+
+/** An initial notification and status transitions, including completion of an asynchronous initializer.
+ * The subscriber owns the listener; one queued notification is enough to
+ * re-read the current registry, so bursts cannot grow an unbounded queue.
+ */
+export const hostChanges = (host: Host): Stream.Stream<void> => Stream.callback<void>((queue) =>
+  Effect.acquireRelease(
+    Effect.sync(() => {
+      const release = ctxOf(host).on("internal/status", () => { Queue.offerUnsafe(queue, undefined) })
+      Queue.offerUnsafe(queue, undefined)
+      return release
+    }),
+    (release) => Effect.promise(async () => { await release() }),
+  ), { bufferSize: 1, strategy: "sliding" })
+
+const closing = new WeakMap<Host, Promise<void>>()
+
+/** Stop every mounted fiber and join cleanup, even while initialization waits. */
+export const closeHost = (host: Host): Effect.Effect<void> => Effect.promise(() => {
+  let task = closing.get(host)
+  if (task === undefined) {
+    const ctx = ctxOf(host)
+    ctx.registry.forEach((runtime) => {
+      for (const fiber of runtime.fibers) interrupt(fiber)
+    })
+    task = ctx.fiber.dispose()
+    closing.set(host, task)
+  }
+  return task
+})
 
 /**
  * PUT A SERVICE BEHIND A KEY, for as long as the enclosing scope is open.
@@ -139,7 +159,7 @@ export const openHost: Effect.Effect<Host> = Effect.map(
  * and the ledger does not stamp.
  */
 export const offered = <Shape>(host: Host, key: ServiceKey<Shape>): Shape | undefined => {
-  const value = (ctxOf(host) as unknown as Record<string, unknown>)[key.cordis]
+  const value = ctxOf(host).reflect.get(key.cordis)
   if (typeof value !== "function") return undefined
   return (value as Provision<Shape>)("core")
 }
@@ -169,16 +189,22 @@ export interface Mounted {
  * It RETURNS once the fiber has settled, so a caller can read whatever the
  * plugin registered on the next line. A plugin held `PENDING` on a service
  * nobody has provided settles immediately in that state; it is not an error and
- * there is nothing to wait for.
+ * there is nothing to wait for. Pass `wait: false` to obtain the stop handle
+ * while initialization is still running (the dynamic-plugin path).
  */
-export const mountPlugin = (host: Host, plugin: Plugin): Effect.Effect<Mounted> =>
+export const mountPlugin = (
+  host: Host,
+  plugin: Plugin,
+  options: { readonly wait?: boolean } = {},
+): Effect.Effect<Mounted> =>
   Effect.promise(async () => {
+    if (closing.has(host)) throw new Error("effect-cordis: cannot mount on a closed host")
     const fiber: Fiber = (ctxOf(host).plugin as (plugin: Plugin) => Fiber)(plugin)
     // SWALLOWED, and it is the containment claim rather than a shrug: a plugin
     // whose `apply` failed lands in `FAILED` having installed nothing, and its
     // siblings — and the boot — are untouched. What it threw is not lost; it is
     // what {@link rowReport} quotes.
-    await fiber.await().catch(() => undefined)
+    if (options.wait !== false) await fiber.await().catch(() => undefined)
     return {
       // THE SAME TWO STEPS {@link rowReport} TAKES, for one fiber: the state
       // synchronously, and the plugin's own words only where there are some to
@@ -189,7 +215,10 @@ export const mountPlugin = (host: Host, plugin: Plugin): Effect.Effect<Mounted> 
         const said = reportOf(fiber)
         return said.state === "failed" ? Effect.promise(() => faulted(fiber)) : Effect.succeed(said)
       }),
-      dispose: Effect.promise(() => fiber.dispose()),
+      dispose: Effect.promise(() => {
+        interrupt(fiber)
+        return fiber.dispose().then(() => fiber.await().then(() => undefined, () => undefined))
+      }),
     }
   })
 

--- a/packages/effect-cordis/src/index.ts
+++ b/packages/effect-cordis/src/index.ts
@@ -51,6 +51,8 @@ export {
   namedBy,
   offered,
   openHost,
+  closeHost,
+  hostChanges,
   provide,
   type RowReport,
   type RowState,
@@ -61,3 +63,5 @@ export { standing } from "./standing.ts"
 export { type Detach, definePlugin, detached, type Plugin } from "./plugin.ts"
 export { type AnyKey, type Provision, serviceTag, type ServiceKey } from "./service.ts"
 export { type Chain, type Dispatch, type Middleware, waterfall, type Waterfall } from "./waterfall.ts"
+
+export { offer } from "./lifecycle.ts"

--- a/packages/effect-cordis/src/index.ts
+++ b/packages/effect-cordis/src/index.ts
@@ -64,4 +64,4 @@ export { type Detach, definePlugin, detached, type Plugin } from "./plugin.ts"
 export { type AnyKey, type Provision, serviceTag, type ServiceKey } from "./service.ts"
 export { type Chain, type Dispatch, type Middleware, waterfall, type Waterfall } from "./waterfall.ts"
 
-export { offer } from "./lifecycle.ts"
+export { offer, OfferConflict } from "./lifecycle.ts"

--- a/packages/effect-cordis/src/lifecycle.test.ts
+++ b/packages/effect-cordis/src/lifecycle.test.ts
@@ -1,0 +1,156 @@
+import { expect, test } from "bun:test"
+import { Deferred, Effect, Exit, Scope } from "effect"
+import { closeHost, mountPlugin, offered, openHost, provide, settled } from "./host.ts"
+import { offer } from "./lifecycle.ts"
+import { definePlugin, detached } from "./plugin.ts"
+import { serviceTag } from "./service.ts"
+
+const Resource = serviceTag<{ use: () => void }>("resource")
+const Dependency = serviceTag<object>("dependency")
+const run = (work: Effect.Effect<void, never, Scope.Scope>) => Effect.runPromise(Effect.scoped(work))
+
+for (const fails of [false, true]) {
+  test(`offered services stay pending until initialization ${fails ? "fails" : "succeeds"}`, () => run(Effect.gen(function*() {
+    const host = yield* openHost
+    const entered = Deferred.makeUnsafe<void>()
+    const ready = Deferred.makeUnsafe<void>()
+    let used = 0
+    let alive = false
+    const consumer = yield* mountPlugin(host, definePlugin({
+      name: "consumer", needs: [Resource],
+      apply: Effect.gen(function*() { (yield* Resource).use() }),
+    }))
+    const provider = yield* mountPlugin(host, definePlugin({
+      name: "provider", needs: [], apply: Effect.gen(function*() {
+        yield* Effect.acquireRelease(Effect.sync(() => { alive = true }), () => Effect.sync(() => { alive = false }))
+        yield* offer(Resource, () => ({ use: () => { expect(alive).toBe(true); used++ } }))
+        yield* Deferred.succeed(entered, undefined)
+        yield* Deferred.await(ready)
+        if (fails) yield* Effect.die(new Error("initialization failed"))
+      }),
+    }), { wait: false })
+    yield* Deferred.await(entered)
+    expect(yield* consumer.report).toEqual({ state: "waiting", missing: ["resource"] })
+    expect(offered(host, Resource)).toBeUndefined()
+    expect(used).toBe(0)
+    yield* Deferred.succeed(ready, undefined)
+    yield* settled(host, ["provider", "consumer"])
+    expect(used).toBe(fails ? 0 : 1)
+    expect(yield* provider.report).toEqual(fails ? { state: "failed", fault: "initialization failed" } : { state: "running" })
+    if (fails) expect(alive).toBe(false)
+  })))
+}
+
+for (const shutdown of [false, true]) {
+  test(`dependent async cleanup uses a live provider during ${shutdown ? "host close" : "removal and replacement"}`, () => run(Effect.gen(function*() {
+    const host = yield* openHost
+    const order: string[] = []
+    let generation = 0
+    const provider = definePlugin({ name: "provider", needs: [], apply: Effect.gen(function*() {
+      const id = ++generation
+      let alive = true
+      yield* Effect.addFinalizer(() => Effect.sync(() => { alive = false; order.push(`release ${id}`) }))
+      yield* offer(Resource, () => ({ use: () => { order.push(`use ${id}: ${alive}`) } }))
+      // A finalizer registered AFTER offer must still run after consumers.
+      yield* Effect.addFinalizer(() => Effect.sync(() => { order.push(`last ${id}`) }))
+    }) })
+    const first = yield* mountPlugin(host, provider)
+    yield* mountPlugin(host, definePlugin({ name: "consumer", needs: [Resource], apply: Effect.gen(function*() {
+      const resource = yield* Resource
+      yield* Effect.addFinalizer(() => Effect.gen(function*() {
+        yield* Effect.sleep("10 millis")
+        resource.use()
+      }))
+    }) }))
+    if (shutdown) {
+      yield* closeHost(host)
+      yield* closeHost(host)
+    } else {
+      yield* first.dispose
+      const second = yield* mountPlugin(host, provider)
+      yield* settled(host, ["consumer"])
+      yield* second.dispose
+    }
+    expect(order).toEqual(shutdown
+      ? ["use 1: true", "last 1", "release 1"]
+      : ["use 1: true", "last 1", "release 1", "use 2: true", "last 2", "release 2"])
+  })))
+}
+
+for (const stop of ["explicit", "withdrawal", "host"] as const) {
+  test(`a loading initializer is cancelled by ${stop}`, () => run(Effect.gen(function*() {
+    const host = yield* openHost
+    const dependency = Scope.makeUnsafe()
+    yield* Scope.provide(dependency)(provide(host, Dependency, () => ({})))
+    const entered = Deferred.makeUnsafe<void>()
+    const background = Deferred.makeUnsafe<void>()
+    const order: string[] = []
+    let attempts = 0
+    const consumer = yield* mountPlugin(host, definePlugin({ name: "consumer", needs: [Resource], apply: Effect.void }))
+    const provider = yield* mountPlugin(host, definePlugin({ name: "provider", needs: [Dependency], apply: Effect.gen(function*() {
+      attempts++
+      yield* Effect.acquireRelease(Effect.sync(() => { order.push("acquire") }), () => Effect.gen(function*() {
+        yield* Effect.sleep("10 millis")
+        order.push("release")
+      }))
+      yield* offer(Resource, () => ({ use: () => {} }))
+      const detach = yield* detached
+      detach(Effect.gen(function*() {
+        yield* Effect.addFinalizer(() => Effect.sync(() => { order.push("background stopped") }))
+        yield* Deferred.succeed(background, undefined)
+        yield* Effect.never
+      }).pipe(Effect.scoped))
+      yield* Deferred.await(background)
+      yield* Deferred.succeed(entered, undefined)
+      if (attempts === 1) yield* Effect.never
+    }) }), { wait: false })
+    yield* Deferred.await(entered)
+    expect(yield* consumer.report).toEqual({ state: "waiting", missing: ["resource"] })
+    if (stop === "explicit") yield* provider.dispose
+    if (stop === "host") yield* closeHost(host)
+    if (stop === "withdrawal") yield* Scope.close(dependency, Exit.void)
+    expect(order).toEqual(["acquire", "background stopped", "release"])
+    expect(yield* provider.report).toEqual(stop === "withdrawal" ? { state: "waiting", missing: ["dependency"] } : { state: "off" })
+    if (stop === "withdrawal") {
+      yield* provide(host, Dependency, () => ({}))
+      yield* settled(host, ["provider", "consumer"])
+      expect(attempts).toBe(2)
+      expect(order).toEqual(["acquire", "background stopped", "release", "acquire"])
+      expect(yield* provider.report).toEqual({ state: "running" })
+      expect(yield* consumer.report).toEqual({ state: "running" })
+    }
+  })))
+}
+
+for (const shutdown of [false, true]) {
+  test(`loader ${shutdown ? "host close" : "flip"} cancels loading without rewriting its file`, () => run(Effect.gen(function*() {
+    const { mkdtemp, writeFile, readFile, rm } = yield* Effect.promise(() => import("node:fs/promises"))
+    const { tmpdir } = yield* Effect.promise(() => import("node:os"))
+    const { pathToFileURL } = yield* Effect.promise(() => import("node:url"))
+    const { mountRows, flipRow } = yield* Effect.promise(() => import("./loader.ts"))
+    const dir = yield* Effect.acquireRelease(
+      Effect.promise(() => mkdtemp(`${tmpdir()}/bridge-lifecycle-`)),
+      (path) => Effect.promise(() => rm(path, { recursive: true, force: true })),
+    )
+    const path = `${dir}/plugins.yml`
+    const source = "- id: loading\n  name: loading\n"
+    yield* Effect.promise(() => writeFile(path, source))
+    const host = yield* openHost
+    const entered = Deferred.makeUnsafe<void>()
+    let released = false
+    const plugin = definePlugin({ name: "loading", needs: [], apply: Effect.gen(function*() {
+      yield* Effect.addFinalizer(() => Effect.gen(function*() {
+        yield* Effect.sleep("10 millis")
+        released = true
+      }))
+      yield* Deferred.succeed(entered, undefined)
+      yield* Effect.never
+    }) })
+    yield* mountRows(host, { baseUrl: pathToFileURL(`${dir}/`).href, path: "plugins.yml", patches: [], resolve: async () => ({ default: plugin }) })
+    yield* Deferred.await(entered)
+    if (shutdown) yield* closeHost(host)
+    else expect(yield* flipRow(host, "loading", true)).toBe(true)
+    expect(released).toBe(true)
+    expect(yield* Effect.promise(() => readFile(path, "utf8"))).toBe(source)
+  })))
+}

--- a/packages/effect-cordis/src/lifecycle.test.ts
+++ b/packages/effect-cordis/src/lifecycle.test.ts
@@ -154,3 +154,39 @@ for (const shutdown of [false, true]) {
     expect(yield* Effect.promise(() => readFile(path, "utf8"))).toBe(source)
   })))
 }
+
+test("host close joins cleanup that already left the registry", () => run(Effect.gen(function*() {
+  const host = yield* openHost
+  const cleaning = Deferred.makeUnsafe<void>()
+  let released = false
+  const mounted = yield* mountPlugin(host, definePlugin({ name: "departing", needs: [], apply: Effect.addFinalizer(() => Effect.gen(function*() {
+    yield* Deferred.succeed(cleaning, undefined)
+    yield* Effect.sleep("20 millis")
+    released = true
+  })) }))
+  yield* mounted.dispose.pipe(Effect.forkScoped)
+  yield* Deferred.await(cleaning)
+  yield* closeHost(host)
+  expect(released).toBe(true)
+})))
+
+test("host close interrupts active background work before resource release", () => run(Effect.gen(function*() {
+  const host = yield* openHost
+  const entered = Deferred.makeUnsafe<void>()
+  const order: string[] = []
+  yield* mountPlugin(host, definePlugin({ name: "background", needs: [], apply: Effect.gen(function*() {
+    yield* Effect.addFinalizer(() => Effect.sync(() => { order.push("resource released") }))
+    const detach = yield* detached
+    detach(Effect.gen(function*() {
+      yield* Effect.addFinalizer(() => Effect.gen(function*() {
+        yield* Effect.sleep("10 millis")
+        order.push("background stopped")
+      }))
+      yield* Deferred.succeed(entered, undefined)
+      yield* Effect.never
+    }).pipe(Effect.scoped))
+  }) }))
+  yield* Deferred.await(entered)
+  yield* closeHost(host)
+  expect(order).toEqual(["background stopped", "resource released"])
+})))

--- a/packages/effect-cordis/src/lifecycle.test.ts
+++ b/packages/effect-cordis/src/lifecycle.test.ts
@@ -190,3 +190,17 @@ test("host close interrupts active background work before resource release", () 
   yield* closeHost(host)
   expect(order).toEqual(["background stopped", "resource released"])
 })))
+
+test("offer transfers its Cordis disposer out of the concurrent disposer set", () => run(Effect.gen(function*() {
+  const { ctxOf } = yield* Effect.promise(() => import("./host.ts"))
+  const { activate, Offering } = yield* Effect.promise(() => import("./lifecycle.ts"))
+  const host = yield* openHost
+  const ctx = ctxOf(host)
+  const activation = activate(ctx, yield* Effect.context<never>())
+  const before = [...ctx.fiber._disposables]
+  yield* offer(Resource, () => ({ use: () => {} })).pipe(Effect.provideService(Offering, activation))
+  expect([...ctx.fiber._disposables]).toEqual(before)
+  expect(offered(host, Resource)).toBeDefined()
+  yield* Effect.promise(() => activation.close(Exit.void))
+  expect(offered(host, Resource)).toBeUndefined()
+})))

--- a/packages/effect-cordis/src/lifecycle.ts
+++ b/packages/effect-cordis/src/lifecycle.ts
@@ -1,53 +1,133 @@
-/** Activation ownership at the Cordis / Effect boundary. */
+/**
+ * ONE ACTIVATION'S LIFETIME, on both sides of the bridge.
+ *
+ * Cordis owns readiness and reactive reloads; Effect owns resources. This module
+ * owns the join between them: revoke provisions, wait for dependent cleanup,
+ * then close the resource scope. Plugin configuration and failure presentation
+ * do not participate in that ordering and remain in plugin.ts.
+ */
 import type { Context as CordisContext, Fiber as CordisFiber } from "cordis"
-import { Context, Effect } from "effect"
+import { Context, Effect, Exit, Fiber, Scope } from "effect"
 import type { Provision, ServiceKey } from "./service.ts"
 
-export interface Activation {
-  readonly ctx: CordisContext
-  readonly revokes: Array<() => Promise<void>>
-  readonly dependencies: ReadonlySet<CordisFiber>
-  readonly drained: Promise<void>
-  closing: boolean
-  interrupt: () => void
+/** A duplicate is a distinct defect so the API can supply its own sentence
+ * without accidentally disguising a cancellation or disposer-ownership defect. */
+export class OfferConflict extends Error {
+  constructor(readonly owner: string, readonly key: string, cause: Error) {
+    super(cause.message, { cause })
+  }
 }
 
-const activations = new Map<CordisFiber, Activation>()
+/** The plugin adapter can bind initialization and close its lifetime, but cannot
+ * rearrange revocation or mark cleanup complete without actually doing it. */
+export interface Activation {
+  readonly scope: Scope.Closeable
+  readonly bind: (fiber: Fiber.Fiber<void>) => void
+  readonly interrupt: () => void
+  readonly close: (exit: Exit.Exit<void>) => Promise<void>
+  readonly offer: <Shape>(key: ServiceKey<Shape>, provision: Provision<Shape>) => void
+}
+
+interface Live {
+  readonly ctx: CordisContext
+  readonly dependencies: ReadonlySet<CordisFiber>
+  readonly drained: Promise<void>
+  readonly interrupt: () => void
+}
+
+/** Cordis removes fibers from its registry BEFORE asynchronous cleanup ends.
+ * Keeping the activation until its scope has closed lets a departing provider
+ * and host shutdown join consumers that are no longer discoverable there.
+ * This is cleanup bookkeeping, not a second readiness or dependency scheduler:
+ * dependencies are the provider identities Cordis committed for this activation.
+ * The entry is removed in finally, including failed and interrupted starts.
+ */
+const live = new Map<CordisFiber, Live>()
+
 export const Offering = Context.Reference<Activation | undefined>("effect-cordis/Offering", {
   defaultValue: () => undefined,
 })
 
-export const track = (activation: Activation): void => {
-  activations.set(activation.ctx.fiber, activation)
-}
-export const untrack = (activation: Activation): void => {
-  if (activations.get(activation.ctx.fiber) === activation) activations.delete(activation.ctx.fiber)
-}
-/** Join the old activations even when Cordis already removed their fibers
- * from the registry (notably when the entire host closes at once). */
-export const drainDependents = async (activation: Activation): Promise<void> => {
-  await Promise.all([...activations.values()]
-    .filter((other) => other.dependencies.has(activation.ctx.fiber))
-    .map((other) => other.drained))
-}
 /** Include activations whose disposal already removed their registry entry. */
-export const hostActivations = (ctx: CordisContext): ReadonlyArray<Activation> =>
-  [...activations.values()].filter((activation) => activation.ctx.root.fiber === ctx.root.fiber)
+export const hostActivations = (ctx: CordisContext): ReadonlyArray<Live> =>
+  [...live.values()].filter((activation) => activation.ctx.root.fiber === ctx.root.fiber)
 
-export const interrupt = (fiber: CordisFiber): void => activations.get(fiber)?.interrupt()
+export const interrupt = (fiber: CordisFiber): void => live.get(fiber)?.interrupt()
 
-/** Provide on the calling fiber, withholding the value until it is ACTIVE.
- * Revocation belongs to the activation, before ANY of its scope finalizers.
- * Pin coupling: detach the provide disposer from `_disposables`. Cordis runs
- * that set concurrently and its guarded disposer cannot be joined twice.
- * Keeping exactly one caller here lets dependent cleanup finish first.
- */
+export const activate = (ctx: CordisContext, services: Context.Context<never>): Activation => {
+  const scope = Scope.makeUnsafe()
+  const drained = Promise.withResolvers<void>()
+  let closing: Promise<void> | undefined
+  const revokes: Array<() => Promise<void>> = []
+  let running: Fiber.Fiber<void> | undefined
+  let interrupted = false
+  const interrupt = (): void => {
+    interrupted = true
+    if (running !== undefined) Effect.runFork(Fiber.interrupt(running))
+  }
+  const activation: Live = {
+    ctx, drained: drained.promise, interrupt,
+    dependencies: new Set(Object.values(ctx.fiber.store ?? {}).map((impl) => impl.fiber)),
+  }
+  live.set(ctx.fiber, activation)
+  return {
+    scope,
+    interrupt,
+    // runForkWith may run plugin code before returning its fiber. Remember an
+    // interruption received during that work, then deliver it when bound.
+    bind: (fiber) => {
+      running = fiber
+      if (interrupted || ctx.fiber.uid === null || Object.keys(ctx.fiber.inject).some((key) => ctx.reflect.get(key) === undefined)) interrupt()
+    },
+    close: (exit) => closing ??= Promise.resolve().then(async () => {
+      try {
+        for (const revoke of revokes.reverse()) await revoke()
+        await Promise.all([...live.values()]
+          .filter((other) => other.dependencies.has(ctx.fiber))
+          .map((other) => other.drained))
+      } finally {
+        try {
+          await Effect.runPromiseWith(services)(Scope.close(scope, exit))
+        } finally {
+          live.delete(ctx.fiber)
+          drained.resolve()
+        }
+      }
+    }),
+    offer: (key, provision) => {
+      if (closing !== undefined) throw new Error("effect-cordis: offer requires an open plugin activation")
+      let revoke: () => void
+      try {
+        revoke = ctx.provide(key.cordis, provision)
+      } catch (cause) {
+        // The pinned runtime exposes no typed duplicate error. Recognize its
+        // exact sentence here, beside the call it belongs to; callers neither
+        // parse Cordis prose nor preflight its exclusive-provider decision.
+        const prefix = `service "${key.cordis}" has been registered at <`
+        if (cause instanceof Error && cause.message.startsWith(prefix) && cause.message.endsWith(">")) {
+          throw new OfferConflict(cause.message.slice(prefix.length, -1), key.cordis, cause)
+        }
+        throw cause
+      }
+      // Pin coupling: ctx.provide installs its own guarded disposer into this
+      // set, whose members Cordis unloads concurrently. An Effect finalizer
+      // calling that wrapper again would return without joining its first call.
+      // Remove it and become the ONLY caller, in close's earlier revoke phase.
+      // Assert the handoff here so pin drift names the cause, not just a later
+      // resource-use failure in a dependent's cleanup.
+      if (!ctx.fiber._disposables.delete(revoke)) {
+        throw new Error(`effect-cordis: could not take ownership of the disposer for "${key.cordis}"; the Cordis pin's provision ownership changed.`)
+      }
+      revokes.push(async () => { await revoke() })
+    },
+  }
+}
+
+/** The offering context is ambient, so authors receive a capability, never the
+ * Cordis fiber or a caller-supplied identity. Readiness remains Cordis's: a
+ * provision on this context is unavailable until the provider becomes ACTIVE. */
 export const offer = <Shape>(key: ServiceKey<Shape>, provision: Provision<Shape>): Effect.Effect<void> =>
   Effect.flatMap(Offering, (activation) => Effect.sync(() => {
-    if (activation === undefined || activation.closing) {
-      throw new Error("effect-cordis: offer requires an open plugin activation")
-    }
-    const revoke = activation.ctx.provide(key.cordis, provision)
-    activation.ctx.fiber._disposables.delete(revoke)
-    activation.revokes.push(async () => { await revoke() })
+    if (activation === undefined) throw new Error("effect-cordis: offer requires a plugin activation")
+    activation.offer(key, provision)
   }))

--- a/packages/effect-cordis/src/lifecycle.ts
+++ b/packages/effect-cordis/src/lifecycle.ts
@@ -30,6 +30,10 @@ export const drainDependents = async (activation: Activation): Promise<void> => 
     .filter((other) => other.dependencies.has(activation.ctx.fiber))
     .map((other) => other.drained))
 }
+/** Include activations whose disposal already removed their registry entry. */
+export const hostActivations = (ctx: CordisContext): ReadonlyArray<Activation> =>
+  [...activations.values()].filter((activation) => activation.ctx.root.fiber === ctx.root.fiber)
+
 export const interrupt = (fiber: CordisFiber): void => activations.get(fiber)?.interrupt()
 
 /** Provide on the calling fiber, withholding the value until it is ACTIVE.

--- a/packages/effect-cordis/src/lifecycle.ts
+++ b/packages/effect-cordis/src/lifecycle.ts
@@ -1,0 +1,49 @@
+/** Activation ownership at the Cordis / Effect boundary. */
+import type { Context as CordisContext, Fiber as CordisFiber } from "cordis"
+import { Context, Effect } from "effect"
+import type { Provision, ServiceKey } from "./service.ts"
+
+export interface Activation {
+  readonly ctx: CordisContext
+  readonly revokes: Array<() => Promise<void>>
+  readonly dependencies: ReadonlySet<CordisFiber>
+  readonly drained: Promise<void>
+  closing: boolean
+  interrupt: () => void
+}
+
+const activations = new Map<CordisFiber, Activation>()
+export const Offering = Context.Reference<Activation | undefined>("effect-cordis/Offering", {
+  defaultValue: () => undefined,
+})
+
+export const track = (activation: Activation): void => {
+  activations.set(activation.ctx.fiber, activation)
+}
+export const untrack = (activation: Activation): void => {
+  if (activations.get(activation.ctx.fiber) === activation) activations.delete(activation.ctx.fiber)
+}
+/** Join the old activations even when Cordis already removed their fibers
+ * from the registry (notably when the entire host closes at once). */
+export const drainDependents = async (activation: Activation): Promise<void> => {
+  await Promise.all([...activations.values()]
+    .filter((other) => other.dependencies.has(activation.ctx.fiber))
+    .map((other) => other.drained))
+}
+export const interrupt = (fiber: CordisFiber): void => activations.get(fiber)?.interrupt()
+
+/** Provide on the calling fiber, withholding the value until it is ACTIVE.
+ * Revocation belongs to the activation, before ANY of its scope finalizers.
+ * Pin coupling: detach the provide disposer from `_disposables`. Cordis runs
+ * that set concurrently and its guarded disposer cannot be joined twice.
+ * Keeping exactly one caller here lets dependent cleanup finish first.
+ */
+export const offer = <Shape>(key: ServiceKey<Shape>, provision: Provision<Shape>): Effect.Effect<void> =>
+  Effect.flatMap(Offering, (activation) => Effect.sync(() => {
+    if (activation === undefined || activation.closing) {
+      throw new Error("effect-cordis: offer requires an open plugin activation")
+    }
+    const revoke = activation.ctx.provide(key.cordis, provision)
+    activation.ctx.fiber._disposables.delete(revoke)
+    activation.revokes.push(async () => { await revoke() })
+  }))

--- a/packages/effect-cordis/src/loader.ts
+++ b/packages/effect-cordis/src/loader.ts
@@ -35,6 +35,7 @@ import type { Entry } from "@cordisjs/plugin-loader"
 import Loader from "@cordisjs/plugin-loader"
 import { Effect } from "effect"
 
+import { interrupt } from "./lifecycle.ts"
 import { ctxOf, type Host } from "./host.ts"
 
 /**
@@ -246,6 +247,7 @@ export const flipRow = (host: Host, id: string, disabled: boolean): Effect.Effec
     // CAUGHT BEFORE THE UPDATE, because the update is what disposes it and a
     // disposed row is one nothing else can hand back.
     const going = disabled ? entry.fiber : undefined
+    if (going !== undefined) interrupt(going)
     await entry.update({ disabled })
     for (let pass = 0; pass < PASSES && going?.inertia !== undefined; pass += 1) {
       await going.inertia

--- a/packages/effect-cordis/src/plugin.test.ts
+++ b/packages/effect-cordis/src/plugin.test.ts
@@ -30,6 +30,7 @@ import { Cause, Effect, Logger, Schema, Scope } from "effect"
 
 import { definePlugin, detached, PluginName } from "./plugin.ts"
 import { mountPlugin, openHost, provide, settled } from "./host.ts"
+import { offer } from "./lifecycle.ts"
 import { serviceTag } from "./service.ts"
 
 /** A TOY SERVICE, and it is keyed by the calling plugin so the stamp claim has
@@ -156,22 +157,12 @@ test("a replaced provider unloads the plugin and applies it again", async () => 
   })))
 })
 
-/**
- * ...AND THE ONE SHAPE THAT REVOCATION CANNOT REACH, which is the residue in
- * `openHost`'s "not scoped" paragraph made checkable.
- *
- * A composition root's provisions are scoped, so the shutdown above unwinds
- * every plugin that NAMES one — that is the reactive half doing its job, and it
- * is what makes "the process owns its plugins for its life" a statement about a
- * host rather than about its plugins. A plugin with an empty `needs` depends on
- * nothing that can be revoked, so nothing brings it down but the disposer the
- * mount handed back.
- */
-test("a plugin that names no service is nobody's to revoke", async () => {
+/** Empty needs still has a lifetime: the host's enclosing scope. */
+test("host scope closes a plugin that names no service", async () => {
   const lines: Array<string> = []
   await Effect.runPromise(Effect.scoped(Effect.gen(function*() {
     const host = yield* openHost
-    const mounted = yield* mountPlugin(
+    yield* mountPlugin(
       host,
       definePlugin({
         name: "hermit",
@@ -188,9 +179,8 @@ test("a plugin that names no service is nobody's to revoke", async () => {
     yield* Effect.scoped(provide(host, Ledger, ledgerOf(lines)))
     yield* Effect.sleep("10 millis")
     expect(lines).toEqual(["hermit: up"])
-    yield* mounted.dispose
-    expect(lines).toEqual(["hermit: up", "hermit: down"])
   })))
+  expect(lines).toEqual(["hermit: up", "hermit: down"])
 })
 
 test("a plugin whose Effect dies lands failed, having installed nothing", async () => {
@@ -379,7 +369,7 @@ test("a plugin behind a key another names is running once the mounts have settle
         apply: Effect.gen(function*() {
           const ledger = yield* Ledger
           yield* Effect.sleep("5 millis")
-          yield* provide(host, Counter, () => ({ bump: ledger.write("bumped") }))
+          yield* offer(Counter, () => ({ bump: ledger.write("bumped") }))
         }),
       }),
     )
@@ -423,7 +413,7 @@ test("a provider that unloads takes its dependents with it, and brings them back
       needs: [Ledger],
       apply: Effect.gen(function*() {
         const ledger = yield* Ledger
-        yield* provide(host, Counter, () => ({ bump: ledger.write("bumped") }))
+        yield* offer(Counter, () => ({ bump: ledger.write("bumped") }))
       }),
     })
     const dependent = definePlugin({

--- a/packages/effect-cordis/src/plugin.ts
+++ b/packages/effect-cordis/src/plugin.ts
@@ -12,8 +12,9 @@
  * `Effect.addFinalizer`, with the same LIFO discipline and a great deal more
  * said about interruption. So {@link definePlugin} opens ONE `Scope` when the
  * fiber activates, runs the plugin's Effect inside it, and hands Cordis a
- * disposer that closes it. Every registration a plugin makes is a finalizer on
- * that scope; the plugin author never calls `ctx.effect`, never sees a
+ * disposer that closes it. Resource registrations are finalizers on that
+ * scope; service offers are revoked first, with dependent cleanup joined before
+ * the resource scope closes. The plugin author never calls `ctx.effect`, never sees a
  * disposer, and never learns that Cordis is under any of it.
  *
  * ## `inject` and the requirement channel are one declaration
@@ -40,7 +41,7 @@ import { Cause, Context, Effect, Exit, Fiber, FiberSet, Schema, Scope } from "ef
 
 import { failed } from "./broadcast.ts"
 import { held } from "./host.ts"
-import { Offering, track, untrack, drainDependents, type Activation } from "./lifecycle.ts"
+import { Offering, activate } from "./lifecycle.ts"
 import type { AnyKey } from "./service.ts"
 
 /**
@@ -222,44 +223,9 @@ export const definePlugin = <const Keys extends ReadonlyArray<AnyKey>, Config = 
     // THE STAMP, READ ONCE, off the registry binding — never off anything the
     // plugin supplied. Every keyed service below is minted from it.
     const who = ctx.fiber.name
-    const scope = Scope.makeUnsafe()
-    const drained = Promise.withResolvers<void>()
-    let interrupted = false
-    const activation: Activation = {
-      ctx, revokes: [], drained: drained.promise, closing: false,
-      dependencies: new Set(Object.values(ctx.fiber.store ?? {}).map((impl) => impl.fiber)),
-      interrupt: () => { interrupted = true },
-    }
-    let closing: Promise<void> | undefined
-    const close = (exit: Exit.Exit<void, never>): Promise<void> => closing ??= (async () => {
-      activation.closing = true
-      try {
-        for (const revoke of activation.revokes.reverse()) await revoke()
-        await drainDependents(activation)
-      } finally {
-        try {
-          await Effect.runPromiseWith(opened)(Scope.close(scope, exit))
-        } finally {
-          untrack(activation)
-          drained.resolve()
-        }
-      }
-    })()
-    // THE TWO AMBIENT ONES KEEP THEIR TYPES, because both are known here: the
-    // context that comes out of this says it carries a plugin name and a scope,
-    // and nothing is asserted to get there.
-    //
-    // The LOOP is where the tracking genuinely ends — a provision is resolved by
-    // a runtime string off a Cordis context, so what a key is a key FOR is not a
-    // thing the compiler can follow — and that is the one place the assertion
-    // belongs. It was written four times, once after each `merge` and `add`,
-    // which made a reader check three identical casts to find the one that meant
-    // something.
-    let services = Context.add(
-      Context.add(Context.merge(opened, Context.make(PluginName, who)), Offering, activation),
-      Scope.Scope,
-      scope,
-    ) as Context.Context<never>
+    // Runtime string lookup is the one point where the key's shape is erased.
+    // Resolve it here; lifetime ownership has no opinion about service shapes.
+    let services = Context.merge(opened, Context.make(PluginName, who)) as Context.Context<never>
     for (const key of spec.needs) {
       const provision = (ctx as unknown as Record<string, unknown>)[key.cordis]
       if (typeof provision !== "function") {
@@ -275,15 +241,13 @@ export const definePlugin = <const Keys extends ReadonlyArray<AnyKey>, Config = 
         (provision as (plugin: string) => unknown)(who),
       ) as Context.Context<never>
     }
-    track(activation)
+    const activation = activate(ctx, opened)
+    services = Context.add(Context.add(services, Offering, activation), Scope.Scope, activation.scope) as Context.Context<never>
     const work = Effect.suspend(() => Effect.isEffect(spec.apply)
       ? spec.apply
       : spec.apply((config ?? {}) as Config))
     const running = Effect.runForkWith(services)(work as Effect.Effect<void>)
-    activation.interrupt = () => { Effect.runFork(Fiber.interrupt(running)) }
-    if (interrupted || ctx.fiber.uid === null || spec.needs.some((key) => ctx.reflect.get(key.cordis) === undefined)) {
-      activation.interrupt()
-    }
+    activation.bind(running)
     const exit = await Effect.runPromise(Fiber.await(running))
     if (Exit.isFailure(exit)) {
       // EVERY FINALIZER IT HAD ALREADY INSTALLED, before the throw goes out —
@@ -299,7 +263,7 @@ export const definePlugin = <const Keys extends ReadonlyArray<AnyKey>, Config = 
       // then read on the preferences row, was the CLEANUP's defect rather than
       // the plugin's. The plugin's failure is the subject of this whole arm; it
       // wins, and a finalizer that died on the way out is said beside it.
-      const unwound = await Effect.runPromiseExit(Effect.promise(() => close(exit)))
+      const unwound = await Effect.runPromiseExit(Effect.promise(() => activation.close(exit)))
       if (Exit.isFailure(unwound)) {
         await Effect.runPromiseWith(opened)(
           failed(who, "unwinding after a failed start", unwound.cause),
@@ -307,6 +271,6 @@ export const definePlugin = <const Keys extends ReadonlyArray<AnyKey>, Config = 
       }
       if (!Cause.hasInterruptsOnly(exit.cause)) throw Cause.squash(exit.cause)
     }
-    return () => close(Exit.void)
+    return () => activation.close(Exit.void)
   },
 })

--- a/packages/effect-cordis/src/plugin.ts
+++ b/packages/effect-cordis/src/plugin.ts
@@ -36,10 +36,11 @@
  */
 
 import type { Context as CordisContext } from "cordis"
-import { Cause, Context, Effect, Exit, FiberSet, Schema, Scope } from "effect"
+import { Cause, Context, Effect, Exit, Fiber, FiberSet, Schema, Scope } from "effect"
 
 import { failed } from "./broadcast.ts"
 import { held } from "./host.ts"
+import { Offering, track, untrack, drainDependents, type Activation } from "./lifecycle.ts"
 import type { AnyKey } from "./service.ts"
 
 /**
@@ -216,10 +217,34 @@ export const definePlugin = <const Keys extends ReadonlyArray<AnyKey>, Config = 
   ...(spec.config === undefined ? {} : { Config: standardOf(spec.config as Schema.Schema<unknown>) }),
   apply: async (ctx: CordisContext, config?: unknown) => {
     const opened = held(ctx)
+    // Disposal can win before Cordis reaches its deferred apply call.
+    if (ctx.fiber.uid === null) return async () => {}
     // THE STAMP, READ ONCE, off the registry binding — never off anything the
     // plugin supplied. Every keyed service below is minted from it.
     const who = ctx.fiber.name
     const scope = Scope.makeUnsafe()
+    const drained = Promise.withResolvers<void>()
+    let interrupted = false
+    const activation: Activation = {
+      ctx, revokes: [], drained: drained.promise, closing: false,
+      dependencies: new Set(Object.values(ctx.fiber.store ?? {}).map((impl) => impl.fiber)),
+      interrupt: () => { interrupted = true },
+    }
+    let closing: Promise<void> | undefined
+    const close = (exit: Exit.Exit<void, never>): Promise<void> => closing ??= (async () => {
+      activation.closing = true
+      try {
+        for (const revoke of activation.revokes.reverse()) await revoke()
+        await drainDependents(activation)
+      } finally {
+        try {
+          await Effect.runPromiseWith(opened)(Scope.close(scope, exit))
+        } finally {
+          untrack(activation)
+          drained.resolve()
+        }
+      }
+    })()
     // THE TWO AMBIENT ONES KEEP THEIR TYPES, because both are known here: the
     // context that comes out of this says it carries a plugin name and a scope,
     // and nothing is asserted to get there.
@@ -231,7 +256,7 @@ export const definePlugin = <const Keys extends ReadonlyArray<AnyKey>, Config = 
     // which made a reader check three identical casts to find the one that meant
     // something.
     let services = Context.add(
-      Context.merge(opened, Context.make(PluginName, who)),
+      Context.add(Context.merge(opened, Context.make(PluginName, who)), Offering, activation),
       Scope.Scope,
       scope,
     ) as Context.Context<never>
@@ -250,12 +275,16 @@ export const definePlugin = <const Keys extends ReadonlyArray<AnyKey>, Config = 
         (provision as (plugin: string) => unknown)(who),
       ) as Context.Context<never>
     }
-    const work = Effect.isEffect(spec.apply)
+    track(activation)
+    const work = Effect.suspend(() => Effect.isEffect(spec.apply)
       ? spec.apply
-      : spec.apply((config ?? {}) as Config)
-    const exit = await Effect.runPromiseExitWith(services)(
-      work as Effect.Effect<void>,
-    )
+      : spec.apply((config ?? {}) as Config))
+    const running = Effect.runForkWith(services)(work as Effect.Effect<void>)
+    activation.interrupt = () => { Effect.runFork(Fiber.interrupt(running)) }
+    if (interrupted || ctx.fiber.uid === null || spec.needs.some((key) => ctx.reflect.get(key.cordis) === undefined)) {
+      activation.interrupt()
+    }
+    const exit = await Effect.runPromise(Fiber.await(running))
     if (Exit.isFailure(exit)) {
       // EVERY FINALIZER IT HAD ALREADY INSTALLED, before the throw goes out —
       // which is what "lands FAILED having installed nothing" means when the
@@ -270,14 +299,14 @@ export const definePlugin = <const Keys extends ReadonlyArray<AnyKey>, Config = 
       // then read on the preferences row, was the CLEANUP's defect rather than
       // the plugin's. The plugin's failure is the subject of this whole arm; it
       // wins, and a finalizer that died on the way out is said beside it.
-      const unwound = await Effect.runPromiseExitWith(opened)(Scope.close(scope, exit))
+      const unwound = await Effect.runPromiseExit(Effect.promise(() => close(exit)))
       if (Exit.isFailure(unwound)) {
         await Effect.runPromiseWith(opened)(
           failed(who, "unwinding after a failed start", unwound.cause),
         )
       }
-      throw Cause.squash(exit.cause)
+      if (!Cause.hasInterruptsOnly(exit.cause)) throw Cause.squash(exit.cause)
     }
-    return () => Effect.runPromiseWith(opened)(Scope.close(scope, Exit.void))
+    return () => close(Exit.void)
   },
 })

--- a/packages/plugin-api/src/services.test.ts
+++ b/packages/plugin-api/src/services.test.ts
@@ -736,8 +736,8 @@ test("a plugin that offers a door core keeps is refused, and only that plugin fa
   })))
 })
 
-/** Cordis owns duplicate refusal and identifies the existing provider. */
-test("two plugins standing behind one door: Cordis refuses the second with the owner and key", async () => {
+/** Cordis refuses the duplicate; olai names both rows and preserves ownership. */
+test("two plugins standing behind one door: refusal names both rows and the key", async () => {
   await Effect.runPromise(Effect.scoped(Effect.gen(function*() {
     const plugins = yield* runtime()
     const offering = (name: string) =>
@@ -754,8 +754,20 @@ test("two plugins standing behind one door: Cordis refuses the second with the o
     expect((yield* first.report).state).toBe("running")
     const [state, fault] = yield* rowOf(second)
     expect(state).toBe("failed")
-    expect(fault).toContain("<chat>")
-    expect(fault).toContain("\"watching\"")
+    expect(fault).toBe(
+      'plugins: "chat" and "mirror" both offer "watching" — a '
+        + "service stands behind one row, and the second would leave every "
+        + "plugin that named it holding whichever was mounted last.",
+    )
+    expect([...plugins.offers()]).toEqual([["watching", "chat"]])
+    yield* second.dispose
+    expect([...plugins.offers()]).toEqual([["watching", "chat"]])
+
+    yield* first.dispose
+    expect([...plugins.offers()]).toEqual([])
+    const replacement = yield* mountPlugin(plugins.host, offering("mirror"))
+    expect((yield* replacement.report).state).toBe("running")
+    expect([...plugins.offers()]).toEqual([["watching", "mirror"]])
   })))
 })
 
@@ -889,5 +901,26 @@ test("a plugin that comes back stands behind its door again", async () => {
       }),
     )
     expect((yield* mirror.report).state).toBe("running")
+  })))
+})
+
+
+test("offer preserves a lifecycle defect when the service already has an owner", async () => {
+  await Effect.runPromise(Effect.scoped(Effect.gen(function*() {
+    const plugins = yield* runtime()
+    let escaped: Effect.Effect<void, never, Scope.Scope> = Effect.void
+    yield* mountPlugin(plugins.host, definePlugin({ name: "owner", needs: [Offers], apply: Effect.gen(function*() {
+      const offers = yield* Offers
+      escaped = offers.offer(Watching, () => ({ subscribe: () => Effect.void }))
+      yield* escaped
+    }) }))
+    // The same capability used outside the activation is a lifecycle error,
+    // even though its first offer still owns the key.
+    const fault = yield* escaped.pipe(
+      Effect.as("unexpected success"),
+      Effect.catchCause((cause) => Effect.succeed(String(Cause.squash(cause)))),
+    )
+    expect(fault).toBe("Error: effect-cordis: offer requires a plugin activation")
+    expect([...plugins.offers()]).toEqual([["watching", "owner"]])
   })))
 })

--- a/packages/plugin-api/src/services.test.ts
+++ b/packages/plugin-api/src/services.test.ts
@@ -736,17 +736,8 @@ test("a plugin that offers a door core keeps is refused, and only that plugin fa
   })))
 })
 
-/**
- * TWO ROWS MAY NOT STAND BEHIND ONE DOOR, and the refusal NAMES BOTH — which is
- * the entire reason the claim is taken here rather than left to the runtime.
- *
- * Cordis refuses the second `provide` on its own, and its sentence is `service
- * "watching" has been registered at <root>`: it names neither author, and
- * `<root>` is a fiber no person has ever heard of. What a person reads on a
- * preferences row has to be this tree's, so the claim goes first and cordis is
- * never reached.
- */
-test("two plugins standing behind one door: the second is refused, naming both and the key", async () => {
+/** Cordis owns duplicate refusal and identifies the existing provider. */
+test("two plugins standing behind one door: Cordis refuses the second with the owner and key", async () => {
   await Effect.runPromise(Effect.scoped(Effect.gen(function*() {
     const plugins = yield* runtime()
     const offering = (name: string) =>
@@ -763,8 +754,7 @@ test("two plugins standing behind one door: the second is refused, naming both a
     expect((yield* first.report).state).toBe("running")
     const [state, fault] = yield* rowOf(second)
     expect(state).toBe("failed")
-    expect(fault).toContain("\"chat\"")
-    expect(fault).toContain("\"mirror\"")
+    expect(fault).toContain("<chat>")
     expect(fault).toContain("\"watching\"")
   })))
 })

--- a/packages/plugin-api/src/services.ts
+++ b/packages/plugin-api/src/services.ts
@@ -83,6 +83,8 @@ import {
   broadcast,
   type Host,
   openHost,
+  hostChanges,
+  offer,
   provide,
   type Provision,
   registry,
@@ -90,7 +92,7 @@ import {
   serviceTag,
   type ServiceKey,
 } from "@olai/effect-cordis"
-import { Deferred, Effect, Exit, Scope } from "effect"
+import { Deferred, Effect, Exit, Scope, type Stream } from "effect"
 
 import {
   type ConversationSeen,
@@ -720,16 +722,13 @@ export const OFFERABLE = [Agents, Deliveries, SessionStart, Watching, Ledger] as
  *     shadowed, replaced or raced by a row.
  *   - THERE IS NO HOST. It is closed over in `openPlugins`, in the package the
  *     ruling names as the one that spends the capability.
- *   - IT IS REFUSABLE, IN OLAI'S WORDS. Cordis refuses a second provide on its
- *     own, and its sentence is `service "deliveries" has been registered at
- *     <root>` — which names neither author and points at a fiber no person has
- *     heard of. The claim is taken here FIRST, so a refused offer never reaches
- *     cordis and what a person reads names both rows and the key.
+ *   - CORDIS REFUSES A SECOND PROVIDER. Provision belongs to the offering
+ *     fiber, so the runtime's refusal names that owner rather than the root.
  *   - IT IS IN `needs`. A plugin that stands behind a door SAYS SO in the one
  *     list a reader, the fence and `@olai/bundle`'s table all read — and the
  *     standing unwinds with the plugin, because `provide` is an `acquireRelease`
- *     on the CALLING fiber's scope and inside an `apply` that scope is the
- *     plugin's.
+ *     on the calling activation. The bridge revokes offers and joins dependent
+ *     cleanup before closing the plugin's resource scope.
  *
  * ## Why FIVE OVERLOADS and not one generic
  *
@@ -934,6 +933,8 @@ export interface Plugins {
   /** Where the fibers hang — handed to `@olai/bundle` to mount the rows on, and
    *  opaque to everybody. */
   readonly host: Host
+  /** Runtime transitions, including asynchronous initialization completing. */
+  readonly changes: Stream.Stream<void>
   /** Every word registered right now, composed. */
   readonly kinds: () => ReadonlyMap<string, ComposedKind>
   /** Every sibling composed right now, in registration order. */
@@ -1209,14 +1210,8 @@ export const openPlugins = (
     }))
 
 
-    // WHO STANDS BEHIND WHAT, keyed by the door and refused like its neighbours.
-    // Cordis refuses a second provide on its own — but its sentence is `service
-    // "deliveries" has been registered at <root>`, which names neither author,
-    // and what a person reads on a preferences row is supposed to be this tree's.
-    // So the claim is taken FIRST and the provide below it can no longer be the
-    // thing that throws; a refused offer never reaches cordis at all, and a
-    // revoke takes the claim and the standing down together.
-    const offered = registry<string, string>()
+    // This table reports ownership; Cordis itself refuses duplicate providers.
+    const offered = new Map<string, { readonly plugin: string }>()
     yield* provide(host, Offers, (plugin) => ({
       offer: (key: AnyKey, door: Provision<never>) =>
         Effect.suspend(() => {
@@ -1235,19 +1230,12 @@ export const openPlugins = (
               ),
             )
           }
-          return offered.claim(
-            key.cordis,
-            plugin,
-            (already) =>
-              `plugins: "${already}" and "${plugin}" both offer "${key.cordis}" — a `
-                + "service stands behind one row, and the second would leave every "
-                + "plugin that named it holding whichever was mounted last.",
-          ).pipe(
-            // ...AND THE PROVIDE, on the CALLING plugin's scope: the acquire
-            // hangs the service on the host's root fiber and the release revokes
-            // it, which unloads every fiber that named it — the same finalizer
-            // discipline that takes a kind word out of the vocabulary.
-            Effect.flatMap(() => provide(host, key as ServiceKey<never>, door)),
+          const owner = { plugin }
+          return offer(key as ServiceKey<never>, door).pipe(
+            Effect.andThen(Effect.acquireRelease(
+              Effect.sync(() => { offered.set(key.cordis, owner) }),
+              () => Effect.sync(() => { if (offered.get(key.cordis) === owner) offered.delete(key.cordis) }),
+            )),
           )
         }),
       // THE CAST IS WHAT AN OVERLOAD SET IS. `Offers.offer` declares five call
@@ -1322,7 +1310,8 @@ export const openPlugins = (
       kinds: kinds.read,
       composed: () => [...siblings.read().values()],
       declared: wakes.read,
-      offers: offered.read,
+      offers: () => new Map([...offered].map(([key, owner]) => [key, owner.plugin])),
+      changes: hostChanges(host),
       published: revisions.tell,
       quiet: quieted.tell(undefined),
       refused: refusals.tell,

--- a/packages/plugin-api/src/services.ts
+++ b/packages/plugin-api/src/services.ts
@@ -86,6 +86,7 @@ import {
   hostChanges,
   closeHost,
   offer,
+  OfferConflict,
   provide,
   type Provision,
   registry,
@@ -723,13 +724,12 @@ export const OFFERABLE = [Agents, Deliveries, SessionStart, Watching, Ledger] as
  *     shadowed, replaced or raced by a row.
  *   - THERE IS NO HOST. It is closed over in `openPlugins`, in the package the
  *     ruling names as the one that spends the capability.
- *   - CORDIS REFUSES A SECOND PROVIDER. Provision belongs to the offering
- *     fiber, so the runtime's refusal names that owner rather than the root.
+ *   - CORDIS REFUSES A SECOND PROVIDER. The bridge identifies that refusal;
+ *     this door supplies the sentence naming both rows and the contested key.
  *   - IT IS IN `needs`. A plugin that stands behind a door SAYS SO in the one
  *     list a reader, the fence and `@olai/bundle`'s table all read — and the
- *     standing unwinds with the plugin, because `provide` is an `acquireRelease`
- *     on the calling activation. The bridge revokes offers and joins dependent
- *     cleanup before closing the plugin's resource scope.
+ *     standing belongs to the calling activation. The bridge revokes offers and
+ *     joins dependent cleanup before closing the plugin's resource scope.
  *
  * ## Why FIVE OVERLOADS and not one generic
  *
@@ -1235,6 +1235,13 @@ export const openPlugins = (
           }
           const owner = { plugin }
           return offer(key as ServiceKey<never>, door).pipe(
+            Effect.catchDefect((defect) => {
+              return Effect.die(!(defect instanceof OfferConflict) ? defect : new Error(
+                `plugins: "${defect.owner}" and "${plugin}" both offer "${key.cordis}" — a `
+                  + "service stands behind one row, and the second would leave every "
+                  + "plugin that named it holding whichever was mounted last.",
+              ))
+            }),
             Effect.andThen(Effect.acquireRelease(
               Effect.sync(() => { offered.set(key.cordis, owner) }),
               () => Effect.sync(() => { if (offered.get(key.cordis) === owner) offered.delete(key.cordis) }),

--- a/packages/plugin-api/src/services.ts
+++ b/packages/plugin-api/src/services.ts
@@ -84,6 +84,7 @@ import {
   type Host,
   openHost,
   hostChanges,
+  closeHost,
   offer,
   provide,
   type Provision,
@@ -935,6 +936,8 @@ export interface Plugins {
   readonly host: Host
   /** Runtime transitions, including asynchronous initialization completing. */
   readonly changes: Stream.Stream<void>
+  /** Drain plugins before the composition root releases their host resources. */
+  readonly close: Effect.Effect<void>
   /** Every word registered right now, composed. */
   readonly kinds: () => ReadonlyMap<string, ComposedKind>
   /** Every sibling composed right now, in registration order. */
@@ -1312,6 +1315,7 @@ export const openPlugins = (
       declared: wakes.read,
       offers: () => new Map([...offered].map(([key, owner]) => [key, owner.plugin])),
       changes: hostChanges(host),
+      close: closeHost(host),
       published: revisions.tell,
       quiet: quieted.tell(undefined),
       refused: refusals.tell,

--- a/packages/server/src/dynamic/runtime.test.ts
+++ b/packages/server/src/dynamic/runtime.test.ts
@@ -23,7 +23,7 @@ import {
 import { REGISTRY, SERVER_MODULES } from "@olai/plugin-build/shared"
 import type { BuiltPlugin } from "@olai/surface"
 import { describe, expect, test } from "bun:test"
-import { Effect } from "effect"
+import { Effect, Option, Stream } from "effect"
 
 import { openDynamic } from "./runtime.ts"
 import { ALWAYS, versionOf } from "./source.ts"
@@ -32,7 +32,7 @@ import { ALWAYS, versionOf } from "./source.ts"
  *  and the shape a `plugins.inspect` answer tells an agent to write. */
 const SERVER = [
   `import { definePlugin } from "@olai/plugin-api"`,
-  `import { Effect } from "effect"`,
+  `import { Effect, Option, Stream } from "effect"`,
   `export default definePlugin({`,
   `  name: "swatch",`,
   `  needs: [],`,
@@ -106,7 +106,15 @@ const bench = <A>(
       const dynamic = openDynamic(plugins.host, [])
       return yield* use(
         dynamic,
-        () => Effect.map(rowReport(plugins.host, dynamic.names()), dynamic.rows),
+        () => plugins.changes.pipe(
+          Stream.mapEffect(() => rowReport(plugins.host, dynamic.names())),
+          // Follow returns a stop handle during initialization. These assertions
+          // read once that work settles; missing dependencies remain waiting.
+          Stream.filter((report) => ![...report.values()].some((row) => row.state === "waiting" && row.missing === undefined)),
+          Stream.take(1),
+          Stream.runHead,
+          Effect.map((report) => dynamic.rows(Option.getOrThrow(report))),
+        ),
         plugins.host,
       )
     })),
@@ -195,7 +203,7 @@ describe("a row's word follows its fiber, not the mount", () => {
    *  waits, which is a legitimate resting state and not a fault. */
   const NEEDS_A_DOOR = [
     `import { Agents, definePlugin } from "@olai/plugin-api"`,
-    `import { Effect } from "effect"`,
+    `import { Effect, Option, Stream } from "effect"`,
     `export default definePlugin({`,
     `  name: "swatch",`,
     `  needs: [Agents],`,
@@ -433,4 +441,21 @@ describe("a definition that goes away takes its fiber with it", () => {
     )
     expect(rows).toEqual([])
   })
+})
+
+test("a dynamic initializer that waits forever can be stopped", async () => {
+  const server = [
+    `import { definePlugin, Kinds } from "@olai/plugin-api"`,
+    `import { Effect } from "effect"`,
+    `export default definePlugin({ name: "swatch", needs: [Kinds], apply: Effect.gen(function*() {`,
+    `  yield* (yield* Kinds).register({ kind: "held", takes: "text", admits: () => true })`,
+    `  yield* Effect.never`,
+    `}) })`,
+  ].join("\n")
+  const state = await bench((dynamic, now) => Effect.gen(function*() {
+    yield* dynamic.follow(vault({ server, approved: ALWAYS }))
+    expect(yield* dynamic.set("swatch", false)).toBe(true)
+    return (yield* now())[0]?.state
+  }))
+  expect(state).toBe("switched")
 })

--- a/packages/server/src/dynamic/runtime.ts
+++ b/packages/server/src/dynamic/runtime.ts
@@ -290,7 +290,7 @@ const start = (host: Host, one: Defined): Effect.Effect<Started> =>
           + `says "${one.name}". The node's \`plugin\` property is the name; make the half agree with it.`,
       )
     }
-    const mounted = yield* mountPlugin(host, plugin)
+    const mounted = yield* mountPlugin(host, plugin, { wait: false })
     return {
       up: true,
       version: one.version,

--- a/packages/server/src/runtime.ts
+++ b/packages/server/src/runtime.ts
@@ -2303,6 +2303,21 @@ export const bind = (
       if (!moving) republishPlugins()
     }
 
+    /** Reconcile an explicit change or an initializer settling. The report
+     * must precede composition because the roster reads it synchronously.
+     */
+    const refreshPlugins = Effect.gen(function*() {
+      pendingStatus = false
+      yield* offered?.reread ?? Effect.void
+      recompose()
+      // Kinds are live, but published validation and ops views are cached.
+      // Revalidate even when no file moved: a switch can remove vocabulary,
+      // and an initializer can register it after its mount already returned.
+      // The store reports failed reads on its own errors channel; a read failure
+      // must not turn a successful plugin change into a refused switch.
+      yield* Effect.ignore(wiring.store.refresh("verified"))
+    })
+
     /**
      * ...AND THE HOLDER THE DYNAMIC HALF REACHES IT THROUGH, filled here
      * because this is the first statement at which there is something to fill it
@@ -2331,41 +2346,8 @@ export const bind = (
           Effect.andThen(Effect.sync(() => { moving = true }), run),
           Effect.sync(() => { moving = false }),
         )
-        if (!changed) return false
-        // THE REPORT, BEFORE THE ROSTER IS DRAWN FROM IT. A definition that
-        // mounted, was disposed or was replaced moved a fiber on this host, and
-        // the holder the roster reads is the composition root's — so it is taken
-        // again here for exactly the reason a flip takes it again on its way
-        // out ({@link PluginRuntime.reread}).
-        yield* offered?.reread ?? Effect.void
-        recompose()
-        // ...AND THE VAULT'S VERDICT IS RE-TAKEN, because NOTHING ON DISK
-        // MOVED and a fiber just took some words with it or brought some.
-        //
-        // A plugin's kind words are a live reading now (`./propKinds.ts`), so
-        // the vocabulary is right the instant the fiber is. What is NOT right
-        // is everything already derived from it: the published reading was
-        // validated a revision ago, and `@olai/ops`'s standing views hand back
-        // the answer they cached against that very reading. So without this
-        // line a vault goes on drawing `kolu-terminal` values as terminals
-        // after kolu was switched off, and — the same hole from the other side,
-        // and this one was measured — an approved definition's kind is claimed,
-        // its values ARE held to it, and the page's licence table still says
-        // nothing about it, so the plugin's own chip does not draw until the
-        // next keystroke anywhere in the vault.
-        //
-        // `verified` is the class: the stamps are forgotten, so a look that
-        // would otherwise find nothing moved re-reads and re-validates the set.
-        // The cost is one pass over the corpus per fiber that moved, which is a
-        // person's gesture or an agent's call and not a loop.
-        //
-        // A FAILED LOOK IS NOT THIS CALL'S TO REPORT. A directory that cannot
-        // be read is published on the store's own errors channel, where every
-        // reader of it already looks; failing here would tell a person their
-        // switch did not work, which is untrue — it worked, and the vault is
-        // unreadable, which is a bigger and separate piece of news.
-        yield* Effect.ignore(wiring.store.refresh("verified"))
-        return true
+        if (changed || pendingStatus) yield* refreshPlugins
+        return changed
       })
 
     /**
@@ -2480,6 +2462,9 @@ export const bind = (
      * two tabs pressing at once are two calls the surface runs in turn.
      */
     let moving = false
+    // An unrelated initializer can finish during a batch that changes nothing.
+    // Remember its notification until the batch releases the publication gate.
+    let pendingStatus = false
 
     /**
      * THE FIRST COMPOSITION, and every one after it.
@@ -2496,7 +2481,20 @@ export const bind = (
      * register, and the thing to call does not exist until here.
      */
     recompose()
-    if (offered !== null) offered.onChange.run = recompose
+    if (offered !== null) {
+      offered.onChange.run = recompose
+      // A dynamic mount returns while apply is still LOADING. Read eventual
+      // readiness or failure even when the plugin registers no sibling surface.
+      // Explicit changes already reconcile after their batch; their intermediate
+      // status notifications must not publish or refresh a half-settled bundle.
+      yield* Stream.runForEach(offered.plugins.changes, () =>
+        Effect.suspend(() => {
+          if (!moving) return refreshPlugins
+          pendingStatus = true
+          return Effect.void
+        }),
+      ).pipe(Effect.forkScoped)
+    }
 
     return {
       /**

--- a/packages/server/src/serve.ts
+++ b/packages/server/src/serve.ts
@@ -45,7 +45,7 @@ import {
   type PropWrite,
   type ToolServer,
 } from "@olai/plugin-api/services"
-import { Deferred, Effect } from "effect"
+import { Deferred, Effect, Stream } from "effect"
 import { randomBytes } from "node:crypto"
 import { resolve } from "node:path"
 
@@ -487,6 +487,14 @@ export const serve = (options: ServeOptions) =>
         dynamic,
       },
     })
+
+    // A dynamic mount returns its stop handle while apply is still LOADING.
+    // Publish its eventual readiness or fault even if it registers nothing else.
+    yield* Stream.runForEach(plugins.changes, () => Effect.gen(function*() {
+      report = yield* reportBundle(plugins.host, dynamic.names())
+      onChange.run()
+      yield* Effect.ignore(store.refresh("verified"))
+    })).pipe(Effect.forkScoped)
 
     // A faulted runtime is unrecoverable structural damage, and telling that
     // apart from the ordinary settle of a shutdown is `fault.ts`'s whole job.

--- a/packages/server/src/serve.ts
+++ b/packages/server/src/serve.ts
@@ -507,6 +507,9 @@ export const serve = (options: ServeOptions) =>
     // it: finalizers run in reverse, and every serving stack the listener
     // drains is answered by this runtime while it drains.
     yield* Effect.addFinalizer(() => Effect.promise(() => wired.bound.close()))
+    // Drain plugin scopes while the store and bound surface still exist.
+    // The listener is acquired next, so it stops accepting calls first.
+    yield* Effect.addFinalizer(() => plugins.close)
 
     // The agent's face onto this process: the same surface the browser reads,
     // plus the ops layer's tools, over the Streamable HTTP transport the route

--- a/packages/server/src/serve.ts
+++ b/packages/server/src/serve.ts
@@ -45,7 +45,7 @@ import {
   type PropWrite,
   type ToolServer,
 } from "@olai/plugin-api/services"
-import { Deferred, Effect, Stream } from "effect"
+import { Deferred, Effect } from "effect"
 import { randomBytes } from "node:crypto"
 import { resolve } from "node:path"
 
@@ -487,14 +487,6 @@ export const serve = (options: ServeOptions) =>
         dynamic,
       },
     })
-
-    // A dynamic mount returns its stop handle while apply is still LOADING.
-    // Publish its eventual readiness or fault even if it registers nothing else.
-    yield* Stream.runForEach(plugins.changes, () => Effect.gen(function*() {
-      report = yield* reportBundle(plugins.host, dynamic.names())
-      onChange.run()
-      yield* Effect.ignore(store.refresh("verified"))
-    })).pipe(Effect.forkScoped)
 
     // A faulted runtime is unrecoverable structural damage, and telling that
     // apart from the ordinary settle of a shutdown is `fault.ts`'s whole job.


### PR DESCRIPTION
A plugin could offer services before initialization succeeded, and a loading initializer could block stop or shutdown indefinitely. This implements phase 12a of the Cordis plan.

Services now belong to the offering fiber and remain unavailable until it is ACTIVE. The bridge revokes offers and joins dependent cleanup before releasing provider resources. Initialization runs on an interruptible Effect fiber: stop leaves it off, dependency withdrawal leaves it waiting and able to recover, and scoped host close drains plugins with empty needs and background work. Dynamic mounting returns its stop handle while initialization runs; status notifications publish eventual readiness or failure.

Activation lifetime is encapsulated in the bridge, including provision, cancellation, and teardown. Runtime reconciliation owns the shared reread, recomposition, and verified-view refresh policy, coalescing status changes during plugin batches. Duplicate-provider errors name both rows and the service while preserving unrelated lifecycle errors. A checked revoke handoff and direct regression test expose Cordis pin drift. Documentation explains resource ordering, root disposal behavior, refresh policy, and cooperative cancellation limits.

Validation: targeted bridge and service tests passed (55 tests). Merged `origin/master` before running full `just ci` on `b88e184c`: 49 legs passed, with no failures, errors, or skips, including typecheck, unit tests, Nix build, dependency checks, and all six browser shards. Coverage includes asynchronous dependent cleanup using provider resources, failed/delayed initialization, withdrawal and recovery, loading flips, shutdown, and a hung dynamic initializer.
