### PR TITLE
The pinned odu moves to db12c8fa, which gives a dead lane another box

### DIFF
--- a/nix/odu.nix
+++ b/nix/odu.nix
@@ -12,8 +12,10 @@
 #
 # THE PIN TRACKS MASTER at the exact revision this tree compiled against.
 # `just update-pins` walks it forward; `npins/sources.json` records the tested
-# revision in this diff. The pinned master includes juspay/odu#101, which lets
-# independent sharded leaves share burst capacity.
+# revision in this diff. The pinned master includes juspay/odu#103, under which
+# a remote lane that loses its ssh link is re-claimed onto a fresh venue and
+# only its unfinished nodes rerun (bounded by `ODU_MAX_LANE_RESURRECTIONS`,
+# default 2).
 #
 # WHY THE SCRIPT IS KOLU'S. The copier is generic — `<src> <dest>` pairs, `cp
 # -rL` so a hydrated source's own imports resolve up into the root

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "58005fa9513cab9a91f6aa82b3c3250465abfdcf",
-      "url": "https://github.com/juspay/odu/archive/58005fa9513cab9a91f6aa82b3c3250465abfdcf.tar.gz",
-      "hash": "sha256-U9VnG51KiVipjrylsofVH+8+hStx/nbkM77iNE+mnhE="
+      "revision": "db12c8fa42f4a52debf18a6d783e2dda203973b0",
+      "url": "https://github.com/juspay/odu/archive/db12c8fa42f4a52debf18a6d783e2dda203973b0.tar.gz",
+      "hash": "sha256-4aiYQtKSFvypSaDelqoYKyy89gsL4EYGXSGneb0rzKY="
     },
     "osfacts": {
       "type": "Git",


### PR DESCRIPTION
The odu pin in `npins/sources.json` moves from `58005fa9` to `db12c8fa`.

That is juspay/odu master at [juspay/odu#103](https://github.com/juspay/odu/pull/103) ("Move the work, not the verdict: a dead lane gets another box"). A remote primary lane whose ssh link dies is now re-claimed onto a fresh venue up to twice (`ODU_MAX_LANE_RESURRECTIONS`, default 2) and reruns only its unfinished nodes — the transport itself still drops within seconds, because Effect RPC's pinger is fixed at 5 seconds, so resurrection rather than a longer grace period is the survival mechanism. `nix/odu.nix`'s pin note names #103 accordingly.

The pin's dependency check (`just odu-deps`) agrees with `@odu/run-client` as-is; nothing else moved.

CI was not run on this PR, at the author's request.

## Deferrals

No deferrals.