### PR TITLE
Fix MCP startup failure from missing tool schemas

### DIFF
--- a/docs/e2e-coverage.md
+++ b/docs/e2e-coverage.md
@@ -1,5 +1,13 @@
 # Browser coverage audit
 
+The MCP startup regression in [#548](https://github.com/juspay/olai/issues/548)
+escaped checks that only asserted HTTP 200 and tool names. Transport lifecycle
+scenarios now require an object input schema on every advertised tool, including
+after MCP reactivation and removal of other transports. Server integration tests
+also connect the MCP SDK client to the production web and surface profiles,
+validate the catalogue, and call an advertised read tool. These tests reproduce
+the missing-schema failure introduced by #538 before the production fix.
+
 Kolu PR #2228 removes the wire-driven app rebuild. The existing document lifecycle
 case checks that an unrelated journal toggle retains the actual editor DOM
 element, followed by a successful save. Cleanup, caret restoration and undo

--- a/packages/plugins/mcp/src/endpoint.ts
+++ b/packages/plugins/mcp/src/endpoint.ts
@@ -136,7 +136,7 @@ export const serveFace = <S extends SurfaceSpec>(
       // cancellation, rendering and error handling for calls and resources.
       const catalogue = Object.entries(tools).map(([name, tool]) => ({
         name, title: tool.title, description: tool.description,
-        inputSchema: toInputSchema(tool.input).schema as { type: "object"; [key: string]: unknown },
+        inputSchema: toInputSchema(tool.input) as { type: "object"; [key: string]: unknown },
         annotations: { readOnlyHint: !(tool.mutates ?? true), destructiveHint: tool.mutates ?? true },
       }))
       served.server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: catalogue.filter(tool => available(tool.name)) }))

--- a/packages/server/src/profiles.test.ts
+++ b/packages/server/src/profiles.test.ts
@@ -9,6 +9,30 @@ import { Effect } from "effect"
 import { WebSocket as WsClient } from "ws"
 import { served, withServe, withServing } from "./serve.testlib.ts"
 import { startWeb } from "./child.testlib.ts"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+
+for (const profile of ["web", "surface"] as const) {
+  test(`an MCP client can discover and call tools in the ${profile} profile`, async () => {
+    const root = served()
+    writeFileSync(join(root, "a.olai"), `${JSON.stringify({ id: "a", ord: "a0", title: "Discovered through MCP" })}\n`)
+    await withServing({ root, profile }, async (url) => {
+      const client = new Client({ name: "mcp-startup-regression", version: "1" })
+      try {
+        await client.connect(new StreamableHTTPClientTransport(new URL(`${url}/mcp`)))
+        // #548: initialization and HTTP 200 succeeded, but the production
+        // catalogue omitted inputSchema. The SDK validates every listed tool.
+        const { tools } = await client.listTools()
+        expect(tools.map(tool => tool.name)).toContain("read_node")
+        const read = await client.callTool({ name: "read_node", arguments: { id: "a" } })
+        expect(read.isError).not.toBe(true)
+        expect(JSON.stringify(read)).toContain("Discovered through MCP")
+      } finally {
+        await client.close()
+      }
+    })
+  }, 30_000)
+}
 
 const request = (url: string, method = "tools/list", params?: unknown) => fetch(`${url}/mcp`, {
   method: "POST",

--- a/packages/tests/step_definitions/transport_steps.ts
+++ b/packages/tests/step_definitions/transport_steps.ts
@@ -14,6 +14,11 @@ Then("the MCP transport answers with status {int}", async function (this: OlaiWo
   if (status === 200) {
     const reply = await response.json();
     assert.ok(reply.result.tools.some((tool: { name: string }) => tool.name === "read_node"));
+    // An HTTP 200 with tool names still fails agent startup if schemas are
+    // missing (#548). Check every tool, including after plugin reactivation.
+    for (const tool of reply.result.tools) {
+      assert.equal(tool.inputSchema?.type, "object", `${tool.name}: missing MCP inputSchema`);
+    }
   }
 });
 


### PR DESCRIPTION
MCP tool discovery broke in #538: `tools/list` omitted every tool's required `inputSchema`, causing Codex to report “Unexpected response type” after successful initialization. Preserve the JSON Schema returned by `toInputSchema()` instead of reading a nonexistent `.schema` property.

Regression coverage connects a real MCP SDK client to the production web and surface profiles, validates the catalogue, and calls a read tool. Transport lifecycle e2e scenarios now require schemas on every advertised tool, including after MCP reactivation. The coverage audit documents the gap.

Validation follows two separate commits:

- **Reproduction:** `aa467f1f` adds tests only. `just ci` failed both new MCP client tests with `Invalid input: expected object, received undefined` at `tools[0].inputSchema`; typechecking passed. [CI failure evidence](https://github.com/juspay/olai/pull/549#issuecomment-5560798238).
- **Fix:** `71a1a4f7` changes the schema projection only, after the CI reproduction. Both new MCP client tests and all five previously failing browser scenarios pass. Typechecking, the full unit/integration suite, Nix, and the other non-browser checks pass.

Full validation: `just ci` is green on `71a1a4f7`: **49 jobs passed, 0 failed**, including **all 1,480 browser scenarios**. All GitHub PR checks also pass. Earlier runs encountered two different intermittent chat failures; both passed on the successful retry without code changes. The original MCP regression evidence remains preserved on the test-only commit and in the linked comment.

Fixes #548.
