### PR TITLE
Bump hono to 4.13.7: close GHSA-gqvv-2mrq-wpjv, GHSA-g6gw-c38x-mqfc, GHSA-crvj-82cr-hjcx

### DIFF
--- a/acp/package-lock.json
+++ b/acp/package-lock.json
@@ -798,9 +798,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
-      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/bun.lock
+++ b/bun.lock
@@ -1554,7 +1554,7 @@
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
-    "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
+    "hono": ["hono@4.13.7", "", {}, "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ=="],
 
     "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -5235,13 +5235,13 @@
       hasInstallScript = false;
     };
   };
-  "hono@4.13.1" = fetchurl
+  "hono@4.13.7" = fetchurl
     {
-      url = "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz";
-      hash = "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==";
+      url = "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz";
+      hash = "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==";
     } // {
     manifest = {
-      tarballUrl = "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz";
+      tarballUrl = "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz";
       dependencies = { };
       peerDependencies = { };
       optionalDependencies = { };

--- a/nix/acp-agent.nix
+++ b/nix/acp-agent.nix
@@ -68,7 +68,7 @@ buildNpmPackage {
     filter = path: _type:
       baseNameOf path == "package.json" || baseNameOf path == "package-lock.json";
   };
-  npmDepsHash = "sha256-dCiEbsKRiCWle/OFr1qypIZQ7lrGhxStLli3zlck+GY=";
+  npmDepsHash = "sha256-AQw99ESOzQALZWKYIhe18WKWXjql07WGow/eAnFJeLg=";
 
   # acp/ is a shim around its two pinned dependencies: nothing to compile,
   # and no package in the tree has an install script to run.


### PR DESCRIPTION
Closes all three open Dependabot alerts on this repository. They are one package and one range: `hono`, everything below **4.13.5**.

| Advisory | Alert | What it is |
| --- | --- | --- |
| [GHSA-gqvv-2mrq-wpjv](https://github.com/advisories/GHSA-gqvv-2mrq-wpjv) | #7 | `toSSG()` writes outside the output directory |
| [GHSA-g6gw-c38x-mqfc](https://github.com/advisories/GHSA-g6gw-c38x-mqfc) | #8 | unbounded dot-notation nesting in `parseBody()` |
| [GHSA-crvj-82cr-hjcx](https://github.com/advisories/GHSA-crvj-82cr-hjcx) | #9 | the query parser reads parameters that sit after the URL fragment |

**Before: `hono` 4.13.1. After: `hono` 4.13.7** — the latest 4.13.x; first patched is 4.13.5.

## Why four files and not one

`hono` is nobody's declared dependency here. It arrives transitively through `@modelcontextprotocol/sdk` 1.30.0, whose manifest asks for `"hono": "^4.11.4"` — a range that already admits the fix, so no manifest in this tree changes. What changes is where that range was *resolved*, and it was resolved twice:

- `acp/package-lock.json` — the npm shim the shipped ACP adapters are pinned through. This is the manifest Dependabot reads, and the one `nix/acp-agent.nix`'s fixed-output derivation fetches from. Regenerated with npm, the tool that wrote it (`npm update hono --package-lock-only --ignore-scripts`), so the diff is the three `hono` lines and nothing else.
- `bun.lock` — the root lockfile the app itself builds from. Same 4.13.1, same bump, via `bun update hono`.
- `bun.nix` — derived from `bun.lock`, regenerated with `just regenerate-bun-nix`; `just bun-nix-fresh` passes. Without it the nix build would go on fetching the old tarball.
- `nix/acp-agent.nix` — `npmDepsHash` moves with `acp/package-lock.json`, as that file's own header says it must. Recomputed the documented way (`lib.fakeHash`, build, paste).

A sweep of the tree (`git grep` over every lockfile, manifest and `.nix`, plus the `npins` pins) finds no other place that resolves `hono` and nothing that pins it to the vulnerable range. The `^4` and `^4.11.4` strings that remain are upstream's own declared ranges recorded inside the lockfiles; both admit 4.13.7.

## Checks

- `nix build .#acp-agent` — rebuilds on the new hash, and both adapters' patches still apply at `patch -p1 -F0`, which is the check that a dependency move did not silently drop patched behaviour.
- `npm ci` in `acp/` (via `just install`) — the new lockfile installs clean.
- `just typecheck-fast-remote` — 13 ok · 0 failed.
- `just test-fast-remote` — 13 ok · 0 failed.
- `just e2e-fast-remote` — 17 ok · 0 failed (the `nix` leg rides along in that graph).
- `just bun-nix-fresh` — clean.

Draft on purpose: full CI and the merge are the orchestrator's, under the human's authorization.
