### PR TITLE
fix(codex): upgrade bundled CLI for GPT-6 Astra

### DIFF
--- a/packages/plugins/codex/acp/default.nix
+++ b/packages/plugins/codex/acp/default.nix
@@ -5,8 +5,8 @@
 { lib, stdenv, buildNpmPackage, fetchFromGitHub, makeWrapper, nodejs }:
 
 let
-  adapterVersion = "1.8.0";
-  codexVersion = "0.152.0"; # resolved by this adapter release's package-lock
+  adapterVersion = "1.10.0";
+  codexVersion = "0.153.3"; # resolved by this adapter release's package-lock
   # The optional npm package and the native binary inside it use different
   # platform vocabularies. One table keeps the pair atomic and makes an
   # unsupported host fail at evaluation rather than fall into a Darwin branch.
@@ -26,9 +26,9 @@ buildNpmPackage {
     owner = "agentclientprotocol";
     repo = "codex-acp";
     rev = "v${adapterVersion}";
-    hash = "sha256-dmih+6xA+v8oNy8LayIGG0+4Psfkct06O/ECKWnYP+g=";
+    hash = "sha256-D8uYd30NRXQYUSBFCi66Oq0iRZXpl8P7nWv2m3+KBig=";
   };
-  npmDepsHash = "sha256-fWAIaVK1fHvY+oJPooiM/9bQ61jf+0vBGLXEOGXdq0Q=";
+  npmDepsHash = "sha256-df1/kPiZFBEq9Um26Qbo9XaYj2J8BOXQmunCQWquDTo=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/packages/plugins/codex/docs.md
+++ b/packages/plugins/codex/docs.md
@@ -12,6 +12,10 @@ The adapter itself wraps the Codex app server. The plugin's `acp/` directory own
 
 Turning this row off is also possible through the plugin roster: `olai web --plugins=claude,opencode,pi` mounts no Codex server half, performs no probe and loads no Codex browser chunk.
 
+### Model requires a newer Codex version
+
+Olai pins `codex-acp` 1.10.0 with Codex CLI 0.153.3. This updates the bundled 0.152.0 CLI, which could list `gpt-6-astra` but fail on the first prompt with a missing-model-metadata warning and “requires a newer version of Codex”. Update olai and restart the server to use the new bundle; upgrading a separate `codex` on PATH does not update the executable olai ships. If you override `OLAI_ACP_CODEX` or `CODEX_PATH`, update that installation too.
+
 ## What is only true of this wire
 
 - **Codex supports interruption.** The adapter advertises `_session/steering`; the composer offers the gesture only when that positive advertisement is present. Both `injected` and `startedNewTurn` mean the adapter consumed the message, so neither is sent a second time as an ordinary prompt.

--- a/website/index.html
+++ b/website/index.html
@@ -564,7 +564,8 @@
     <p class="lead">Chat lives in a side panel. You keep the keyboard. The
     agent ticks boxes and rewrites the markdown, and you see it happen.
     Git records both of you. Follow live execution plans and command output, and adjust the agent’s advertised session settings. Choose a model from the chat header, including
-    when chatting with Codex.</p>
+    when chatting with Codex. Olai bundles the Codex adapter and CLI; update
+    olai to receive newer Codex model support.</p>
     <div class="cols">
       <div class="panel chat">
         <div class="file">chat</div>


### PR DESCRIPTION
Selecting `gpt-6-astra` in Olai could list the model but fail on the first prompt with a missing-model-metadata warning and HTTP 400 asking for a newer Codex. Olai shipped Codex 0.152.0 in its Nix closure, so upgrading a separate CLI on PATH did not fix the panel.

Update the pinned codex-acp adapter from 1.8.0 to 1.10.0 and its bundled Codex CLI from 0.152.0 to 0.153.3, using the upstream release lockfile and refreshed source/dependency hashes. Document how to update the bundled runtime and account for explicit adapter/CLI overrides.

Validation:
- `nix build .#codex-agent --no-link --print-out-paths --accept-flake-config` passed.
- Built executable reports `codex-cli 0.153.3`; app-server initialization and `model/list` succeeded with `gpt-6-astra` metadata and supported reasoning efforts.
- `git diff --check` passed.
- `just ci` passed: 49 successful jobs, including Linux Nix build, typecheck, unit tests, and all six end-to-end shards.

A live inference turn has not been tested.
