### PR TITLE
Warm the darwin nix cache on macos-latest-xlarge

### DIFF
--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -22,7 +22,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # xlarge is the ARM box (aarch64-darwin). macos-latest-large is Intel
+        # and would warm x86_64-darwin instead.
+        os: [ubuntu-latest, macos-latest-xlarge]
     runs-on: ${{ matrix.os }}
     steps:
       # pull_request's default ref is the synthetic merge commit; warm the


### PR DESCRIPTION
The nix-cache workflow's darwin leg currently runs on `macos-latest` (3-core / 7GB ARM). This moves it to `macos-latest-xlarge` (5-core / 14GB ARM) so the warmed system stays `aarch64-darwin`.

`macos-latest-large` is the Intel 12-core box and would switch the cache build to `x86_64-darwin`.

Confirmed available to this org on #529.